### PR TITLE
Remove -Xcheckinit scalac option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,9 @@ lazy val commonSettings = {
     organization := "org.apache.daffodil",
     scalaVersion := "2.12.13",
     scalacOptions ++= Seq("-Ypartial-unification"),
+    // remove the -Xcheckinit option added by the sbt tpoletcat plugin. This
+    // option leads to non-reproducible builds
+    scalacOptions --= Seq("-Xcheckinit"),
     startYear := Some(2021)
   )
 }


### PR DESCRIPTION
The sbt-tpoletcat plugin enables the -Xcheckinit scalacOption. This
option causes scalac to wrap field accessors so they throw an exception
on uninitialized access. Unfortunately, the error message generated in
this exception includes an absolute path to scala files, which is a
constant stored in byte code. This means different build systems create
different bytecode due to different paths, and so builds are not
reproducible.

By removing it, we lose checks for unitialized accesses, but that seems
unlikely and not worth the loss of reproducibility.

Closes #92