### PR TITLE
Consistent References

### DIFF
--- a/.asf.yml
+++ b/.asf.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 github:
-  description: "Apache Daffodil VSCode"
+  description: "VS Code extension for Apache Daffodil"
   homepage: https://daffodil.apache.org/
   features:
     wiki:     true

--- a/LICENSE
+++ b/LICENSE
@@ -204,7 +204,7 @@
 
 SUBCOMPONENTS:
 
-The Apache Daffodil VS Code Debug project contains subcomponents with separate copyright
+The Apache Daffodil VS Code Extension project contains subcomponents with separate copyright
 notices and license terms. Your use of the source code for these subcomponents
 is subject to the terms and conditions of the following licenses.
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache Daffodil VSCode
+Apache Daffodil VS Code Extension
 Copyright 2021 The Apache Software Foundation
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ![Daffodil Debug](images/daffodil.jpg)
 
-# VS Code Daffodil Debug
+# Apache Daffodil VS Code Extension
 
 This is a VS Code extension which enables the interactive debugging of DFDL schema parsing using [Apache Daffodil](https://daffodil.apache.org/).
 
@@ -35,7 +35,7 @@ Until the extension is available in the [VS Code Extension Marketplace](https://
 ## Build VSIX and Debugger
 :exclamation:**NOT necessary if using prebuilt VSIX**:exclamation:
 
-:exclamation:**NOT necessary if running extension via VSCode without VSIX but a `yarn install` will be required**:exclamation:
+:exclamation:**NOT necessary if running extension via VS Code without VSIX but a `yarn install` will be required**:exclamation:
 
 Run full build
   ```bash
@@ -58,7 +58,7 @@ Run full build
 The debug server will automatically be ran by the extension unless `useExistingServer` is to set to `true` inside of `.vscode/launch.json`
 
 If you wish to ran the debug server manually the scripts to do so are at the following locations:
-* Debugging through VSCode with or without VSIX:
+* Debugging through VS Code with or without VSIX:
   * Linux = `/home/USERNAME/.local/share/daffodil-dap`
   * Mac = `/Users/USERNAME/Library/Application\ Support/daffodil-dap`
   * Windows = `C:\\Users\\USERNAME\\AppData\\Roaming\\daffodil-dap`
@@ -90,7 +90,7 @@ users@daffodil.apache.org mailing lists.  You can report bugs via
 
 ## License
 
-Apache Daffodil VSCode is licensed under the [Apache License, v2.0].
+Apache Daffodil VS Code Extension is licensed under the [Apache License, v2.0].
 
 [Apache License, v2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [GitHub Issues]: https://github.com/apache/daffodil-vscode/issues

--- a/build/bin.LICENSE
+++ b/build/bin.LICENSE
@@ -204,7 +204,7 @@
 
   SUBCOMPONENTS:
 
-  The Apache Daffodil VS Code Debug project contains subcomponents with separate copyright
+  The Apache Daffodil VS Code Extension project contains subcomponents with separate copyright
   notices and license terms. Your use of the source code for these subcomponents
   is subject to the terms and conditions of the following licenses.
 

--- a/build/bin.NOTICE
+++ b/build/bin.NOTICE
@@ -1,4 +1,4 @@
-Apache Daffodil VSCode
+Apache Daffodil VS Code Extension
 Copyright 2021 The Apache Software Foundation
 
 This product includes software developed at

--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
@@ -733,7 +733,7 @@ object DAPodil extends IOApp {
 
   /** Our own capabilities data type that is a superset of java-debug, which doesn't have `supportsLoadedSourcesRequest`.
     *
-    * TODO: VSCode doesn't seem to notice supportsRestartRequest=true and sends Disconnect (+restart) requests instead
+    * TODO: VS Code doesn't seem to notice supportsRestartRequest=true and sends Disconnect (+restart) requests instead
     */
   case class Caps(
       supportsConfigurationDoneRequest: Boolean = true,


### PR DESCRIPTION
Update project to be more consistent with naming conventions:

- Update project reference from "Apache Daffodil VSCode" to be "Apache Daffodil VSCode Extension"
- Update files referencing "VS Code" to be "VSCode"
- Updated description in the `.asf.yaml`

Wiki documentation updated with these changes as well

Closes #24
Closes #65