### PR TITLE
RC2 Updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,9 +34,12 @@ lazy val commonSettings = {
       "org.apache.daffodil" %% "daffodil-sapi" % daffodilVer,
       "org.apache.daffodil" %% "daffodil-runtime1" % daffodilVer
     ),
+    dependencyOverrides ++= Seq(
+      "org.apache.commons" % "commons-lang3" % "3.12.0"
+    ),
     licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
     organization := "org.apache.daffodil",
-    scalaVersion := "2.12.13",
+    scalaVersion := "2.12.15",
     scalacOptions ++= Seq("-Ypartial-unification"),
     // remove the -Xcheckinit option added by the sbt tpoletcat plugin. This
     // option leads to non-reproducible builds
@@ -73,11 +76,11 @@ lazy val core = project
   .settings(
     name := "daffodil-debugger",
     libraryDependencies ++= Seq(
-      "ch.qos.logback" % "logback-classic" % "1.2.3",
-      "com.microsoft.java" % "com.microsoft.java.debug.core" % "0.31.1",
-      "co.fs2" %% "fs2-io" % "3.0.4",
-      "com.monovore" %% "decline-effect" % "2.1.0",
-      "org.typelevel" %% "log4cats-slf4j" % "2.1.0"
+      "ch.qos.logback" % "logback-classic" % "1.2.11",
+      "com.microsoft.java" % "com.microsoft.java.debug.core" % "0.35.0",
+      "co.fs2" %% "fs2-io" % "3.0.6",
+      "com.monovore" %% "decline-effect" % "2.2.0",
+      "org.typelevel" %% "log4cats-slf4j" % "2.1.1"
     ),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, "daffodilVersion" -> daffodilVer),
     buildInfoPackage := "org.apache.daffodil.debugger.dap",

--- a/build/bin.LICENSE
+++ b/build/bin.LICENSE
@@ -1,222 +1,400 @@
 
-                               Apache License
-                         Version 2.0, January 2004
-                      http://www.apache.org/licenses/
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-  TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-  1. Definitions.
+   1. Definitions.
 
-    "License" shall mean the terms and conditions for use, reproduction,
-    and distribution as defined by Sections 1 through 9 of this document.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-    "Licensor" shall mean the copyright owner or entity authorized by
-    the copyright owner that is granting the License.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-    "Legal Entity" shall mean the union of the acting entity and all
-    other entities that control, are controlled by, or are under common
-    control with that entity. For the purposes of this definition,
-    "control" means (i) the power, direct or indirect, to cause the
-    direction or management of such entity, whether by contract or
-    otherwise, or (ii) ownership of fifty percent (50%) or more of the
-    outstanding shares, or (iii) beneficial ownership of such entity.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-    "You" (or "Your") shall mean an individual or Legal Entity
-    exercising permissions granted by this License.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-    "Source" form shall mean the preferred form for making modifications,
-    including but not limited to software source code, documentation
-    source, and configuration files.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-    "Object" form shall mean any form resulting from mechanical
-    transformation or translation of a Source form, including but
-    not limited to compiled object code, generated documentation,
-    and conversions to other media types.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-    "Work" shall mean the work of authorship, whether in Source or
-    Object form, made available under the License, as indicated by a
-    copyright notice that is included in or attached to the work
-    (an example is provided in the Appendix below).
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-    "Derivative Works" shall mean any work, whether in Source or Object
-    form, that is based on (or derived from) the Work and for which the
-    editorial revisions, annotations, elaborations, or other modifications
-    represent, as a whole, an original work of authorship. For the purposes
-    of this License, Derivative Works shall not include works that remain
-    separable from, or merely link (or bind by name) to the interfaces of,
-    the Work and Derivative Works thereof.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-    "Contribution" shall mean any work of authorship, including
-    the original version of the Work and any modifications or additions
-    to that Work or Derivative Works thereof, that is intentionally
-    submitted to Licensor for inclusion in the Work by the copyright owner
-    or by an individual or Legal Entity authorized to submit on behalf of
-    the copyright owner. For the purposes of this definition, "submitted"
-    means any form of electronic, verbal, or written communication sent
-    to the Licensor or its representatives, including but not limited to
-    communication on electronic mailing lists, source code control systems,
-    and issue tracking systems that are managed by, or on behalf of, the
-    Licensor for the purpose of discussing and improving the Work, but
-    excluding communication that is conspicuously marked or otherwise
-    designated in writing by the copyright owner as "Not a Contribution."
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-    "Contributor" shall mean Licensor and any individual or Legal Entity
-    on behalf of whom a Contribution has been received by Licensor and
-    subsequently incorporated within the Work.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-  2. Grant of Copyright License. Subject to the terms and conditions of
-    this License, each Contributor hereby grants to You a perpetual,
-    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-    copyright license to reproduce, prepare Derivative Works of,
-    publicly display, publicly perform, sublicense, and distribute the
-    Work and such Derivative Works in Source or Object form.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-  3. Grant of Patent License. Subject to the terms and conditions of
-    this License, each Contributor hereby grants to You a perpetual,
-    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-    (except as stated in this section) patent license to make, have made,
-    use, offer to sell, sell, import, and otherwise transfer the Work,
-    where such license applies only to those patent claims licensable
-    by such Contributor that are necessarily infringed by their
-    Contribution(s) alone or by combination of their Contribution(s)
-    with the Work to which such Contribution(s) was submitted. If You
-    institute patent litigation against any entity (including a
-    cross-claim or counterclaim in a lawsuit) alleging that the Work
-    or a Contribution incorporated within the Work constitutes direct
-    or contributory patent infringement, then any patent licenses
-    granted to You under this License for that Work shall terminate
-    as of the date such litigation is filed.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-  4. Redistribution. You may reproduce and distribute copies of the
-    Work or Derivative Works thereof in any medium, with or without
-    modifications, and in Source or Object form, provided that You
-    meet the following conditions:
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-    (a) You must give any other recipients of the Work or
-        Derivative Works a copy of this License; and
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-    (b) You must cause any modified files to carry prominent notices
-        stating that You changed the files; and
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-    (c) You must retain, in the Source form of any Derivative Works
-        that You distribute, all copyright, patent, trademark, and
-        attribution notices from the Source form of the Work,
-        excluding those notices that do not pertain to any part of
-        the Derivative Works; and
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-    (d) If the Work includes a "NOTICE" text file as part of its
-        distribution, then any Derivative Works that You distribute must
-        include a readable copy of the attribution notices contained
-        within such NOTICE file, excluding those notices that do not
-        pertain to any part of the Derivative Works, in at least one
-        of the following places: within a NOTICE text file distributed
-        as part of the Derivative Works; within the Source form or
-        documentation, if provided along with the Derivative Works; or,
-        within a display generated by the Derivative Works, if and
-        wherever such third-party notices normally appear. The contents
-        of the NOTICE file are for informational purposes only and
-        do not modify the License. You may add Your own attribution
-        notices within Derivative Works that You distribute, alongside
-        or as an addendum to the NOTICE text from the Work, provided
-        that such additional attribution notices cannot be construed
-        as modifying the License.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-    You may add Your own copyright statement to Your modifications and
-    may provide additional or different license terms and conditions
-    for use, reproduction, or distribution of Your modifications, or
-    for any such Derivative Works as a whole, provided Your use,
-    reproduction, and distribution of the Work otherwise complies with
-    the conditions stated in this License.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-  5. Submission of Contributions. Unless You explicitly state otherwise,
-    any Contribution intentionally submitted for inclusion in the Work
-    by You to the Licensor shall be under the terms and conditions of
-    this License, without any additional terms or conditions.
-    Notwithstanding the above, nothing herein shall supersede or modify
-    the terms of any separate license agreement you may have executed
-    with Licensor regarding such Contributions.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-  6. Trademarks. This License does not grant permission to use the trade
-    names, trademarks, service marks, or product names of the Licensor,
-    except as required for reasonable and customary use in describing the
-    origin of the Work and reproducing the content of the NOTICE file.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-  7. Disclaimer of Warranty. Unless required by applicable law or
-    agreed to in writing, Licensor provides the Work (and each
-    Contributor provides its Contributions) on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    implied, including, without limitation, any warranties or conditions
-    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-    PARTICULAR PURPOSE. You are solely responsible for determining the
-    appropriateness of using or redistributing the Work and assume any
-    risks associated with Your exercise of permissions under this License.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-  8. Limitation of Liability. In no event and under no legal theory,
-    whether in tort (including negligence), contract, or otherwise,
-    unless required by applicable law (such as deliberate and grossly
-    negligent acts) or agreed to in writing, shall any Contributor be
-    liable to You for damages, including any direct, indirect, special,
-    incidental, or consequential damages of any character arising as a
-    result of this License or out of the use or inability to use the
-    Work (including but not limited to damages for loss of goodwill,
-    work stoppage, computer failure or malfunction, or any and all
-    other commercial damages or losses), even if such Contributor
-    has been advised of the possibility of such damages.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-  9. Accepting Warranty or Additional Liability. While redistributing
-    the Work or Derivative Works thereof, You may choose to offer,
-    and charge a fee for, acceptance of support, warranty, indemnity,
-    or other liability obligations and/or rights consistent with this
-    License. However, in accepting such obligations, You may act only
-    on Your own behalf and on Your sole responsibility, not on behalf
-    of any other Contributor, and only if You agree to indemnify,
-    defend, and hold each Contributor harmless for any liability
-    incurred by, or claims asserted against, such Contributor by reason
-    of your accepting any such warranty or additional liability.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-  END OF TERMS AND CONDITIONS
+   END OF TERMS AND CONDITIONS
 
-  APPENDIX: How to apply the Apache License to your work.
+   APPENDIX: How to apply the Apache License to your work.
 
-    To apply the Apache License to your work, attach the following
-    boilerplate notice, with the fields enclosed by brackets "[]"
-    replaced with your own identifying information. (Don't include
-    the brackets!)  The text should be enclosed in the appropriate
-    comment syntax for the file format. We also recommend that a
-    file or class name and description of purpose be included on the
-    same "printed page" as the copyright notice for easier
-    identification within third-party archives.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-  Copyright [yyyy] [name of copyright owner]
+   Copyright [yyyy] [name of copyright owner]
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
 
-  SUBCOMPONENTS:
+APACHE DAFFODIL VS CODE EXTENSION SUBCOMPONENTS:
 
-  The Apache Daffodil VS Code Extension project contains subcomponents with separate copyright
-  notices and license terms. Your use of the source code for these subcomponents
-  is subject to the terms and conditions of the following licenses.
+The Apache Daffodil VS Code Extension project contains subcomponents with
+separate copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the following
+licenses.
 
-  This product bundles content from the VS Code Mock Debug extension, including
-  the following files:
-      - src/adapter/activateDaffodilDebug.ts
-      - src/adapter/daffodilDebug.ts
-      - src/adapter/daffodilRuntime.ts
-      - src/adapter/debugAdapter.ts
-      - src/adapter/extension.ts
-  The content is available under the MIT License:
+- extension/dist/ext/extension.js
+  This product bundles 'Node Await Notify' from the above files.
+  These files are available under the ISC License
+    https://github.com/davidaq/node-await-notify
 
