### PR TITLE
Avoid endElement parsing callbacks when debugger is paused.

### DIFF
--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
@@ -791,7 +791,8 @@ object Parse {
 
     override def endElement(pstate: PState, processor: Parser): Unit =
       dispatcher.unsafeRunSync {
-        events.offer(Some(Event.EndElement(pstate.copyStateForDebugger)))
+        control.await *> // ensure no events while debugger is paused
+          events.offer(Some(Event.EndElement(pstate.copyStateForDebugger)))
       }
   }
 


### PR DESCRIPTION
Previously it would emit an event that would pop the maintained stack
so when a breakpoint was hit the subsequently fetched stacktrace
was missing the breakpoint.

Fixes #90.