### PR TITLE
Fix typo, daffodilDebugClassPath -> daffodilDebugClasspath

### DIFF
--- a/src/daffodilDebugger.ts
+++ b/src/daffodilDebugger.ts
@@ -167,7 +167,7 @@ export async function getDebugger(
       // Get daffodilDebugger class paths to be added to the debugger
       let daffodilDebugClasspath = ''
 
-      if (config.daffodilDebugClassPath) {
+      if (config.daffodilDebugClasspath) {
         daffodilDebugClasspath = config.daffodilDebugClasspath.includes(
           '${workspaceFolder}'
         )


### PR DESCRIPTION
This should fix the issue @mbeckerle was seeing in the 1.2.0-rc2 release of the extension

Closes #357