### PR TITLE
Remove unused stopOnEntry options

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,11 +227,6 @@
                   "path": "${workspaceFolder}/infoset.xml"
                 }
               },
-              "stopOnEntry": {
-                "type": "boolean",
-                "description": "Automatically stop after launch.",
-                "default": true
-              },
               "trace": {
                 "type": "boolean",
                 "description": "Enable logging of the Debug Adapter Protocol.",
@@ -276,7 +271,6 @@
             "request": "launch",
             "name": "Ask for file name",
             "program": "${command:AskForProgramName}",
-            "stopOnEntry": true,
             "data": "${command:AskForDataName}",
             "infosetOutput": {
               "type": "file",
@@ -298,7 +292,6 @@
               "request": "launch",
               "name": "Ask for file name",
               "program": "^\"\\${command:AskForProgramName}\"",
-              "stopOnEntry": true,
               "data": "^\"\\${command:AskForDataName}\"",
               "infosetOutput": {
                 "type": "file",


### PR DESCRIPTION
Closes #59 

I'm not sure if this is how we want to fix this issue due to a rebuild being required to change the behavior. Of the 3 stopOnEntry booleans, this was the only one that changed the behavior of the debugger. I also tried the inverse - removing this option, and setting the remaining options to false, and the debugger still stopped.

Note that a rebuild of the vsix file is required in order to pick the changes up.
From the root directory of the repo:
`yarn build`
`code --install-extension apache-daffodil-vscode-1.0.0.vsix`