### PR TITLE
Clean up VS Code ignores

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,23 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.vscode/**/*
-.gitignore
-.travis.yml
-appveyor.yml
-src/**/*
-out/tests/**/*
-**/*.js.map
-build
-sampleworkspace
-node_modules
-tsconfig.json
-out
-sampleWebWorkerWorkspace
-sampleWorkspace
-
-# sbt directories
-target
-server
-project
+*
+*/**
+!dist/ext/extension.js
+!images/*
+!LICENSE
+!NOTICE
+!package.json
+!README.md
 !server/core/target/universal/daffodil-debugger-*.zip
+!snippets/*


### PR DESCRIPTION
The .vscodeignores file controls what files are packaged in the extension distribution (VSIX).

There were several files, both committed and created during a build, that should have been ignored but were not.  There were also other non applicable entries in the file from previous iterations of this repo.

This PR updates the file for our build and does some general cleanup.

Closes #30