### PR TITLE
Add support for JSON formatting of infoset

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "apache-daffodil-vscode",
 	"displayName": "Apache Daffodil VS Code Extension",
 	"description": "VS Code extension for Apache Daffodil DFDL schema debugging",
-	"version": "1.2.0",
+	"version": "1.2.0-SNAPSHOT",
 	"daffodilVersion": "3.4.0",
 	"omegaEditServerHash": "1c11c5711b6cd477023be71d04b070e1289312aaaef5f81fb9ded4e3884b7135ca13e2b2cf7b547e374142167c19789555eeb5d83dbed38ff6dde71c25db5fb7",
 	"publisher": "asf",
@@ -25,11 +25,12 @@
 	},
 	"scripts": {
 		"omega-edit-download": "node -e \"require('./build/scripts/omega_edit_download.ts').downloadServer()\"",
-		"precompile": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
+		"gen-version-ts": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
+		"precompile": "yarn run gen-version-ts",
 		"compile": "tsc -p ./ && yarn omega-edit-download",
 		"lint": "yarn run prettier src -c",
-		"watch": "yarn omega-edit-download && webpack --watch --devtool nosources-source-map --config ./build/extension.webpack.config.js",
-		"watch2": "tsc -watch -p ./",
+		"prewatch": "yarn omega-edit-download && yarn run gen-version-ts",
+		"watch": "webpack --watch --devtool nosources-source-map --config ./build/extension.webpack.config.js",
 		"webpack": "webpack --mode production --config ./build/extension.webpack.config.js",
 		"prepackage": "yarn sbt && yarn install && yarn compile && yarn webpack",
 		"package": "yarn package-setup && yarn package-create",
@@ -302,6 +303,11 @@
 								"description": "Absolute path to the input data file.",
 								"default": "${command:AskForDataName}"
 							},
