### PR TITLE
Infoset File Written Popup

### DIFF
--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -19,7 +19,7 @@ import { getDebugger, getDataFileFromFolder } from '../daffodilDebugger'
 import { FileAccessor } from './daffodilRuntime'
 import * as fs from 'fs'
 import * as infoset from '../infoset'
-import { getConfig } from '../utils'
+import { getConfig, setCurrentConfig } from '../utils'
 import * as launchWizard from '../launchWizard/launchWizard'
 
 // Function for setting up the commands for Run and Debug file
@@ -318,6 +318,7 @@ class DaffodilConfigurationProvider
     ) {
       return getDataFileFromFolder(dataFolder).then((dataFile) => {
         config.data = dataFile
+        setCurrentConfig(config)
         return getDebugger(this.context, config).then((result) => {
           return config
         })
@@ -325,6 +326,7 @@ class DaffodilConfigurationProvider
     }
 
     return getDebugger(this.context, config).then((result) => {
+      setCurrentConfig(config)
       return config
     })
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,18 @@
 import * as vscode from 'vscode'
 
 const defaultConf = vscode.workspace.getConfiguration()
+let currentConfig: vscode.ProviderResult<vscode.DebugConfiguration>
+
+// Function to retrieve to the current debug config
+export function getCurrentConfg() {
+  return currentConfig
+}
+
+// Function to set the current debug config
+export function setCurrentConfig(config) {
+  currentConfig = config
+  return currentConfig
+}
 
 // Function to run vscode command and catch the error to not cause other issues
 export function runCommand(command: string) {
@@ -29,18 +41,7 @@ export function runCommand(command: string) {
 // Function for checking if config specifies if either the
 // infoset, infoset diff or hex view needs to be opened
 export async function onDebugStartDisplay(viewsToCheck: string[]) {
-  let config = JSON.parse(
-    JSON.stringify(
-      vscode.workspace
-        .getConfiguration(
-          'launch',
-          vscode.workspace.workspaceFolders
-            ? vscode.workspace.workspaceFolders[0].uri
-            : vscode.Uri.parse('')
-        )
-        .get('configurations')
-    )
-  )[0]
+  let config = JSON.parse(JSON.stringify(getCurrentConfg()))
 
   viewsToCheck.forEach(async (viewToCheck) => {
     switch (viewToCheck) {


### PR DESCRIPTION
Updates:

 - Create popup notification when infoset is written.
 - Create code to set a variable that can be shared amongst files to get the current config being debugged
   - This helps to support multiple different configs as it makes sure the code is working on the config being used not just the first config in the `launch.json` file
 
What the popup notification looks like:

![Screen Shot 2021-12-06 at 2 03 33 PM](https://user-images.githubusercontent.com/32347414/144906494-79248ca0-7ca0-440b-92fd-6089bfbf8e6f.png)

When `Open` is clicked the infoset file will be become the active opened file

Closes #12 