+- extension/dist/ext/extension.js
+  This product bundles 'Node binary' from the above files.
+  These files are available under the MIT License
+    Copyright 2010 James Halliday (mail@substack.net)
+
+    This project is free software released under the MIT license:
+    http://www.opensource.org/licenses/mit-license.php
+
+- extension/dist/ext/extension.js
+  This product bundles 'Node buffers' from the above files.
+  These files are available under the MIT License
+    Copyright 2010 James Halliday (mail@substack.net)
+
+    This project is free software released under the MIT license:
+    http://www.opensource.org/licenses/mit-license.php
+
+- extension/dist/ext/extension.js
+  This product bundles 'Node chainsaw' from the above files.
+  These files are available under the MIT License
+    Copyright 2010 James Halliday (mail@substack.net)
+
+    This project is free software released under the MIT license:
+    http://www.opensource.org/licenses/mit-license.php
+
+- extension/dist/ext/extension.js
+  This product bundles 'hexy.js' from the above files.
+  These files are available under the MIT License
+    Copyright 2010, 2011 Tim Becker
+    All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following
+    conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+
+- extension/dist/ext/extension.js
+  This product bundles 'minimist' from the above files.
+  These files are available under the MIT License
+    This software is released under the MIT license:
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+- extension/dist/ext/extension.js
+  This product bundles 'Node mkdirp' from the above files.
+  These files are available under the MIT/X11 License
+    Copyright James Halliday (mail@substack.net) and Isaac Z. Schlueter (i@izs.me)
+
+    This project is free software released under the MIT license:
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+- extension/dist/ext/extension.js
+  This product bundles 'os-paths' from the above files.
+  These files are available under the MIT License
+    MIT License
+
+    Copyright (c) Roy Ivy III <rivy.dev@gmail.com>
+    Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+
+- extension/dist/ext/extension.js
+  This product bundles 'traverse' from the above files.
+  These files are available under the MIT/X11 license
+    Copyright 2010 James Halliday (mail@substack.net)
+
+    This project is free software released under the MIT/X11 license:
+    http://www.opensource.org/licenses/mit-license.php
+
+    Copyright 2010 James Halliday (mail@substack.net)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+- extension/dist/ext/extension.js
+  This product bundles 'unzip-stream' from the above files.
+  These files are available under the MIT License
+    Copyright (c) 2017 Michal Hruby
+    Copyright (c) 2012 - 2013 Near Infinity Corporation
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+- extension/dist/ext/extension.js
+  This product bundles 'VS Code Debug Adapter' from the above files.
+  These files are available under the MIT License
     Copyright (c) Microsoft Corporation
 
     All rights reserved.
@@ -230,21 +408,105 @@
     copies of the Software, and to permit persons to whom the Software is
     furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
 
-  This product bundles content from the VS Code Mock Debug extension, including
-  the following files:
-    - images/arrow.svg
-  The content is available under the CC0 License:
+- extension/dist/ext/extension.js
+  This product bundles 'VS Code Debug Protocol' from the above files.
+  These files are available under the MIT License
+    Copyright (c) Microsoft Corporation
+
+    All rights reserved.
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+
+- extension/dist/ext/extension.js
+  This product bundles 'xdg-app-paths' from the above files.
+  These files are available under the MIT License
+
+    MIT License
+
+    Copyright (c) Roy Ivy III <rivy.dev@gmail.com>
+    Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+
+- extension/dist/ext/extension.js
+  This product bundles 'xdg-portable' from the above files.
+  These files are available under the MIT License
+
+    MIT License
+
+    Copyright (c) Roy Ivy III <rivy.dev@gmail.com>
+    Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+
+- images/arrow.svg
+  This product bundles the above files from the 'VS Code Mock Debug' extension.
+  These files are available under the CC0 License:
 
     Creative Commons Legal Code
 
@@ -368,90 +630,66 @@
       party to this document and has no duty or obligation with respect to
       this CC0 or use of the Work.
 
+- src/adapter/activateDaffodilDebug.ts
+- src/adapter/daffodilDebug.ts
+- src/adapter/daffodilRuntime.ts
+- src/adapter/debugAdapter.ts
+- src/adapter/extension.ts
+  This product bundles the above files from the 'VS Code Mock Debug' extension.
+  These files are available under the MIT License:
 
-  This product bundles Node Await Notify in extension/dist/ext/extension.js
-  These files are available under the ISC License
-    https://github.com/davidaq/node-await-notify
+    Copyright (c) Microsoft Corporation
 
-
-  This product bundles Node binary in extension/dist/ext/extension.js
-  These files are available under the MIT License
-    Copyright 2010 James Halliday (mail@substack.net)
-
-    This project is free software released under the MIT license:
-    http://www.opensource.org/licenses/mit-license.php
-
-
-  This product bundles Node buffers in extension/dist/ext/extension.js
-  These files are available under the MIT License
-    Copyright 2010 James Halliday (mail@substack.net)
-
-    This project is free software released under the MIT license:
-    http://www.opensource.org/licenses/mit-license.php
-
-
-  This product bundles Node chainsaw in extension/dist/ext/extension.js
-  These files are available under the MIT License
-    Copyright 2010 James Halliday (mail@substack.net)
-
-    This project is free software released under the MIT license:
-    http://www.opensource.org/licenses/mit-license.php
-
-
-  This product bundles hexy.js in extension/dist/ext/extension.js
-  These files are available under the MIT License
-    Copyright 2010, 2011 Tim Becker
     All rights reserved.
 
-    Permission is hereby granted, free of charge, to any person
-    obtaining a copy of this software and associated documentation
-    files (the "Software"), to deal in the Software without
-    restriction, including without limitation the rights to use,
-    copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the
-    Software is furnished to do so, subject to the following
-    conditions:
+    MIT License
 
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-    OTHER DEALINGS IN THE SOFTWARE.
-
-
-  This product bundles minimist in extension/dist/ext/extension.js
-  These files are available under the MIT License
-    This software is released under the MIT license:
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy of
-    this software and associated documentation files (the "Software"), to deal in
-    the Software without restriction, including without limitation the rights to
-    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-    the Software, and to permit persons to whom the Software is furnished to do so,
-    subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
 
     The above copyright notice and this permission notice shall be included in all
     copies or substantial portions of the Software.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 
+- ch.qos.logback.logback-classic-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+- ch.qos.logback.logback-core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'logback' from the above files.
+  These files are available under the Logback license:
 
-  This product bundles Node mkdirp in extension/dist/ext/extension.js
-  These files are available under the MIT/X11 License
-    Copyright James Halliday (mail@substack.net) and Isaac Z. Schlueter (i@izs.me)
+    Logback LICENSE
+    ---------------
 
-    This project is free software released under the MIT license:
+    Logback: the reliable, generic, fast and flexible logging framework.
+    Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+
+    This program and the accompanying materials are dual-licensed under
+    either the terms of the Eclipse Public License v1.0 as published by
+    the Eclipse Foundation
+
+    or (per the licensee's choosing)
+
+    under the terms of the GNU Lesser General Public License version 2.1
+    as published by the Free Software Foundation.
+
+- co.fs2.fs2-core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+- co.fs2.fs2-io-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'fs2' from the above files.
+  These files are available under the MIT license:
+   
+    The MIT License (MIT)
+
+    Copyright (c) 2013 Paul Chiusano, and respective contributors 
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -471,356 +709,155 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 
+    Code in FS2 is derived in part from scodec. The scodec license is as follows:
 
-  This product bundles os-paths in extension/dist/ext/extension.js
-  These files are available under the MIT License
-    MIT License
+    Copyright (c) 2013-2014, Michael Pilquist and Paul Chiusano
+    All rights reserved.
 
-    Copyright (c) Roy Ivy III <rivy.dev@gmail.com>
-    Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    3. Neither the name of the scodec team nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-    OTHER DEALINGS IN THE SOFTWARE.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-  This product bundles traverse in extension/dist/ext/extension.js
-  These files are available under the MIT/X11 license
-    Copyright 2010 James Halliday (mail@substack.net)
+    Code in FS2 is derived in part from Cats. The Cats license is as follows:
 
-    This project is free software released under the MIT/X11 license:
-    http://www.opensource.org/licenses/mit-license.php
+    Cats Copyright (c) 2015 Erik Osheim.
 
-    Copyright 2010 James Halliday (mail@substack.net)
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is furnished to do
+    so, subject to the following conditions: 
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software. 
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE. 
 
+    ------
 
-  This product bundles unzip-stream in extension/dist/ext/extension.js
-  These files are available under the MIT License
-    Copyright (c) 2017 Michal Hruby
-    Copyright (c) 2012 - 2013 Near Infinity Corporation
+    Code in Cats is derived in part from Scalaz. The Scalaz license follows:
+
+    Copyright (c) 2009-2014 Tony Morris, Runar Bjarnason, Tom Adams,
+    Kristian Domagala, Brad Clow, Ricky Clarkson, Paul Chiusano, Trygve
+    Laugstøl, Nick Partridge, Jason Zaugg. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. The name of the author may not be used to endorse or promote products
+       derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+    IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+    IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+    THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+- com.ibm.icu.icu4j-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'ICU4J' from the above files.
+  These files are available under the Unicode License. For details, see
+  https://github.com/unicode-org/icu/blob/release-<VERSION>/icu4c/LICENSE
+
+    COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+
+    Copyright © 1991-2020 Unicode, Inc. All rights reserved.
+    Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of the Unicode data files and any associated documentation
+    (the "Data Files") or Unicode software and any associated documentation
+    (the "Software") to deal in the Data Files or Software
+    without restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, and/or sell copies of
+    the Data Files or Software, and to permit persons to whom the Data Files
+    or Software are furnished to do so, provided that either
+    (a) this copyright and permission notice appear with all copies
+    of the Data Files or Software, or
+    (b) this copyright and permission notice appear in associated
+    Documentation.
+
+    THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+    IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+    NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+    DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+    DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+    TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+    PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+    Except as contained in this notice, the name of a copyright holder
+    shall not be used in advertising or otherwise to promote the sale,
+    use or other dealings in these Data Files or Software without prior
+    written authorization of the copyright holder.
+
+    ---------------------
+
+    Third-Party Software Licenses
+
+    This section contains third-party software notices and/or additional
+    terms for licensed third-party software components included within ICU
+    libraries.
+
+    1. ICU License - ICU 1.8.1 to ICU 57.1
+
+    COPYRIGHT AND PERMISSION NOTICE
+
+    Copyright (c) 1995-2016 International Business Machines Corporation and others
+    All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the
     "Software"), to deal in the Software without restriction, including
     without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Software, and to
