### PR TITLE
Admin - Add contributors as github collaborators for wiki and issues 

### DIFF
--- a/.asf.yml
+++ b/.asf.yml
@@ -24,7 +24,11 @@ github:
     squash:   false
     merge:    false
     rebase:   true
+  collaborators:
+    - scholarsmate
+    - michael-hoke
 notifications:
     commits:      commits@daffodil.apache.org
     issues:       commits@daffodil.apache.org
     pullrequests: commits@daffodil.apache.org
+


### PR DESCRIPTION
We made a decision a while back to do the vscode extension work using the github issues and wiki, instead of the ASF JIRA and Confluence. (I believe the notion was to do this as an experiment, because... why straddle two infrastructures if one will do.)

Achieving equivalent permissions for contributors on github wiki/issues to what they have on ASF Confluence/JIRA with role "contributor" requires adding a github userid of a contributor as role "collaborator" on github.

Instead of a admin/settings dialog, this is achieved via the main branch .asf.yml file. 

D Shearer and M Hoke are active contributors who need these permissions. 