### PR TITLE
Improved check on infoset output path

### DIFF
--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
@@ -211,9 +211,10 @@ object Parse {
                           Either
                             .catchNonFatal(LaunchArgs.InfosetOutput.File(Paths.get(path.getAsString)))
                             .leftMap(t => s"'infosetOutput.path' field from launch request is not a valid path: $t")
-                            .ensureOr(file => s"can't write to infoset output file at ${file.path}")(
-                              _.path.toFile().canWrite()
-                            )
+                            .ensureOr(file => s"can't write to infoset output file at ${file.path}") { f =>
+                              val file = f.path.toFile
+                              file.canWrite || (!file.exists && file.getParentFile.canWrite)
+                            }
                         )
                         .toEitherNel
                     case invalidType =>


### PR DESCRIPTION
Handles the case where the infoset output file does not exist.

closes #43 