+							"infosetFormat": {
+								"type": "string",
+								"description": "Infoset format type (xml/json)",
+								"default": "xml"
+							},
 							"infosetOutput": {
 								"type": "object",
 								"description": "Destination for final Infoset (file-path | 'console' | 'none')",
@@ -361,6 +367,7 @@
 						"program": "${command:AskForProgramName}",
 						"stopOnEntry": true,
 						"data": "${command:AskForDataName}",
+						"infosetFormat": "xml",
 						"infosetOutput": {
 							"type": "file",
 							"path": "${workspaceFolder}/infoset.xml"
@@ -383,6 +390,7 @@
 							"program": "^\"\\${command:AskForProgramName}\"",
 							"stopOnEntry": true,
 							"data": "^\"\\${command:AskForDataName}\"",
+							"infosetFormat": "xml",
 							"infosetOutput": {
 								"type": "file",
 								"path": "${workspaceFolder}/infoset.xml"

--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
@@ -41,6 +41,7 @@ import org.apache.daffodil.processors.dfa.DFADelimiter
 import org.apache.daffodil.processors.parsers._
 import org.apache.daffodil.processors._
 import org.apache.daffodil.sapi.infoset.XMLTextInfosetOutputter
+import org.apache.daffodil.sapi.infoset.JsonInfosetOutputter
 import org.apache.daffodil.sapi.io.InputSourceDataInputStream
 import org.apache.daffodil.util.Misc
 import org.typelevel.log4cats.Logger
@@ -63,7 +64,8 @@ object Parse {
   def apply(
       schema: Path,
       data: InputStream,
-      debugger: Debugger
+      debugger: Debugger,
+      infosetFormat: String
   ): IO[Parse] =
     for {
       dp <- Compiler().compile(schema).map(p => p.withDebugger(debugger).withDebugging(true))
@@ -76,11 +78,16 @@ object Parse {
             val stopper =
               pleaseStop.get *> IO.canceled // will cancel the concurrent parse effect
 
+            val infosetOutputter = infosetFormat match {
+              case "xml"  => new XMLTextInfosetOutputter(os, true)
+              case "json" => new JsonInfosetOutputter(os, true)
+            }
+
             val parse =
               IO.interruptibleMany {
                 dp.parse(
                   new InputSourceDataInputStream(data),
-                  new XMLTextInfosetOutputter(os, true)
+                  infosetOutputter
                 ) // WARNING: parse doesn't close the OutputStream, so closed below
               }.guaranteeCase(outcome => Logger[IO].debug(s"parse finished: $outcome"))
                 .void
@@ -160,6 +167,7 @@ object Parse {
         schemaPath: Path,
         dataPath: Path,
         stopOnEntry: Boolean,
+        infosetFormat: String,
         infosetOutput: LaunchArgs.InfosetOutput
     ) extends Arguments {
       def data: IO[InputStream] =
@@ -199,6 +207,11 @@ object Parse {
           Option(arguments.getAsJsonPrimitive("stopOnEntry"))
             .map(_.getAsBoolean())
             .getOrElse(true)
+            .asRight[String]
+            .toEitherNel,
+          Option(arguments.getAsJsonPrimitive("infosetFormat"))
+            .map(_.getAsString())
+            .getOrElse("xml")
             .asRight[String]
             .toEitherNel,
           Option(arguments.getAsJsonObject("infosetOutput")) match {
@@ -257,13 +270,25 @@ object Parse {
       infosetChanges = Stream
         .fromQueueNoneTerminated(infoset)
         .evalTap(latestInfoset.set)
-        .evalTap(content => dapEvents.offer(Some(InfosetEvent(content, "text/xml"))))
+        .evalTap(content =>
+          dapEvents.offer(
+            Some(
+              InfosetEvent(
+                content,
+                args.infosetFormat match {
+                  case "xml"  => "text/xml"
+                  case "json" => "application/json"
+                }
+              )
+            )
+          )
+        )
         .onFinalizeCase(ec => Logger[IO].debug(s"infosetChanges (orig): $ec"))
 
       events <- Resource.eval(Queue.bounded[IO, Option[Event]](10))
       debugger <- DaffodilDebugger
-        .resource(state, events, breakpoints, control, infoset)
-      parse <- Resource.eval(args.data.flatMap(in => Parse(args.schemaPath, in, debugger)))
+        .resource(state, events, breakpoints, control, infoset, args.infosetFormat)
+      parse <- Resource.eval(args.data.flatMap(in => Parse(args.schemaPath, in, debugger, args.infosetFormat)))
 
       parsing = args.infosetOutput match {
         case Debugee.LaunchArgs.InfosetOutput.None =>
@@ -594,7 +619,13 @@ object Parse {
   case class ConfigEvent(launchArgs: ConfigEvent.LaunchArgs, buildInfo: ConfigEvent.BuildInfo)
       extends Events.DebugEvent("daffodil.config")
   object ConfigEvent {
-    case class LaunchArgs(schemaPath: String, dataPath: String, stopOnEntry: Boolean, infosetOutput: InfosetOutput)
+    case class LaunchArgs(
+        schemaPath: String,
+        dataPath: String,
+        stopOnEntry: Boolean,
+        infosetFormat: String,
+        infosetOutput: InfosetOutput
+    )
 
     sealed trait InfosetOutput {
       val `type`: String =
@@ -625,6 +656,7 @@ object Parse {
           launchArgs.schemaPath.toString,
           launchArgs.dataPath.toString(),
           launchArgs.stopOnEntry,
+          launchArgs.infosetFormat,
           InfosetOutput(launchArgs.infosetOutput)
         ),
         BuildInfo(
@@ -731,7 +763,8 @@ object Parse {
       breakpoints: Breakpoints,
       control: Control,
       events: QueueSink[IO, Option[Event]],
-      infoset: QueueSink[IO, Option[String]]
+      infoset: QueueSink[IO, Option[String]],
+      infosetFormat: String
   ) extends Debugger {
     implicit val logger: Logger[IO] = Slf4jLogger.getLogger
 
@@ -776,10 +809,14 @@ object Parse {
 
     def infosetToString(ie: InfosetElement): String = {
       val bos = new java.io.ByteArrayOutputStream()
-      val xml = new XMLTextInfosetOutputter(bos, true)
+      val infosetOutputter = infosetFormat match {
+        case "xml"  => new XMLTextInfosetOutputter(bos, true)
+        case "json" => new JsonInfosetOutputter(bos, true)
+      }
+
       val iw = InfosetWalker(
         ie.asInstanceOf[DIElement],
-        xml,
+        infosetOutputter,
         walkHidden = false,
         ignoreBlocks = true,
         releaseUnneededInfoset = false
@@ -818,7 +855,8 @@ object Parse {
         events: QueueSink[IO, Option[Event]],
         breakpoints: Breakpoints,
         control: Control,
-        infoset: QueueSink[IO, Option[String]]
+        infoset: QueueSink[IO, Option[String]],
+        infosetFormat: String
     ): Resource[IO, DaffodilDebugger] =
       for {
         dispatcher <- Dispatcher[IO]
@@ -828,7 +866,8 @@ object Parse {
         breakpoints,
         control,
         events,
-        infoset
+        infoset,
+        infosetFormat
       )
   }
 }

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -95,6 +95,7 @@ function createDebugRunFileConfigs(
           targetResource.fsPath,
           false,
           false,
+          'xml',
           { type: 'file', path: '${workspaceFolder}/' + infosetFile }
         ),
         { noDebug: noDebug }
@@ -215,6 +216,7 @@ export function activateDaffodilDebug(
                 '${file}',
                 false,
                 false,
+                'xml',
                 { type: 'file', path: '${file}-infoset.xml' }
               ),
             ]
@@ -235,6 +237,7 @@ export function activateDaffodilDebug(
               '${file}',
               false,
               false,
+              'xml',
               { type: 'file', path: '${workspaceFolder}/' + infosetFile }
             ),
           ]

--- a/src/daffodil.ts
+++ b/src/daffodil.ts
@@ -40,6 +40,7 @@ export interface LaunchArgs {
   schemaPath: string
   dataPath: string
   stopOnEntry: boolean
+  infosetFormat: string
   infosetOutput: InfosetOutput
 }
 

--- a/src/infoset.ts
+++ b/src/infoset.ts
@@ -46,8 +46,8 @@ async function openInfosetFilePrompt() {
 
     switch (action) {
       case 'Open':
-        let xml = await vscode.workspace.openTextDocument(uri)
-        await vscode.window.showTextDocument(xml, {
+        let infoset = await vscode.workspace.openTextDocument(uri)
+        await vscode.window.showTextDocument(infoset, {
           preview: false,
           viewColumn: vscode.ViewColumn.One,
         })
@@ -173,7 +173,7 @@ const fileInfosetProvider = new (class
 })()
 
 function tmp(sid: string): string {
-  return `${tmpdir()}/infoset-${sid}.xml`
+  return `${tmpdir()}/infoset-${sid}.${getCurrentConfig().infosetFormat}`
 }
 
 function ensure(path: string): string {

--- a/src/launchWizard/launchWizard.js
+++ b/src/launchWizard/launchWizard.js
@@ -97,6 +97,7 @@ function save() {
       : configSelectedValue
   const data = document.getElementById('data').value
   const debugServer = parseInt(document.getElementById('debugServer').value)
+  const infosetFormat = document.getElementById('infosetFormat').value
   const infosetOutputFilePath = document.getElementById(
     'infosetOutputFilePath'
   ).value
@@ -121,6 +122,7 @@ function save() {
         program: program,
         data: data,
         debugServer: debugServer,
+        infosetFormat: infosetFormat,
         infosetOutput: {
           type: infosetOutputType,
           path: infosetOutputFilePath,
@@ -147,6 +149,9 @@ function updateConfigValues(config) {
   document.getElementById('name').value = config.name
   document.getElementById('data').value = config.data
   document.getElementById('debugServer').value = parseInt(config.debugServer)
+  document.getElementById('infosetFormat').value = config.infosetFormat
+    ? config.infosetFormat
+    : 'xml'
   document.getElementById('infosetOutputFilePath').value = config.infosetOutput[
     'path'
   ]

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -334,6 +334,18 @@ class LaunchWizard {
       daffodilDebugClasspathAction !== 'append' ? 'checked' : ''
     let appendCheck = daffodilDebugClasspathAction === 'append' ? 'checked' : ''
 
+    let infosetFormatSelect = ''
+    let infosetFormatTypes = ['xml', 'json']
+    let infosetFormat = defaultValues.infosetFormat
+
+    infosetFormatTypes.forEach((type) => {
+      if (type === infosetFormat) {
+        infosetFormatSelect += `<option selected value="${type}">${type}</option>`
+      } else {
+        infosetFormatSelect += `<option value="${type}">${type}</option>`
+      }
+    })
+
     let infosetOutputTypeSelect = ''
     let infosetOutputTypes = ['none', 'console', 'file']
     let infosetOutputType = defaultValues.infosetOutput['type']
@@ -428,6 +440,14 @@ class LaunchWizard {
         <p>Debug Server:</p>
         <p class="setting-description">Port debug server running on.</p>
         <input class="file-input" value="${defaultValues.debugServer}" id="debugServer"/>
+      </div>
+
+      <div id="infosetFormatDiv" class="setting-div">
+        <p>Infoset Format:</p>
+        <p class="setting-description">Desired format of infoset ('xml' | 'json')</p>
+        <select class="file-input" style="width: 200px;" id="infosetFormat">
+          ${infosetFormatSelect}
+        </select>
       </div>
 
       <div id="infosetOutputTypeDiv" class="setting-div">

--- a/src/tests/suite/daffodil.test.ts
+++ b/src/tests/suite/daffodil.test.ts
@@ -53,14 +53,24 @@ suite('Daffodfil', () => {
       assert.strictEqual(100, daffodilData.bytePos1b)
     })
 
-    test('InfosetEvent functions properly', () => {
+    test('InfosetEvent functions properly (xml)', () => {
       let infosetEvent: daffodil.InfosetEvent = {
-        content: 'This is content',
+        content: 'This is xml content',
         mimeType: 'xml',
       }
 
-      assert.strictEqual('This is content', infosetEvent.content)
+      assert.strictEqual('This is xml content', infosetEvent.content)
       assert.strictEqual('xml', infosetEvent.mimeType)
+    })
+
+    test('InfosetEvent functions properly (json)', () => {
+      let infosetEvent: daffodil.InfosetEvent = {
+        content: 'This is json content',
+        mimeType: 'json',
+      }
+
+      assert.strictEqual('This is json content', infosetEvent.content)
+      assert.strictEqual('json', infosetEvent.mimeType)
     })
 
     test('InfosetOutput functions properly', () => {
@@ -93,12 +103,14 @@ suite('Daffodfil', () => {
         schemaPath: '/path/to/schema.xsd.xml',
         dataPath: '/path/to/data.jpg',
         stopOnEntry: true,
+        infosetFormat: 'json',
         infosetOutput: infosetOutput,
       }
 
       assert.strictEqual('/path/to/schema.xsd.xml', launchArgs.schemaPath)
       assert.strictEqual('/path/to/data.jpg', launchArgs.dataPath)
       assert.strictEqual(true, launchArgs.stopOnEntry)
+      assert.strictEqual('json', launchArgs.infosetFormat)
       assert.strictEqual(infosetOutput, launchArgs.infosetOutput)
     })
 
@@ -116,6 +128,7 @@ suite('Daffodfil', () => {
         schemaPath: '/path/to/schema.xsd.xml',
         dataPath: '/path/to/data.jpg',
         stopOnEntry: true,
+        infosetFormat: 'xml',
         infosetOutput: infosetOutput,
       }
 

--- a/src/tests/suite/utils.test.ts
+++ b/src/tests/suite/utils.test.ts
@@ -30,6 +30,7 @@ suite('Utils Test Suite', () => {
     program: '${command:AskForProgramName}',
     data: '${command:AskForDataName}',
     debugServer: 4711,
+    infosetFormat: 'xml',
     infosetOutput: {
       type: 'none',
       path: '${workspaceFolder}/infoset.xml',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,6 +86,7 @@ export function getConfig(
   program: string = '',
   data: string | boolean = false,
   debugServer: number | boolean = false,
+  infosetFormat: string | null = null,
   infosetOutput: object | null = null,
   stopOnEntry = false,
   useExistingServer = false,
@@ -106,6 +107,7 @@ export function getConfig(
     debugServer: debugServer
       ? debugServer
       : defaultConf.get('debugServer', 4711),
+    infosetFormat: infosetFormat ? infosetFormat : 'xml',
     infosetOutput: infosetOutput
       ? infosetOutput
       : {


### PR DESCRIPTION
Add support for JSON formatting of infoset

- Create new argument infosetFormat
- Update scala code to support infosetFormat:
  - Parse in value from extension.
  - Based on parse value decide what InfosetFormatter to use.
- Update extension code to support infosetFormat:
  - Add it is a launch arg inside of the launch.json.
  - Set default value as "xml".
  - Add selection box for infosetFormat on the Launch Wizard.
  - Send value over the debugger on launch
  - Update infoset view to select file type based on infosetFormat so they look correct.
  - Update LaunchArgs interface to include infosetFormat.
  - Update unit tests to use value and check that it is set properly
- Update yarn watch to generate src/version.ts before running actual watch command.

Closes #343

NOTE: 1.2.0 was released but holding off on merging this until the update for the daffodil website is merged and I send the release announcement out.