### PR TITLE
Debugger Rework

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -31,3 +31,4 @@ sampleWorkspace
 target
 server
 project
+!server/core/target/universal/daffodil-debugger-*.zip

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -145,7 +145,7 @@ export function activateDaffodilDebug(
   )
 
   // register a configuration provider for 'dfdl' debug type
-  const provider = new DaffodilConfigurationProvider()
+  const provider = new DaffodilConfigurationProvider(context)
   context.subscriptions.push(
     vscode.debug.registerDebugConfigurationProvider('dfdl', provider)
   )
@@ -274,6 +274,12 @@ export function activateDaffodilDebug(
 class DaffodilConfigurationProvider
   implements vscode.DebugConfigurationProvider
 {
+  context: vscode.ExtensionContext
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context
+  }
+
   /**
    * Massage a debug configuration just before a debug session is being launched,
    * e.g. add all missing attributes to the debug configuration.
@@ -331,13 +337,13 @@ class DaffodilConfigurationProvider
     ) {
       return getDataFileFromFolder(dataFolder).then((dataFile) => {
         config.data = dataFile
-        return getDebugger(config).then((result) => {
+        return getDebugger(this.context, config).then((result) => {
           return config
         })
       })
     }
 
-    return getDebugger(config).then((result) => {
+    return getDebugger(this.context, config).then((result) => {
       return config
     })
   }

--- a/src/hexView.ts
+++ b/src/hexView.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs'
 import * as hexy from 'hexy'
 import XDGAppPaths from 'xdg-app-paths'
 import { ConfigEvent, DaffodilData } from './daffodil'
-const xdgAppPaths = XDGAppPaths({ name: 'dapodil' })
+const xdgAppPaths = XDGAppPaths({ name: 'daffodil-dap' })
 
 export class DebuggerHexView {
   context: vscode.ExtensionContext


### PR DESCRIPTION
Updates:
- Rename folder `dapodil` to `daffodil-dao`
- Include sbt zip in vsix file from now on
- When running via extension the backend will start via a file that would have been downloaded when the extension was installed should be something similar to `~/.vscode/extensions/asf.daffodil-debugger-*/server/core/target/universal/daffodil-debugger-*.zip`
- When not running via extension if the sbt zip package does not exist `sbt universal:packageBin` will be ran to create it

Fixes #39 
Fixes #40 
