### PR TITLE
Fix intellisense extra '<' issue. Replace deprecated 'substr' with 'substring'

### DIFF
--- a/src/hexView.ts
+++ b/src/hexView.ts
@@ -250,9 +250,9 @@ export class DebuggerHexView {
         for (var i = 1; i < dataLocations.length - 2; i++) {
           let middle = Math.floor(dataLocations[i].length / 2)
           this.hexString +=
-            dataLocations[i].substr(0, middle).toUpperCase() +
+            dataLocations[i].substring(0, middle).toUpperCase() +
             ' ' +
-            dataLocations[i].substr(middle).toUpperCase() +
+            dataLocations[i].substring(middle).toUpperCase() +
             ' '
         }
         this.hexString += '\t' + dataLocations[dataLocations.length - 1] + '\n'

--- a/src/language/providers/attributeCompletion.ts
+++ b/src/language/providers/attributeCompletion.ts
@@ -65,7 +65,7 @@ export function getAttributeCompletionProvider() {
       ) {
         const wholeLine = document
           .lineAt(position)
-          .text.substr(0, position.character)
+          .text.substring(0, position.character)
         var nearestOpenItem = nearestOpen(document, position)
         const nsPrefix = getXsdNsPrefix(document, position)
 

--- a/src/language/providers/closeElement.ts
+++ b/src/language/providers/closeElement.ts
@@ -31,7 +31,7 @@ export function getCloseElementProvider() {
         const nearestOpenItem = nearestOpen(document, position)
         const wholeLine = document
           .lineAt(position)
-          .text.substr(0, position.character)
+          .text.substring(0, position.character)
 
         if (
           !wholeLine.includes('</') &&

--- a/src/language/providers/closeElementSlash.ts
+++ b/src/language/providers/closeElementSlash.ts
@@ -35,7 +35,7 @@ export function getCloseElementSlashProvider() {
         const nsPrefix = getXsdNsPrefix(document, position)
         const wholeLine = document
           .lineAt(position)
-          .text.substr(0, position.character)
+          .text.substring(0, position.character)
         const nearestOpenItem = nearestOpen(document, position)
         if (checkBraceOpen(document, position)) {
           return undefined

--- a/src/language/providers/elementCompletion.ts
+++ b/src/language/providers/elementCompletion.ts
@@ -45,8 +45,15 @@ export function getElementCompletionProvider(dfdlFormatString: string) {
         dfdlFormatString,
         nsPrefix
       ).items.forEach((e) => {
-        const completionItem = createCompletionItem(e, '', nsPrefix)
-        compItems.push(completionItem)
+        const line = document
+          .lineAt(position)
+          .text.substring(0, position.character)
+
+        if (line.includes('<') && e.snippetString.startsWith('<')) {
+          e.snippetString = e.snippetString.substring(1, e.snippetString.length)
+        }
+
+        compItems.push(createCompletionItem(e, '', nsPrefix))
       })
 
       return compItems

--- a/src/language/providers/endSingleBrace.ts
+++ b/src/language/providers/endSingleBrace.ts
@@ -28,7 +28,7 @@ export function getEndSingleBraceProvider() {
       ) {
         const wholeLine = document
           .lineAt(position)
-          .text.substr(0, position.character)
+          .text.substring(0, position.character)
         if (
           wholeLine.includes('dfdl:length="{') ||
           wholeLine.includes('dfdl:choiceDispatchKey="{')

--- a/src/omega_edit/utils.ts
+++ b/src/omega_edit/utils.ts
@@ -89,9 +89,9 @@ export async function setViewportDataForPanel(
                 for (var i = 1; i < 9; i++) {
                   let middle = Math.floor(dataLocations[i].length / 2)
                   encodedData +=
-                    dataLocations[i].substr(0, middle).toUpperCase() +
+                    dataLocations[i].substring(0, middle).toUpperCase() +
                     '' +
-                    dataLocations[i].substr(middle).toUpperCase() +
+                    dataLocations[i].substring(middle).toUpperCase() +
                     ' '
                 }
               }


### PR DESCRIPTION
Fix intellisense extra '<' issue. Replace deprecated 'substr' with 'substring'.

This is an issue found in 1.2.0-rc1.

Closes #350
Closes #353