-    permit persons to whom the Software is furnished to do so, subject to
-    the following conditions:
-
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
+    distribute, and/or sell copies of the Software, and to permit persons
+    to whom the Software is furnished to do so, provided that the above
+    copyright notice(s) and this permission notice appear in all copies of
+    the Software and that both the above copyright notice(s) and this
+    permission notice appear in supporting documentation.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+    OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+    HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+    SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+    RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+    CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+    CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+    Except as contained in this notice, the name of a copyright holder
+    shall not be used in advertising or otherwise to promote the sale, use
+    or other dealings in this Software without prior written authorization
+    of the copyright holder.
 
-  This product bundles VS Code Debug Adapter in extension/dist/ext/extension.js
-  These files are available under the MIT License
-    Copyright (c) Microsoft Corporation
+    All trademarks and registered trademarks mentioned herein are the
+    property of their respective owners.
 
-    All rights reserved.
-
-    MIT License
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-    OTHER DEALINGS IN THE SOFTWARE.
-
-
-  This product bundles VS Code Debug Protocol in extension/dist/ext/extension.js
-  These files are available under the MIT License
-    Copyright (c) Microsoft Corporation
-
-    All rights reserved.
-
-    MIT License
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-    OTHER DEALINGS IN THE SOFTWARE.
-
-
-  This product bundles xdg-app-paths in extension/dist/ext/extension.js
-  These files are available under the MIT License
-
-    MIT License
-
-    Copyright (c) Roy Ivy III <rivy.dev@gmail.com>
-    Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-    OTHER DEALINGS IN THE SOFTWARE.
-
-
-  This product bundles xdg-portable in extension/dist/ext/extension.js
-  These files are available under the MIT License
-
-    MIT License
-
-    Copyright (c) Roy Ivy III <rivy.dev@gmail.com>
-    Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-    OTHER DEALINGS IN THE SOFTWARE.
-
-
-   This product bundles compiled source from 'Passera', including the following
-   files:
-     - passera/ directory in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the BSD-2-Clause license:
-
-     Copyright (c) 2011-2013, Nate Nystrom
-     All rights reserved.
-
-     Redistribution and use in source and binary forms, with or without
-     modification, are permitted provided that the following conditions are met:
-
-     Redistributions of source code must retain the above copyright notice, this
-     list of conditions and the following disclaimer.
-
-     Redistributions in binary form must reproduce the above copyright notice, this
-     list of conditions and the following disclaimer in the documentation and/or
-     other materials provided with the distribution.
-
-     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-     FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-     DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-     SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-   This product bundles material copied or derived from W3C, including the
-   following files:
-     - org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - org/apache/daffodil/xsd/XMLSchema.xsd (https://www.w3.org/2001/XMLSchema.xsd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd (https://www.w3.org/2001/XMLSchema.dtd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - org/apache/daffodil/xsd/datatypes.dtd (https://www.w3.org/2001/datatypes.dtd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - org/apache/daffodil/xsd/xml.xsd (https://www.w3.org/2001/xml.xsd) in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the W3C Software and Document Licnese:
-
-     By obtaining and/or copying this work, you (the licensee) agree that you have
-     read, understood, and will comply with the following terms and conditions.
-
-     Permission to copy, modify, and distribute this work, with or without
-     modification, for any purpose and without fee or royalty is hereby granted,
-     provided that you include the following on ALL copies of the work or portions
-     thereof, including modifications:
-
-     * The full text of this NOTICE in a location viewable to users of the
-        redistributed or derivative work.
-
-     * Any pre-existing intellectual property disclaimers, notices, or terms and
-        conditions. If none exist, the W3C Software and Document Short Notice should be
-        included.
-
-     * Notice of any changes or modifications, through a copyright statement on the
-        new code or document such as "This software or document includes material
-        copied from or derived from [title and URI of the W3C document]. Copyright ©
-        [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
-
-     Disclaimers
-
-     THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO
-     REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-     LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR
-     PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY
-     THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-
-     COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
-     CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
-
-     The name and trademarks of copyright holders may NOT be used in advertising
-     or publicity pertaining to the work without specific, written prior
-     permission. Title to copyright in this work will at all times remain with
-     copyright holders.
-
-   This product bundles 'ICU4J', including the following files:
-     - lib/com.ibm.icu.icu4j-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the Unicode License. For details, see
-     https://github.com/unicode-org/icu/blob/release-<VERSION>/icu4c/LICENSE
-
-     COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
-
-     Copyright © 1991-2020 Unicode, Inc. All rights reserved.
-     Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
-
-     Permission is hereby granted, free of charge, to any person obtaining
-     a copy of the Unicode data files and any associated documentation
-     (the "Data Files") or Unicode software and any associated documentation
-     (the "Software") to deal in the Data Files or Software
-     without restriction, including without limitation the rights to use,
-     copy, modify, merge, publish, distribute, and/or sell copies of
-     the Data Files or Software, and to permit persons to whom the Data Files
-     or Software are furnished to do so, provided that either
-     (a) this copyright and permission notice appear with all copies
-     of the Data Files or Software, or
-     (b) this copyright and permission notice appear in associated
-     Documentation.
-
-     THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
-     ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-     WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-     NONINFRINGEMENT OF THIRD PARTY RIGHTS.
-     IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
-     NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
-     DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
-     DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-     TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-     PERFORMANCE OF THE DATA FILES OR SOFTWARE.
-
-     Except as contained in this notice, the name of a copyright holder
-     shall not be used in advertising or otherwise to promote the sale,
-     use or other dealings in these Data Files or Software without prior
-     written authorization of the copyright holder.
-
-     ---------------------
-
-     Third-Party Software Licenses
-
-     This section contains third-party software notices and/or additional
-     terms for licensed third-party software components included within ICU
-     libraries.
-
-     1. ICU License - ICU 1.8.1 to ICU 57.1
-
-     COPYRIGHT AND PERMISSION NOTICE
-
-     Copyright (c) 1995-2016 International Business Machines Corporation and others
-     All rights reserved.
-
-     Permission is hereby granted, free of charge, to any person obtaining
-     a copy of this software and associated documentation files (the
-     "Software"), to deal in the Software without restriction, including
-     without limitation the rights to use, copy, modify, merge, publish,
-     distribute, and/or sell copies of the Software, and to permit persons
-     to whom the Software is furnished to do so, provided that the above
-     copyright notice(s) and this permission notice appear in all copies of
-     the Software and that both the above copyright notice(s) and this
-     permission notice appear in supporting documentation.
-
-     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-     MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
-     OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
-     HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
-     SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
-     RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
-     CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
-     CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-     Except as contained in this notice, the name of a copyright holder
-     shall not be used in advertising or otherwise to promote the sale, use
-     or other dealings in this Software without prior written authorization
-     of the copyright holder.
-
-     All trademarks and registered trademarks mentioned herein are the
-     property of their respective owners.
-
-     2. Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
+    2. Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
 
      #     The Google Chrome software developed by Google is licensed under
      # the BSD license. Other software included in this distribution is
@@ -1024,33 +1061,31 @@
      #
      #  ---------------COPYING.ipadic-----END----------------------------------
 
-     3. Lao Word Break Dictionary Data (laodict.txt)
+    3. Lao Word Break Dictionary Data (laodict.txt)
 
-     #  Copyright (c) 2013 International Business Machines Corporation
-     #  and others. All Rights Reserved.
+     # Copyright (C) 2016 and later: Unicode, Inc. and others.
+     # License & terms of use: http://www.unicode.org/copyright.html
+     # Copyright (c) 2015 International Business Machines Corporation
+     # and others. All Rights Reserved.
      #
-     # Project: https://github.com/veer66/lao-dictionary
-     # Dictionary: https://github.com/veer66/lao-dictionary/blob/2c2344310636f548b09d854362ab2e2e666369e0/Lao-Dictionary.txt
-     # License: https://github.com/veer66/lao-dictionary/blob/2c2344310636f548b09d854362ab2e2e666369e0/Lao-Dictionary-LICENSE.txt
-     #              (copied below)
+     # Project: https://github.com/rober42539/lao-dictionary
+     # Dictionary: https://github.com/rober42539/lao-dictionary/laodict.txt
+     # License: https://github.com/rober42539/lao-dictionary/LICENSE.txt
+     #          (copied below)
      #
-     #  This file is derived from the above dictionary, with slight
-     #  modifications.
+     #	This file is derived from the above dictionary version of Nov 22, 2020
      #  ----------------------------------------------------------------------
      #  Copyright (C) 2013 Brian Eugene Wilson, Robert Martin Campbell.
      #  All rights reserved.
      #
      #  Redistribution and use in source and binary forms, with or without
-     #  modification,
-     #  are permitted provided that the following conditions are met:
+     #  modification, are permitted provided that the following conditions are met:
      #
-     #
-     # Redistributions of source code must retain the above copyright notice, this
-     #  list of conditions and the following disclaimer. Redistributions in
-     #  binary form must reproduce the above copyright notice, this list of
-     #  conditions and the following disclaimer in the documentation and/or
-     #  other materials provided with the distribution.
-     #
+     #  Redistributions of source code must retain the above copyright notice, this
+     #  list of conditions and the following disclaimer. Redistributions in binary
+     #  form must reproduce the above copyright notice, this list of conditions and
+     #  the following disclaimer in the documentation and/or other materials
+     #  provided with the distribution.
      #
      # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
      # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -1066,7 +1101,7 @@
      # OF THE POSSIBILITY OF SUCH DAMAGE.
      #  --------------------------------------------------------------------------
 
-     4. Burmese Word Break Dictionary Data (burmesedict.txt)
+    4. Burmese Word Break Dictionary Data (burmesedict.txt)
 
      #  Copyright (c) 2014 International Business Machines Corporation
      #  and others. All Rights Reserved.
@@ -1106,12 +1141,12 @@
      #  SUCH DAMAGE.
      #  --------------------------------------------------------------------------
 
-     5. Time Zone Database
+    5. Time Zone Database
 
-        ICU uses the public domain data and code derived from Time Zone
-     Database for its time zone support. The ownership of the TZ database
-     is explained in BCP 175: Procedure for Maintaining the Time Zone
-     Database section 7.
+      ICU uses the public domain data and code derived from Time Zone
+    Database for its time zone support. The ownership of the TZ database
+    is explained in BCP 175: Procedure for Maintaining the Time Zone
+    Database section 7.
 
      # 7.  Database Ownership
      #
@@ -1129,1081 +1164,436 @@
      #    making a contribution to the database or code waives all rights to
      #    future claims in that contribution or in the TZ Database.
 
-     6. Google double-conversion
+    6. Google double-conversion
 
-     Copyright 2006-2011, the V8 project authors. All rights reserved.
-     Redistribution and use in source and binary forms, with or without
-     modification, are permitted provided that the following conditions are
-     met:
+    Copyright 2006-2011, the V8 project authors. All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
 
-        * Redistributions of source code must retain the above copyright
+      * Redistributions of source code must retain the above copyright
         notice, this list of conditions and the following disclaimer.
-        * Redistributions in binary form must reproduce the above
+      * Redistributions in binary form must reproduce the above
         copyright notice, this list of conditions and the following
         disclaimer in the documentation and/or other materials provided
         with the distribution.
-        * Neither the name of Google Inc. nor the names of its
+      * Neither the name of Google Inc. nor the names of its
         contributors may be used to endorse or promote products derived
         from this software without specific prior written permission.
 
-     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-     "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-     A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-     OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-     SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-     LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-     DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-   This product bundles 'JDOM2', including the following files:
-     - lib/org.jdom.jdom2-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under an Apache style License:
+- com.lihaoyi.geny_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+- com.lihaoyi.os-lib_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'os-lib' from the above files.
+  These files are available under the MIT license:
 
-     Redistribution and use in source and binary forms, with or without
-     modification, are permitted provided that the following conditions
-     are met:
+    License
+    =======
 
-     1. Redistributions of source code must retain the above copyright
-        notice, this list of conditions, and the following disclaimer.
 
-     2. Redistributions in binary form must reproduce the above copyright
-        notice, this list of conditions, and the disclaimer that follows
-        these conditions in the documentation and/or other materials
-        provided with the distribution.
+    The MIT License (MIT)
 
-     3. The name "JDOM" must not be used to endorse or promote products
-        derived from this software without prior written permission.  For
-        written permission, please contact <request_AT_jdom_DOT_org>.
+    Copyright (c) 2019 Li Haoyi (haoyi.sg@gmail.com)
 
-     4. Products derived from this software may not be called "JDOM", nor
-        may "JDOM" appear in their name, without prior written permission
-        from the JDOM Project Management <request_AT_jdom_DOT_org>.
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
 
-     In addition, we request (but do not require) that you include in the
-     end-user documentation provided with the redistribution and/or in the
-     software itself an acknowledgement equivalent to the following:
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+- com.microsoft.java.com.microsoft.java.debug.core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'Java Debug Server for Visual Studio Code' from the above files.
+  These files are available under the Eclipse Public License - v 1.0 license:
+
+    Java Debug Server for Visual Studio Code
+
+    Copyright (c) Microsoft Corporation 
+
+    All rights reserved.  
+
+
+    Eclipse Public License - v 1.0
+
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+
+    1. DEFINITIONS
+
+    "Contribution" means:
+
+    a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
+
+    b) in the case of each subsequent Contributor:
+
+    i) changes to the Program, and
+
+    ii) additions to the Program;
+
+    where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
+
+    "Contributor" means any person or entity that distributes the Program.
+
+    "Licensed Patents" mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+
+    "Program" means the Contributions distributed in accordance with this Agreement.
+
+    "Recipient" means anyone who receives the Program under this Agreement, including all Contributors.
+
+
+    2. GRANT OF RIGHTS
+
+    a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
+
+    b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+
+    c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+
+    d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+
+
+    3. REQUIREMENTS
+
+    A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
+
+    a) it complies with the terms and conditions of this Agreement; and
+
+    b) its license agreement:
+
+    i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+
+    ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+
+    iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
+
+    iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
+
+    When the Program is made available in source code form:
+
+    a) it must be made available under this Agreement; and
+
+    b) a copy of this Agreement must be included with each copy of the Program.
+
+    Contributors may not remove or alter any copyright notices contained within the Program.
+
+    Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
+
+
+    4. COMMERCIAL DISTRIBUTION
+
+    Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor ("Commercial Contributor") hereby agrees to defend and indemnify every other Contributor ("Indemnified Contributor") against any losses, damages and costs (collectively "Losses") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+    For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+
+    5. NO WARRANTY
+
+
+    EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+
+    6. DISCLAIMER OF LIABILITY
+
+    EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+    7. GENERAL
+
+    If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+    If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+
+    All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+
+    Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
+
+    This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+
+- org.apache.daffodil.daffodil-lib-<VERSION>.jar in daffodil-debugger-<VERSION>.zip with:
+  org/apache/daffodil/xsd/XMLSchema.dtd (https://www.w3.org/2001/XMLSchema.dtd)
+  org/apache/daffodil/xsd/XMLSchema.xsd (https://www.w3.org/2001/XMLSchema.xsd)
+  org/apache/daffodil/xsd/XMLSchema_for_DFDL.xsd (https://www.w3.org/2001/XMLSchema.dtd)
+  org/apache/daffodil/xsd/datatypes.dtd (https://www.w3.org/2001/datatypes.dtd)
+  org/apache/daffodil/xsd/xml.xsd (https://www.w3.org/2001/xml.xsd)
+  This product bundles 'W3C' copied or derived material from the above files.
+  These files are available under the W3C Software and Document License:
+
+    By obtaining and/or copying this work, you (the licensee) agree that you have
+    read, understood, and will comply with the following terms and conditions.
+
+    Permission to copy, modify, and distribute this work, with or without
+    modification, for any purpose and without fee or royalty is hereby granted,
+    provided that you include the following on ALL copies of the work or portions
+    thereof, including modifications:
+
+    * The full text of this NOTICE in a location viewable to users of the
+      redistributed or derivative work.
+
+    * Any pre-existing intellectual property disclaimers, notices, or terms and
+      conditions. If none exist, the W3C Software and Document Short Notice should be
+      included.
+
+    * Notice of any changes or modifications, through a copyright statement on the
+      new code or document such as "This software or document includes material
+      copied from or derived from [title and URI of the W3C document]. Copyright ©
+      [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)."
+
+    Disclaimers
+
+    THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO
+    REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+    LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR
+    PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY
+    THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+    COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+    CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+    The name and trademarks of copyright holders may NOT be used in advertising
+    or publicity pertaining to the work without specific, written prior
+    permission. Title to copyright in this work will at all times remain with
+    copyright holders.
+
+- org.apache.daffodil.daffodil-lib-<VERSION>.jar in daffodil-debugger-<VERSION>.zip with:
+  passera/ directory
+  This product bundles 'Passera' compiled source from the above files.
+  These files are available under the BSD-2-Clause license:
+
+    Copyright (c) 2011-2013, Nate Nystrom
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice, this
+    list of conditions and the following disclaimer in the documentation and/or
+    other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+- org.codehaus.woodstox.stax2-api-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'Stax 2 API' from the above files.
+  These files are available under the BSD-2-Clause license:
+
+    Copyright 2010- FasterXML.com
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+- org.jdom.jdom2-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'JDOM2' from the above files.
+  These files are available under an Apache style License:
+
+    Copyright (C) 2000-2012 Jason Hunter & Brett McLaughlin.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions, and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions, and the disclaimer that follows 
+       these conditions in the documentation and/or other materials 
+       provided with the distribution.
+
+    3. The name "JDOM" must not be used to endorse or promote products
+       derived from this software without prior written permission.  For
+       written permission, please contact <request_AT_jdom_DOT_org>.
+
+    4. Products derived from this software may not be called "JDOM", nor
+       may "JDOM" appear in their name, without prior written permission
+       from the JDOM Project Management <request_AT_jdom_DOT_org>.
+
+    In addition, we request (but do not require) that you include in the 
+    end-user documentation provided with the redistribution and/or in the 
+    software itself an acknowledgement equivalent to the following:
 
         "This product includes software developed by the
-           JDOM Project (http://www.jdom.org/)."
-
-     Alternatively, the acknowledgment may be graphical using the logos
-     available at http://www.jdom.org/images/logos.
-
-     THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
-     WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-     OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-     DISCLAIMED.  IN NO EVENT SHALL THE JDOM AUTHORS OR THE PROJECT
-     CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-     SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-     LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
-     USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-     ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-     OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-     SUCH DAMAGE.
-
-     This software consists of voluntary contributions made by many
-     individuals on behalf of the JDOM Project and was originally
-     created by Jason Hunter <jhunter_AT_jdom_DOT_org> and
-     Brett McLaughlin <brett_AT_jdom_DOT_org>.  For more information
-     on the JDOM Project, please see <http://www.jdom.org/>.
-
-
-   This product bundles 'Saxon-HE (Home Edition)', including the following files:
-     - lib/Saxon-HE-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the MPL 2.0 license:
-
-     Most of the open source code in the Saxon product is governed by the Mozilla Public
-     License version 2.0, which is reproduced below.
-
-
-     Mozilla Public License Version 2.0
-     ==================================
-
-     1. Definitions
-     --------------
-
-     1.1. "Contributor"
-        means each individual or legal entity that creates, contributes to
-        the creation of, or owns Covered Software.
-
-     1.2. "Contributor Version"
-        means the combination of the Contributions of others (if any) used
-        by a Contributor and that particular Contributor's Contribution.
-
-     1.3. "Contribution"
-        means Covered Software of a particular Contributor.
-
-     1.4. "Covered Software"
-        means Source Code Form to which the initial Contributor has attached
-        the notice in Exhibit A, the Executable Form of such Source Code
-        Form, and Modifications of such Source Code Form, in each case
-        including portions thereof.
-
-     1.5. "Incompatible With Secondary Licenses"
-        means
-
-        (a) that the initial Contributor has attached the notice described
-              in Exhibit B to the Covered Software; or
-
-        (b) that the Covered Software was made available under the terms of
-              version 1.1 or earlier of the License, but not also under the
-              terms of a Secondary License.
-
-     1.6. "Executable Form"
-        means any form of the work other than Source Code Form.
-
-     1.7. "Larger Work"
-        means a work that combines Covered Software with other material, in
-        a separate file or files, that is not Covered Software.
-
-     1.8. "License"
-        means this document.
-
-     1.9. "Licensable"
-        means having the right to grant, to the maximum extent possible,
-        whether at the time of the initial grant or subsequently, any and
-        all of the rights conveyed by this License.
-
-     1.10. "Modifications"
-        means any of the following:
-
-        (a) any file in Source Code Form that results from an addition to,
-              deletion from, or modification of the contents of Covered
-              Software; or
-
-        (b) any new file in Source Code Form that contains any Covered
-              Software.
-
-     1.11. "Patent Claims" of a Contributor
-        means any patent claim(s), including without limitation, method,
-        process, and apparatus claims, in any patent Licensable by such
-        Contributor that would be infringed, but for the grant of the
-        License, by the making, using, selling, offering for sale, having
-        made, import, or transfer of either its Contributions or its
-        Contributor Version.
-
-     1.12. "Secondary License"
-        means either the GNU General Public License, Version 2.0, the GNU
-        Lesser General Public License, Version 2.1, the GNU Affero General
-        Public License, Version 3.0, or any later versions of those
-        licenses.
-
-     1.13. "Source Code Form"
-        means the form of the work preferred for making modifications.
-
-     1.14. "You" (or "Your")
-        means an individual or a legal entity exercising rights under this
-        License. For legal entities, "You" includes any entity that
-        controls, is controlled by, or is under common control with You. For
-        purposes of this definition, "control" means (a) the power, direct
-        or indirect, to cause the direction or management of such entity,
-        whether by contract or otherwise, or (b) ownership of more than
-        fifty percent (50%) of the outstanding shares or beneficial
-        ownership of such entity.
-
-     2. License Grants and Conditions
-     --------------------------------
-
-     2.1. Grants
-
-     Each Contributor hereby grants You a world-wide, royalty-free,
-     non-exclusive license:
-
-     (a) under intellectual property rights (other than patent or trademark)
-        Licensable by such Contributor to use, reproduce, make available,
-        modify, display, perform, distribute, and otherwise exploit its
-        Contributions, either on an unmodified basis, with Modifications, or
-        as part of a Larger Work; and
-
-     (b) under Patent Claims of such Contributor to make, use, sell, offer
-        for sale, have made, import, and otherwise transfer either its
-        Contributions or its Contributor Version.
-
-     2.2. Effective Date
-
-     The licenses granted in Section 2.1 with respect to any Contribution
-     become effective for each Contribution on the date the Contributor first
-     distributes such Contribution.
-
-     2.3. Limitations on Grant Scope
-
-     The licenses granted in this Section 2 are the only rights granted under
-     this License. No additional rights or licenses will be implied from the
-     distribution or licensing of Covered Software under this License.
-     Notwithstanding Section 2.1(b) above, no patent license is granted by a
-     Contributor:
-
-     (a) for any code that a Contributor has removed from Covered Software;
-        or
-
-     (b) for infringements caused by: (i) Your and any other third party's
-        modifications of Covered Software, or (ii) the combination of its
-        Contributions with other software (except as part of its Contributor
-        Version); or
-
-     (c) under Patent Claims infringed by Covered Software in the absence of
-        its Contributions.
-
-     This License does not grant any rights in the trademarks, service marks,
-     or logos of any Contributor (except as may be necessary to comply with
-     the notice requirements in Section 3.4).
-
-     2.4. Subsequent Licenses
-
-     No Contributor makes additional grants as a result of Your choice to
-     distribute the Covered Software under a subsequent version of this
-     License (see Section 10.2) or under the terms of a Secondary License (if
-     permitted under the terms of Section 3.3).
-
-     2.5. Representation
-
-     Each Contributor represents that the Contributor believes its
-     Contributions are its original creation(s) or it has sufficient rights
-     to grant the rights to its Contributions conveyed by this License.
-
-     2.6. Fair Use
-
-     This License is not intended to limit any rights You have under
-     applicable copyright doctrines of fair use, fair dealing, or other
-     equivalents.
-
-     2.7. Conditions
-
-     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
-     in Section 2.1.
-
-     3. Responsibilities
-     -------------------
-
-     3.1. Distribution of Source Form
-
-     All distribution of Covered Software in Source Code Form, including any
-     Modifications that You create or to which You contribute, must be under
-     the terms of this License. You must inform recipients that the Source
-     Code Form of the Covered Software is governed by the terms of this
-     License, and how they can obtain a copy of this License. You may not
-     attempt to alter or restrict the recipients' rights in the Source Code
-     Form.
-
-     3.2. Distribution of Executable Form
-
-     If You distribute Covered Software in Executable Form then:
-
-     (a) such Covered Software must also be made available in Source Code
-        Form, as described in Section 3.1, and You must inform recipients of
-        the Executable Form how they can obtain a copy of such Source Code
-        Form by reasonable means in a timely manner, at a charge no more
-        than the cost of distribution to the recipient; and
-
-     (b) You may distribute such Executable Form under the terms of this
-        License, or sublicense it under different terms, provided that the
-        license for the Executable Form does not attempt to limit or alter
-        the recipients' rights in the Source Code Form under this License.
-
-     3.3. Distribution of a Larger Work
-
-     You may create and distribute a Larger Work under terms of Your choice,
-     provided that You also comply with the requirements of this License for
-     the Covered Software. If the Larger Work is a combination of Covered
-     Software with a work governed by one or more Secondary Licenses, and the
-     Covered Software is not Incompatible With Secondary Licenses, this
-     License permits You to additionally distribute such Covered Software
-     under the terms of such Secondary License(s), so that the recipient of
-     the Larger Work may, at their option, further distribute the Covered
-     Software under the terms of either this License or such Secondary
-     License(s).
-
-     3.4. Notices
-
-     You may not remove or alter the substance of any license notices
-     (including copyright notices, patent notices, disclaimers of warranty,
-     or limitations of liability) contained within the Source Code Form of
-     the Covered Software, except that You may alter any license notices to
-     the extent required to remedy known factual inaccuracies.
-
-     3.5. Application of Additional Terms
-
-     You may choose to offer, and to charge a fee for, warranty, support,
-     indemnity or liability obligations to one or more recipients of Covered
-     Software. However, You may do so only on Your own behalf, and not on
-     behalf of any Contributor. You must make it absolutely clear that any
-     such warranty, support, indemnity, or liability obligation is offered by
-     You alone, and You hereby agree to indemnify every Contributor for any
-     liability incurred by such Contributor as a result of warranty, support,
-     indemnity or liability terms You offer. You may include additional
-     disclaimers of warranty and limitations of liability specific to any
-     jurisdiction.
-
-     4. Inability to Comply Due to Statute or Regulation
-     ---------------------------------------------------
-
-     If it is impossible for You to comply with any of the terms of this
-     License with respect to some or all of the Covered Software due to
-     statute, judicial order, or regulation then You must: (a) comply with
-     the terms of this License to the maximum extent possible; and (b)
-     describe the limitations and the code they affect. Such description must
-     be placed in a text file included with all distributions of the Covered
-     Software under this License. Except to the extent prohibited by statute
-     or regulation, such description must be sufficiently detailed for a
-     recipient of ordinary skill to be able to understand it.
-
-     5. Termination
-     --------------
-
-     5.1. The rights granted under this License will terminate automatically
-     if You fail to comply with any of its terms. However, if You become
-     compliant, then the rights granted under this License from a particular
-     Contributor are reinstated (a) provisionally, unless and until such
-     Contributor explicitly and finally terminates Your grants, and (b) on an
-     ongoing basis, if such Contributor fails to notify You of the
-     non-compliance by some reasonable means prior to 60 days after You have
-     come back into compliance. Moreover, Your grants from a particular
-     Contributor are reinstated on an ongoing basis if such Contributor
-     notifies You of the non-compliance by some reasonable means, this is the
-     first time You have received notice of non-compliance with this License
-     from such Contributor, and You become compliant prior to 30 days after
-     Your receipt of the notice.
-
-     5.2. If You initiate litigation against any entity by asserting a patent
-     infringement claim (excluding declaratory judgment actions,
-     counter-claims, and cross-claims) alleging that a Contributor Version
-     directly or indirectly infringes any patent, then the rights granted to
-     You by any and all Contributors for the Covered Software under Section
-     2.1 of this License shall terminate.
-
-     5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-     end user license agreements (excluding distributors and resellers) which
-     have been validly granted by You or Your distributors under this License
-     prior to termination shall survive termination.
-
-     ************************************************************************
-     *                                                                      *
-     *  6. Disclaimer of Warranty                                           *
-     *  -------------------------                                           *
-     *                                                                      *
-     *  Covered Software is provided under this License on an "as is"       *
-     *  basis, without warranty of any kind, either expressed, implied, or  *
-     *  statutory, including, without limitation, warranties that the       *
-     *  Covered Software is free of defects, merchantable, fit for a        *
-     *  particular purpose or non-infringing. The entire risk as to the     *
-     *  quality and performance of the Covered Software is with You.        *
-     *  Should any Covered Software prove defective in any respect, You     *
-     *  (not any Contributor) assume the cost of any necessary servicing,   *
-     *  repair, or correction. This disclaimer of warranty constitutes an   *
-     *  essential part of this License. No use of any Covered Software is   *
-     *  authorized under this License except under this disclaimer.         *
-     *                                                                      *
-     ************************************************************************
-
-     ************************************************************************
-     *                                                                      *
-     *  7. Limitation of Liability                                          *
-     *  --------------------------                                          *
-     *                                                                      *
-     *  Under no circumstances and under no legal theory, whether tort      *
-     *  (including negligence), contract, or otherwise, shall any           *
-     *  Contributor, or anyone who distributes Covered Software as          *
-     *  permitted above, be liable to You for any direct, indirect,         *
-     *  special, incidental, or consequential damages of any character      *
-     *  including, without limitation, damages for lost profits, loss of    *
-     *  goodwill, work stoppage, computer failure or malfunction, or any    *
-     *  and all other commercial damages or losses, even if such party      *
-     *  shall have been informed of the possibility of such damages. This   *
-     *  limitation of liability shall not apply to liability for death or   *
-     *  personal injury resulting from such party's negligence to the       *
-     *  extent applicable law prohibits such limitation. Some               *
-     *  jurisdictions do not allow the exclusion or limitation of           *
-     *  incidental or consequential damages, so this exclusion and          *
-     *  limitation may not apply to You.                                    *
-     *                                                                      *
-     ************************************************************************
-
-     8. Litigation
-     -------------
-
-     Any litigation relating to this License may be brought only in the
-     courts of a jurisdiction where the defendant maintains its principal
-     place of business and such litigation shall be governed by laws of that
-     jurisdiction, without reference to its conflict-of-law provisions.
-     Nothing in this Section shall prevent a party's ability to bring
-     cross-claims or counter-claims.
-
-     9. Miscellaneous
-     ----------------
-
-     This License represents the complete agreement concerning the subject
-     matter hereof. If any provision of this License is held to be
-     unenforceable, such provision shall be reformed only to the extent
-     necessary to make it enforceable. Any law or regulation which provides
-     that the language of a contract shall be construed against the drafter
-     shall not be used to construe this License against a Contributor.
-
-     10. Versions of the License
-     ---------------------------
-
-     10.1. New Versions
-
-     Mozilla Foundation is the license steward. Except as provided in Section
-     10.3, no one other than the license steward has the right to modify or
-     publish new versions of this License. Each version will be given a
-     distinguishing version number.
-
-     10.2. Effect of New Versions
-
-     You may distribute the Covered Software under the terms of the version
-     of the License under which You originally received the Covered Software,
-     or under the terms of any subsequent version published by the license
-     steward.
-
-     10.3. Modified Versions
-
-     If you create software not governed by this License, and you want to
-     create a new license for such software, you may create and use a
-     modified version of this License if you rename the license and remove
-     any references to the name of the license steward (except to note that
-     such modified license differs from this License).
-
-     10.4. Distributing Source Code Form that is Incompatible With Secondary
-     Licenses
-
-     If You choose to distribute Source Code Form that is Incompatible With
-     Secondary Licenses under the terms of this version of the License, the
-     notice described in Exhibit B of this License must be attached.
-
-     Exhibit A - Source Code Form License Notice
-     -------------------------------------------
-
-        This Source Code Form is subject to the terms of the Mozilla Public
-        License, v. 2.0. If a copy of the MPL was not distributed with this
-        file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-     If it is not possible or desirable to put the notice in a particular
-     file, then You may include the notice in a location (such as a LICENSE
-     file in a relevant directory) where a recipient would be likely to look
-     for such a notice.
-
-     You may add additional accurate notices of copyright ownership.
-
-     Exhibit B - "Incompatible With Secondary Licenses" Notice
-     ---------------------------------------------------------
-
-        This Source Code Form is "Incompatible With Secondary Licenses", as
-        defined by the Mozilla Public License, v. 2.0.
-
-
-     SAXON SUBCOMPONENTS
-
-     Saxon contains subcomponents with separate copyright notices:
-
-
-        (This notice is included in the Saxon distribution because Saxon includes a QuickSort
-        module that was originally developed by Wolfgang Hoschek at CERN, and which was licensed
-        for use under the conditions specified here.)
-
-
-        Copyright © 1999 CERN - European Organization for Nuclear Research.
-
-        Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose
-        is hereby granted without fee, provided that the above copyright notice appear in all copies and
-        that both that copyright notice and this permission notice appear in supporting documentation.
-        CERN makes no representations about the suitability of this software for any purpose.
-        It is provided "as is" without expressed or implied warranty.
-
-
-        (This notice is included in the Saxon distribution because Saxon
-        uses code extracted from the PCollections library. The only substantive change
-        in the version distributed with Saxon is the removal of code that Saxon does not need.)
-
-
-        (This license is published at https://github.com/hrldcpr/pcollections/blob/v3.1.4/LICENSE)
-
-        MIT License
-
-        Copyright 2008 Harold Cooper
-
-        Permission is hereby granted, free of charge, to any person obtaining a copy
-        of this software and associated documentation files (the "Software"), to deal
-        in the Software without restriction, including without limitation the rights
-        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-        copies of the Software, and to permit persons to whom the Software is
-        furnished to do so, subject to the following conditions:
-
-        The above copyright notice and this permission notice shall be included in
-        all copies or substantial portions of the Software.
-
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-        SOFTWARE.
-
-
-        (This notice is included in the Saxon distribution because Saxon's XPath parser
-        was originally derived from an XPath parser written by James Clark and made available
-        under this license. The Saxon XPath parser has since diverged very substantially, but
-        there are traces of the original code still present.)
-
-
-        Copyright (c) 1998, 1999 James Clark
-
-        Permission is hereby granted, free of charge, to any person obtaining
-        a copy of this software and associated documentation files (the
-        "Software"), to deal in the Software without restriction, including
-        without limitation the rights to use, copy, modify, merge, publish,
-        distribute, sublicense, and/or sell copies of the Software, and to
-        permit persons to whom the Software is furnished to do so, subject to
-        the following conditions:
-
-        The above copyright notice and this permission notice shall be included
-        in all copies or substantial portions of the Software.
-
-        THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND, EXPRESS
-        OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-        IN NO EVENT SHALL JAMES CLARK BE LIABLE FOR ANY CLAIM, DAMAGES OR
-        OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-        ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-        OTHER DEALINGS IN THE SOFTWARE.
-
-        Except as contained in this notice, the name of James Clark shall
-        not be used in advertising or otherwise to promote the sale, use or
-        other dealings in this Software without prior written authorization
-        from James Clark.
-
-
-        (This notice is included in the Saxon distribution because Saxon
-        uses code for conversion of XML Schema Regular expressions to
-        Java/.NET regular expressions that was originally written by James
-        Clark and made available under this license. The Saxon version of
-        the code has been enhanced in various ways but is still recognizably
-        based on the original.)
-
-
-        Copyright (c) 2001-2003 Thai Open Source Software Center Ltd
-        All rights reserved.
-
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are
-        met:
-
-           Redistributions of source code must retain the above copyright
-           notice, this list of conditions and the following disclaimer.
-
-           Redistributions in binary form must reproduce the above copyright
-           notice, this list of conditions and the following disclaimer in
-           the documentation and/or other materials provided with the
-           distribution.
-
-           Neither the name of the Thai Open Source Software Center Ltd nor
-           the names of its contributors may be used to endorse or promote
-           products derived from this software without specific prior written
-           permission.
-
-        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-        "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-        LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-        A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
-        CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-        EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-        PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-        PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-        LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-        NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-        (This notice is included in the Saxon distribution because Saxon
-        uses code performing Unicode Normalization that was originally written by Mark
-        Davis and made available under this license. The Saxon version of the
-        code has been enhanced in various minor ways but is still recognizably
-        based on the original. For details of modifications, see the comments in
-        the source code.)
-
-
-        COPYRIGHT AND PERMISSION NOTICE
-        Copyright © 1991-2007 Unicode, Inc. All rights reserved. Distributed under the Terms of Use
-        in http://www.unicode.org/copyright.html.
-
-        Permission is hereby granted, free of charge, to any person obtaining a copy of the Unicode
-        data files and any associated documentation (the "Data Files") or Unicode software and any
-        associated documentation (the "Software") to deal in the Data Files or Software without
-        restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute,
-        and/or sell copies of the Data Files or Software, and to permit persons to whom the Data Files or
-        Software are furnished to do so, provided that (a) the above copyright notice(s) and this
-        permission notice appear with all copies of the Data Files or Software, (b) both the above
-        copyright notice(s) and this permission notice appear in associated documentation, and
-        (c) there is clear notice in each modified Data File or in the Software as well as in the
-        documentation associated with the Data File(s) or Software that the data or software has
-        been modified.
-
-        THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
-        IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
-        BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
-        OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
-        WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
-        ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
-        FILES OR SOFTWARE.
-
-        Except as contained in this notice, the name of a copyright holder shall not be used
-        in advertising or otherwise to promote the sale, use or other dealings in these
-        Data Files or Software without prior written authorization of the copyright holder.
-
-
-   This product bundles 'Stax 2 API', including the following files:
-     - lib/org.codehaus.woodstox.stax2-api-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the BSD-2-Clause license:
-
-     Copyright 2010- FasterXML.com
-
-     Redistribution and use in source and binary forms, with or without
-     modification, are permitted provided that the following conditions are met:
-
-     1. Redistributions of source code must retain the above copyright notice, this
-        list of conditions and the following disclaimer.
-
-     2. Redistributions in binary form must reproduce the above copyright notice,
-        this list of conditions and the following disclaimer in the documentation
-        and/or other materials provided with the distribution.
-
-     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-     FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-     DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-     SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-   This product bundles content from the Schematron "skeleton" - XSLT implementation, including
-   the following files:
-     - iso-schematron-xslt2/iso_abstract_expand.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - iso-schematron-xslt2/iso_dsdl_include.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - iso-schematron-xslt2/iso_schematron_message_xslt2.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - iso-schematron-xslt2/iso_schematron_skeleton_for_saxon.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - iso-schematron-xslt2/iso_svrl_for_xslt2.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - iso-schematron-xslt2/sch-messages-en.xhtml in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   The content is available under the MIT License:
-
-     Copyright (c) 2004-2010 Rick Jellife and Academia Sinica Computing Centre, Taiwan
-
-     Permission is hereby granted, free of charge, to any person obtaining a copy
-     of this software and associated documentation files (the "Software"), to deal
-     in the Software without restriction, including without limitation the rights
-     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-     copies of the Software, and to permit persons to whom the Software is
-     furnished to do so, subject to the following conditions:
-
-     The above copyright notice and this permission notice shall be included in all
-     copies or substantial portions of the Software.
-
-     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-     SOFTWARE.
-
-   This product bundles content from the Schematron converters, including
-   the following files:
-     - iso-schematron-xslt2/ExtractSchFromXSD-2.xsl in lib/org.apache.daffodil.daffodil-schematron-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   The content is available under the MIT License:
-
-     Copyright (c) 2002-2010 Rick Jelliffe and Topologi Pty. Ltd.
-
-     Permission is hereby granted, free of charge, to any person obtaining a copy
-     of this software and associated documentation files (the "Software"), to deal
-     in the Software without restriction, including without limitation the rights
-     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-     copies of the Software, and to permit persons to whom the Software is
-     furnished to do so, subject to the following conditions:
-
-     The above copyright notice and this permission notice shall be included in
-     all copies or substantial portions of the Software.
-
-     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-     THE SOFTWARE.
-
-
-   This product bundles libraries from 'os-lib', including the following files:
-     - lib/com.lihaoyi.geny_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - lib/com.lihaoyi.os-lib_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the MIT license:
-
-     License
-     =======
-
-
-     The MIT License (MIT)
-
-     Copyright (c) 2019 Li Haoyi (haoyi.sg@gmail.com)
-
-     Permission is hereby granted, free of charge, to any person obtaining a copy
-     of this software and associated documentation files (the "Software"), to deal
-     in the Software without restriction, including without limitation the rights
-     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-     copies of the Software, and to permit persons to whom the Software is
-     furnished to do so, subject to the following conditions:
-
-     The above copyright notice and this permission notice shall be included in
-     all copies or substantial portions of the Software.
-
-     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-     DEALINGS IN THE SOFTWARE.
-
-
-   This product bundles libraries from 'logback', including the following files:
-     - lib/ch.qos.logback:logback-classic-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - lib/ch.qos.logback:logback-core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the Logback license:
-
-      Logback LICENSE
-      ---------------
-
-      Logback: the reliable, generic, fast and flexible logging framework.
-      Copyright (C) 1999-2015, QOS.ch. All rights reserved.
-
-      This program and the accompanying materials are dual-licensed under
-      either the terms of the Eclipse Public License v1.0 as published by
-      the Eclipse Foundation
-      
-      or (per the licensee's choosing)
-      
-      under the terms of the GNU Lesser General Public License version 2.1
-      as published by the Free Software Foundation.
-
-
-   This product bundles libraries from 'fs2', including the following files:
-     - lib/co.fs2:fs2-core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - lib/co.fs2:fs2-io-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the MIT license:
-   
-      The MIT License (MIT)
-
-      Copyright (c) 2013 Paul Chiusano, and respective contributors 
-
-      Permission is hereby granted, free of charge, to any person obtaining a copy
-      of this software and associated documentation files (the "Software"), to deal
-      in the Software without restriction, including without limitation the rights
-      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-      copies of the Software, and to permit persons to whom the Software is
-      furnished to do so, subject to the following conditions:
-
-      The above copyright notice and this permission notice shall be included in
-      all copies or substantial portions of the Software.
-
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-      THE SOFTWARE.
-
-      Code in FS2 is derived in part from scodec. The scodec license is as follows:
-
-      Copyright (c) 2013-2014, Michael Pilquist and Paul Chiusano
-      All rights reserved.
-
-      Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-      1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-      2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-      3. Neither the name of the scodec team nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-      Code in FS2 is derived in part from Cats. The Cats license is as follows:
-
-      Cats Copyright (c) 2015 Erik Osheim.
-
-      Permission is hereby granted, free of charge, to any person obtaining a copy of
-      this software and associated documentation files (the "Software"), to deal in
-      the Software without restriction, including without limitation the rights to
-      use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-      of the Software, and to permit persons to whom the Software is furnished to do
-      so, subject to the following conditions: 
-
-      The above copyright notice and this permission notice shall be included in all
-      copies or substantial portions of the Software. 
-
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-      SOFTWARE. 
-
-      ------
-
-      Code in Cats is derived in part from Scalaz. The Scalaz license follows:
-
-      Copyright (c) 2009-2014 Tony Morris, Runar Bjarnason, Tom Adams,
-      Kristian Domagala, Brad Clow, Ricky Clarkson, Paul Chiusano, Trygve
-      Laugstøl, Nick Partridge, Jason Zaugg. All rights reserved.
-
-      Redistribution and use in source and binary forms, with or without
-      modification, are permitted provided that the following conditions
-      are met:
-      1. Redistributions of source code must retain the above copyright
-         notice, this list of conditions and the following disclaimer.
-      2. Redistributions in binary form must reproduce the above copyright
-         notice, this list of conditions and the following disclaimer in the
-         documentation and/or other materials provided with the distribution.
-      3. The name of the author may not be used to endorse or promote products
-         derived from this software without specific prior written permission.
-
-      THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
-      IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-      OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-      IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
-      INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-      NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-      THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-   This product bundles libraries from 'Java Debug Server for Visual Studio Code', including the following files:
-     - lib/com.microsoft.java:com.microsoft.java.debug.core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the Eclipse Public License - v 1.0 license:
-
-      Java Debug Server for Visual Studio Code
-
-      Copyright (c) Microsoft Corporation 
-
-      All rights reserved.  
-
-
-      Eclipse Public License - v 1.0
-
-
-      THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
-
-
-      1. DEFINITIONS
-
-      "Contribution" means:
-
-      a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
-
-      b) in the case of each subsequent Contributor:
-
-      i) changes to the Program, and
-
-      ii) additions to the Program;
-
-      where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
-
-      "Contributor" means any person or entity that distributes the Program.
-
-      "Licensed Patents" mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
-
-      "Program" means the Contributions distributed in accordance with this Agreement.
-
-      "Recipient" means anyone who receives the Program under this Agreement, including all Contributors.
-
-
-      2. GRANT OF RIGHTS
-
-      a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
-
-      b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
-
-      c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
-
-      d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
-
-
-      3. REQUIREMENTS
-
-      A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
-
-      a) it complies with the terms and conditions of this Agreement; and
-
-      b) its license agreement:
-
-      i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
-
-      ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
-
-      iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
-
-      iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
-
-      When the Program is made available in source code form:
-
-      a) it must be made available under this Agreement; and
-
-      b) a copy of this Agreement must be included with each copy of the Program.
-
-      Contributors may not remove or alter any copyright notices contained within the Program.
-
-      Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
-
-
-      4. COMMERCIAL DISTRIBUTION
-
-      Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor ("Commercial Contributor") hereby agrees to defend and indemnify every other Contributor ("Indemnified Contributor") against any losses, damages and costs (collectively "Losses") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
-
-      For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
-
-
-      5. NO WARRANTY
-
-
-      EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
-
-
-      6. DISCLAIMER OF LIABILITY
-
-      EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-      7. GENERAL
-
-      If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
-
-      If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
-
-
-      All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
-
-
-      Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
-
-      This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
-
-
-   This product bundles libraries from 'reactive streams', including the following files:
-     - lib/org.reactivestreams:reactive-streams-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the MIT-0 license:
-
-      MIT No Attribution
-
-      Copyright 2014 Reactive Streams
-
-      Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
-
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-   This product bundles libraries from 'scodec', including the following files:
-     - lib/org.scodec:scodec-bits-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the BSD 3-Clause license:
-
-      Copyright (c) 2013-2014, Michael Pilquist and Paul Chiusano
-      All rights reserved.
-
-      Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-      1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-      2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-      3. Neither the name of the scodec team nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-   This product bundles libraries from 'slf4j', including the following files:
-     - lib/org.slf4j:slf4j-api-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the MIT license:
-
-      Copyright (c) 2004-2017 QOS.ch
-      All rights reserved.
-
-      Permission is hereby granted, free  of charge, to any person obtaining
-      a  copy  of this  software  and  associated  documentation files  (the
-      "Software"), to  deal in  the Software without  restriction, including
-      without limitation  the rights to  use, copy, modify,  merge, publish,
-      distribute,  sublicense, and/or sell  copies of  the Software,  and to
-      permit persons to whom the Software  is furnished to do so, subject to
-      the following conditions:
-
-      The  above  copyright  notice  and  this permission  notice  shall  be
-      included in all copies or substantial portions of the Software.
-
-      THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
-      EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
-      MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
-      NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-      LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-      OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
-      WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-   This product bundles libraries from 'cats', including the following files:
-     - lib/org.typelevel:cats-core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-     - lib/org.typelevel:cats-kernel-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
-   These files are available under the MIT license:
-
-      Cats Copyright (c) 2015 Cats Contributors.
-
-      Permission is hereby granted, free of charge, to any person obtaining a copy of
-      this software and associated documentation files (the "Software"), to deal in
-      the Software without restriction, including without limitation the rights to
-      use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-      of the Software, and to permit persons to whom the Software is furnished to do
-      so, subject to the following conditions: 
-
-      The above copyright notice and this permission notice shall be included in all
-      copies or substantial portions of the Software. 
-
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-      SOFTWARE. 
-
-      ------
-
-      Code in Cats is derived in part from Scalaz. The Scalaz license follows:
-
-      Copyright (c) 2009-2014 Tony Morris, Runar Bjarnason, Tom Adams,
-      Kristian Domagala, Brad Clow, Ricky Clarkson, Paul Chiusano, Trygve
-      Laugstøl, Nick Partridge, Jason Zaugg. All rights reserved.
-
-      Redistribution and use in source and binary forms, with or without
-      modification, are permitted provided that the following conditions
-      are met:
-      1. Redistributions of source code must retain the above copyright
-         notice, this list of conditions and the following disclaimer.
-      2. Redistributions in binary form must reproduce the above copyright
-         notice, this list of conditions and the following disclaimer in the
-         documentation and/or other materials provided with the distribution.
-      3. The name of the author may not be used to endorse or promote products
-         derived from this software without specific prior written permission.
-
-      THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
-      IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
-      OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-      IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
-      INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-      NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-      THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+         JDOM Project (http://www.jdom.org/)."
+
+    Alternatively, the acknowledgment may be graphical using the logos 
+    available at http://www.jdom.org/images/logos.
+
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED.  IN NO EVENT SHALL THE JDOM AUTHORS OR THE PROJECT
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+    USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+    OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+
+    This software consists of voluntary contributions made by many 
+    individuals on behalf of the JDOM Project and was originally 
+    created by Jason Hunter <jhunter_AT_jdom_DOT_org> and
+    Brett McLaughlin <brett_AT_jdom_DOT_org>.  For more information
+    on the JDOM Project, please see <http://www.jdom.org/>.
+
+- org.reactivestreams.reactive-streams-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'reactive streams' from the above files.
+  These files are available under the MIT-0 license:
+
+    MIT No Attribution
+
+    Copyright 2014 Reactive Streams
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+- org.scodec.scodec-bits-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'scodec' from the above files.
+  These files are available under the BSD 3-Clause license:
+
+    Copyright (c) 2013-2014, Michael Pilquist and Paul Chiusano
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    3. Neither the name of the scodec team nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+- org.slf4j.slf4j-api-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'slf4j' from the above files.
+  These files are available under the MIT license:
+
+    Copyright (c) 2004-2017 QOS.ch
+    All rights reserved.
+
+    Permission is hereby granted, free  of charge, to any person obtaining
+    a  copy  of this  software  and  associated  documentation files  (the
+    "Software"), to  deal in  the Software without  restriction, including
+    without limitation  the rights to  use, copy, modify,  merge, publish,
+    distribute,  sublicense, and/or sell  copies of  the Software,  and to
+    permit persons to whom the Software  is furnished to do so, subject to
+    the following conditions:
+
+    The  above  copyright  notice  and  this permission  notice  shall  be
+    included in all copies or substantial portions of the Software.
+
+    THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+    EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+    MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+- org.typelevel.cats-core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+- org.typelevel.cats-kernel-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'cats' from the above files.
+  These files are available under the MIT license:
+
+    Cats Copyright (c) 2015 Cats Contributors.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is furnished to do
+    so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE. 
+
+    ------
+
+    Code in Cats is derived in part from Scalaz. The Scalaz license follows:
+
+    Copyright (c) 2009-2014 Tony Morris, Runar Bjarnason, Tom Adams,
+    Kristian Domagala, Brad Clow, Ricky Clarkson, Paul Chiusano, Trygve
+    Laugstøl, Nick Partridge, Jason Zaugg. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. The name of the author may not be used to endorse or promote products
+       derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+    IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+    IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+    THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/build/bin.NOTICE
+++ b/build/bin.NOTICE
@@ -10,104 +10,11 @@ Based on source code originally developed by
 
 The following NOTICE information applies to binary components distributed with this project:
 
-Apache Daffodil (lib/org.apache.daffodil:daffodil-core_<VERSION>.jar, lib/org.apache.daffodil:daffodil-io_<VERSION>.jar, lib/org.apache.daffodil:daffodil-lib_<VERSION>.jar, lib/org.apache.daffodil:daffodil-runtime1-unparser_<VERSION>.jar, lib/org.apache.daffodil:daffodil-runtime1_<VERSION>.jar, lib/org.apache.daffodil:daffodil-sapi_<VERSION>.jar, lib/org.apache.daffodil:daffodil-udf_<VERSION>.jar)
-  Apache Daffodil
+- com.comcast.ip4s-core_<VERSION>.jar
+  IP Addresses for Scala and Scala.js
+  Copyright 2018 Comcast Cable Communications Management, LLC
 
-  Copyright 2021 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  Based on source code originally developed by
-  - The Univerisity of Illinois National Center for Supercomputing Applications (http://www.ncsa.illinois.edu/)
-  - Tresys Technology (http://www.tresys.com/)
-  - International Business Machines Corporation (http://www.ibm.com)
-
-Apache Commons IO (lib/commons-io.commons-io-<VERSION>.jar)
-  Apache Commons IO
-  Copyright 2002-2021 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (https://www.apache.org/).
-
-Apache Log4j (lib/org.apache.logging.log4j.log4j-api-<VERSION>.jar, org.apache.logging.log4j.log4j-core-<VERSION>.jar)
-  Apache Log4j
-  Copyright 1999-2019 Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  ResolverUtil.java
-  Copyright 2005-2006 Tim Fennell
-
-  Dumbster SMTP test server
-  Copyright 2004 Jason Paul Kitchen
-
-  TypeUtil.java
-  Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
-
-  picocli (http://picocli.info)
-  Copyright 2017 Remko Popma
-
-Apache Log4j Scala API (lib/org.apache.logging.log4j.log4j-api-scala_<VERSION>.jar)
-  Copyright 2016-2018 Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  AsciidocPlugin.scala
-  Copyright (c) 2008, 2009, 2010, 2011 Josh Suereth, Steven Blundy, Josh Cough,
-  Mark Harrah, Stuart Roebuck, Tony Sloane, Vesa Vilhonen, Jason Zaugg
-
-Apache Xerces Java (lib/xerces.xercesImpl-<VERSION>.jar)
-  Apache Xerces Java
-  Copyright 1999-2020 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  Portions of this software were originally based on the following:
-    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-    - voluntary contributions made by Paul Eng on behalf of the 
-      Apache Software Foundation that were originally developed at iClick, Inc.,
-      software copyright (c) 1999.
-
-Apache XML Commons Resolver (lib/xml-resolver.xml-resolver-<VERSION>.jar)
-  Apache XML Commons Resolver
-  Copyright 2006 The Apache Software Foundation.
-
-  This product includes software developed at
-  The Apache Software Foundation http://www.apache.org/
-
-  Portions of this code are derived from classes placed in the
-  public domain by Arbortext on 10 Apr 2000. See:
-  http://www.arbortext.com/customer_support/updates_and_technical_notes/catalogs/docs/README.htm
-
-Apache XML Commons XML APIs (lib/xml-apis.xml-apis-<VERSION>.jar)
-  Apache XML Commons XML APIs
-  Copyright 1999-2009 The Apache Software Foundation.
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
-  Portions of this software were originally based on the following:
-    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-    - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
-
-JDOM2 (lib/org.jdom.jdom2-<VERSION>.jar)
-  Copyright (C) 2000-2012 Jason Hunter & Brett McLaughlin.
-
-  All rights reserved.
-
-  This product includes software developed by the
-  JDOM Project (http://www.jdom.org/).
-
-Jackson JSON processor (lib/com.fasterxml.jackson.core.jackson-core-<VERSION>.jar)
-  Copyright (c) 2007- Tatu Saloranta, tatu.saloranta@iki.fi
-  Copyright (c) 2008-2020 FasterXML. All rights reserved.
-
+- com.fasterxml.jackson.core.jackson-core-<VERSION>.jar
   # Jackson JSON processor
 
   Jackson is a high-performance, Free/Open Source JSON processing library.
@@ -126,23 +33,89 @@ Jackson JSON processor (lib/com.fasterxml.jackson.core.jackson-core-<VERSION>.ja
   in some artifacts (usually source distributions); but is always available
   from the source code management (SCM) system project uses.
 
-Scala (lib/org.scala-lang.scala-library-<VERSION>.jar)
-      (org/apache/daffodil/util/UniquenessCache.class in lib/org.apache.daffodil.daffodil-lib-<VERSION>.jar)
-  Scala
-  Copyright (c) 2002-2020 EPFL
-  Copyright (c) 2011-2020 Lightbend, Inc.
+- commons-io.commons-io-<VERSION>.jar
+  Apache Commons IO
+  Copyright 2002-2021 The Apache Software Foundation
+
+- org.apache.commons.commons-lang3-<VERSION>.jar
+  Apache Commons Lang
+  Copyright 2001-2017 The Apache Software Foundation
+  
+  This product includes software from the Spring Framework,
+  under the Apache License 2.0 (see: StringUtils.containsWhitespace())
+
+- org.apache.daffodil.daffodil-core_<VERSION>.jar
+- org.apache.daffodil.daffodil-io_<VERSION>.jar
+- org.apache.daffodil.daffodil-lib_<VERSION>.jar
+- org.apache.daffodil.daffodil-runtime1-layers_<VERSION>.jar
+- org.apache.daffodil.daffodil-runtime1-unparser_<VERSION>.jar
+- org.apache.daffodil.daffodil-runtime1_<VERSION>.jar
+- org.apache.daffodil.daffodil-sapi_<VERSION>.jar
+- org.apache.daffodil.daffodil-udf_<VERSION>.jar
+  Apache Daffodil
+  Copyright 2022 The Apache Software Foundation
+
+  Based on source code originally developed by
+  - The Univerisity of Illinois National Center for Supercomputing Applications (http://www.ncsa.illinois.edu/)
+  - Tresys Technology (http://www.tresys.com/)
+  - International Business Machines Corporation (http://www.ibm.com)
+
+  The following NOTICE information applies to components distributed with this project:
+
+  This product includes derived works from Scala
+    Scala
+    Copyright (c) 2002-2021 EPFL
+    Copyright (c) 2011-2021 Lightbend, Inc.
+
+    Scala includes software developed at
+    LAMP/EPFL (https://lamp.epfl.ch/) and
+    Lightbend, Inc. (https://www.lightbend.com/).
+
+    The derived work is adapted from scala/src/library/scala/Symbol.scala:
+      https://github.com/scala/scala/blob/904e3a5d2b9616b9c533d77d0c51652b138e8659/src/library/scala/Symbol.scala
+    and can be found in:
+      daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
+
+- org.apache.logging.log4j.log4j-api-<VERSION>.jar
+  Apache Log4j API
+  Copyright 1999-2022 The Apache Software Foundation
+
+- org.apache.logging.log4j.log4j-api-scala_<VERSION>.jar
+  Apache Log4j Scala API
+  Copyright 2016-2022 Apache Software Foundation
+
+  AsciidocPlugin.scala
+  Copyright (c) 2008, 2009, 2010, 2011 Josh Suereth, Steven Blundy, Josh Cough,
+  Mark Harrah, Stuart Roebuck, Tony Sloane, Vesa Vilhonen, Jason Zaugg
+
+- org.jdom.jdom2-<VERSION>.jar
+  Copyright (C) 2000-2012 Jason Hunter & Brett McLaughlin.
+  All rights reserved.
+
+  This product includes software developed by the
+  JDOM Project (http://www.jdom.org/).
+
+- org.scala-lang.modules.scala-parser-combinators_<VERSION>.jar
+  Scala parser combinators
+  Copyright (c) 2002-2022 EPFL
+  Copyright (c) 2011-2022 Lightbend, Inc.
 
   Scala includes software developed at
   LAMP/EPFL (https://lamp.epfl.ch/) and
   Lightbend, Inc. (https://www.lightbend.com/).
 
-  The derived work is adapted from scala/src/library/scala/Symbol.scala:
-    https://github.com/scala/scala/blob/904e3a5d2b9616b9c533d77d0c51652b138e8659/src/library/scala/Symbol.scala
-  and can be found in:
-    daffodil-lib/src/main/scala/org/apache/daffodil/util/UniquenessCache.scala
+- org.scala-lang.modules.scala-xml_<VERSION>.jar
+  scala-xml
+  Copyright (c) 2002-2022 EPFL
+  Copyright (c) 2011-2022 Lightbend, Inc.
 
-Scala Parser Combinators (lib/org.scala-lang.modules.scala-parser-combinators_<VERSION>.jar)
-  Scala parser combinators
+  scala-xml includes software developed at
+  LAMP/EPFL (https://lamp.epfl.ch/) and
+  Lightbend, Inc. (https://www.lightbend.com/).
+
+- org.scala-lang.scala-library-<VERSION>.jar
+- org.scala-lang.scala-reflect-<VERSION>.jar
+  Scala
   Copyright (c) 2002-2021 EPFL
   Copyright (c) 2011-2021 Lightbend, Inc.
 
@@ -150,22 +123,30 @@ Scala Parser Combinators (lib/org.scala-lang.modules.scala-parser-combinators_<V
   LAMP/EPFL (https://lamp.epfl.ch/) and
   Lightbend, Inc. (https://www.lightbend.com/).
 
-Scala XML (lib/org.scala-lang.modules.scala-xml_<VERSION>.jar)
-  scala-xml
-  Copyright (c) 2002-2020 EPFL
-  Copyright (c) 2011-2020 Lightbend, Inc.
+- xerces.xercesImpl-<VERSION>.jar
+  Apache Xerces Java
+  Copyright 1999-2022 The Apache Software Foundation
 
-  scala-xml includes software developed at
-  LAMP/EPFL (https://lamp.epfl.ch/) and
-  Lightbend, Inc. (https://www.lightbend.com/).
+  Portions of this software were originally based on the following:
+    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+    - voluntary contributions made by Paul Eng on behalf of the 
+      Apache Software Foundation that were originally developed at iClick, Inc.,
+      software copyright (c) 1999.
 
-ip4s (lib/com.comcast:ip4s-core.jar-<VERSION>.jar)
-  IP Addresses for Scala and Scala.js
-  Copyright 2018 Comcast Cable Communications Management, LLC
+- xml-apis.xml-apis-<VERSION>.jar
+  Apache XML Commons XML APIs
+  Copyright 1999-2009 The Apache Software Foundation.
 
-Apache Commons Lang (lib/org.apache.commons:commons-lang3-<VERSION>.jar)
-  Apache Commons Lang
-  Copyright 2001-2021 The Apache Software Foundation
-  
-  This product includes software developed at
-  The Apache Software Foundation (https://www.apache.org/).
+  Portions of this software were originally based on the following:
+    - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+    - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+    - software copyright (c) 2000 World Wide Web Consortium, http://www.w3.org
+
+- xml-resolver.xml-resolver-<VERSION>.jar
+  Apache XML Commons Resolver
+  Copyright 2006 The Apache Software Foundation.
+
+  Portions of this code are derived from classes placed in the
+  public domain by Arbortext on 10 Apr 2000. See:
+  http://www.arbortext.com/customer_support/updates_and_technical_notes/catalogs/docs/README.htm

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Apache Daffodil VS Code Extension",
   "description": "VS Code extension for Apache Daffodil DFDL schema debugging",
   "version": "1.0.0",
-  "daffodilVersion": "3.2.1",
+  "daffodilVersion": "3.3.0",
   "publisher": "asf",
   "author": "Apache Daffodil",
   "license": "Apache-2.0",


### PR DESCRIPTION
Multiple updates from rc2 release:

- Update daffodilVersion from 3.2.1 to 3.3.0.
- Add plugins to project/plugins.sbt.
  - These plugins allow for checking dependencies for updates, CVEs and viewing the tree of dependencies.
- Update scalaVersion from 2.12.13 to 2.12.15.
  - Can move to 2.13.8 at some point not sure when we want to do this however.
- Update "logback-classic" version from 1.2.3 to 1.2.11 to fix CVEs.
- Update "com.microsoft.java.debug.core" version from 0.31.1 to 0.35.0.
- Update "fs2-io" version from 3.0.4 to 3.0.6.
  - Updating to 3.2.5 breaks the build.
- Update "decline-effect" from 2.1.0 to 2.2.0.
- Update "log4cats-slf4j" from 2.1.0 to 2.1.1.
  - Updating to 2.2.0 breaks the build.
  - CVEs seem to be false positives here.
- Add dependencyOverrides for commons-lang3 to fix a CVE item.
- Update bin.NOTICE files as some of the incorated projects NOTICE's were updated.

Closes #97 