### PR TITLE
Update code to use Daffodil 3.4.0

### DIFF
--- a/build/package/NONOTICE
+++ b/build/package/NONOTICE
@@ -51,3 +51,47 @@ The following binary components distributed with this project are licensed under
 	This product bundles '@xtuc/long, long' from the above files.
 	This package is available under the Apache License v2 without a NOTICE:
         Repository at: https://github.com/dcodeIO/long.js
+
+- com.fasterxml.woodstox.woodstox-core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'woodstox-core' from the above files.
+  This packages is available under the Apache License v2 without a NOTICE:
+	  	Repository at: https://github.com/FasterXML/woodstox
+
+- com.google.code.gson.gson-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'gso' from the above files.
+  This packages is available under the Apache License v2 without a NOTICE:
+	  	Repository at: https://github.com/google/gson
+
+- com.monovore.decline-effect_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+- com.monovore.decline_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'decline' from the above files.
+  This packages is available under the Apache License v2 without a NOTICE:
+	  	Repository at: https://github.com/bkirwi/decline
+
+- com.typesafe.config-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'config' from the above files.
+  This packages is available under the Apache License v2 without a NOTICE:
+	  	Repository at: https://github.com/lightbend/config
+
+- io.reactivex.rxjava2.rxjava-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'rxjava' from the above files.
+  This packages is available under the Apache License v2 without a NOTICE:
+	  	Repository at: https://github.com/ReactiveX/RxJava
+
+- org.typelevel.cats-effect-kernel_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+- org.typelevel.cats-effect-std_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+- org.typelevel.cats-effect_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'cats-effect' from the above files.
+  This packages is available under the Apache License v2 without a NOTICE:
+	  	Repository at: https://github.com/typelevel/cats-effect
+
+- org.typelevel.literally_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'literally' from the above files.
+  This packages is available under the Apache License v2 without a NOTICE:
+	  	Repository at: https://github.com/typelevel/literally
+
+- org.typelevel.log4cats-core_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+- org.typelevel.log4cats-slf4j_<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'log4cats' from the above files.
+  This packages is available under the Apache License v2 without a NOTICE:
+	  	Repository at: https://github.com/typelevel/log4cats

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Apache Daffodil VS Code Extension",
 	"description": "VS Code extension for Apache Daffodil DFDL schema debugging",
 	"version": "1.1.0-SNAPSHOT",
-	"daffodilVersion": "3.3.0",
+	"daffodilVersion": "3.4.0",
 	"omegaEditServerHash": "1c11c5711b6cd477023be71d04b070e1289312aaaef5f81fb9ded4e3884b7135ca13e2b2cf7b547e374142167c19789555eeb5d83dbed38ff6dde71c25db5fb7",
 	"publisher": "asf",
 	"author": "Apache Daffodil",


### PR DESCRIPTION
Update code to use Daffodil 3.4.0:

- daffodil-debugger now uses Daffodil version 3.4.0.
- Update NOTICE and NONOTICE files with missing Scala dependencies.

Closes #336 