### PR TITLE
Launch Wizard - Daffodil Debugger Classpath manipulation

### DIFF
--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -152,38 +152,7 @@ async function openFilePicker(description) {
       title: description,
     })
     .then(async (fileUri) => {
-      if (fileUri && fileUri[0]) {
-        let stats = fs.statSync(fileUri[0].fsPath)
-
-        if (stats.isDirectory()) {
-          let basePath = fileUri[0].fsPath
-          let fileString = ''
-
-          fs.readdirSync(basePath).forEach((file) => {
-            if (file.includes('.jar')) {
-              fileString += `${basePath}/${file},`
-            }
-          })
-
-          return fileString.substring(0, fileString.length - 1) // make sure to remove comma at the end of the string
-        }
-
-        if (fileUri.length === 1) {
-          return fileUri[0].fsPath
-        } else {
-          let files = ''
-
-          fileUri.forEach((file) => {
-            if (file.fsPath.includes('.jar')) {
-              files += `${file.fsPath},`
-            }
-          })
-
-          return files.substring(0, files.length - 1) // make sure to remove comma at the end of the string
-        }
-      }
-
-      return ''
+      return fileUri && fileUri[0] ? fileUri[0].fsPath : ''
     })
 
   if (chosenFile.includes(rootPath)) {
@@ -325,13 +294,22 @@ class LaunchWizard {
     let stopOnEntry = defaultValues.stopOnEntry ? 'checked' : ''
     let trace = defaultValues.trace ? 'checked' : ''
     let useExistingServer = defaultValues.useExistingServer ? 'checked' : ''
-    let daffodilDebugClasspathAction =
-      defaultValues.daffodilDebugClasspathAction === 'append'
-        ? defaultConf.daffodilDebugClasspath
-        : 'replace'
-    let replaceCheck =
-      daffodilDebugClasspathAction !== 'append' ? 'checked' : ''
-    let appendCheck = daffodilDebugClasspathAction === 'append' ? 'checked' : ''
+
+    let daffodilDebugClasspathList =
+      '<ul id="daffodilDebugClasspathTable" style="list-style: none; padding-left: 20px;">'
+    if (defaultValues.daffodilDebugClasspath) {
+      let itemArray = defaultValues.daffodilDebugClasspath.split(':')
+      for (var i = 0; i < itemArray.length; i++) {
+        daffodilDebugClasspathList += `
+          <li style="margin-left: -5px;" onclick="removeDebugClasspathItem(this)">
+            <p id="debug-classpath-li-${itemArray[i]}" class="debug-classpath-item">
+              <button id="remove-debug-classpath-li-${itemArray[i]}" class="minus-button" type="button">-</button>
+              ${itemArray[i]}
+            </p>
+          </li>`
+      }
+    }
+    daffodilDebugClasspathList += '</ul>'
 
     let infosetFormatSelect = ''
     let infosetFormatTypes = ['xml', 'json']
@@ -412,20 +390,13 @@ class LaunchWizard {
 
       <div id="daffodilDebugClasspathDiv" class="setting-div">
         <p>Daffodil Debugger Classpath:</p>
-        <p class="setting-description">Additional classpaths to be added to the debugger.</p>
+        <p class="setting-description">Additional classpaths to be added to the debugger:</p>
 
-        <label class="container" style="margin-top: 10px; margin-bottom: 0px;">Replace value in input box with selected files.
-          <input type="checkbox" id="daffodilDebugClasspathReplace" ${replaceCheck} onclick="daffodilDebugClassAction('replace')">
-          <span class="checkmark"></span>
-        </label>
+        ${daffodilDebugClasspathList}
 
-        <label class="container" style="margin-top: 10px; margin-bottom: 10px;">Append selected files to value in input box.
-          <input type="checkbox" id="daffodilDebugClasspathAppend" ${appendCheck} onclick="daffodilDebugClassAction('append')">
-          <span class="checkmark"></span>
-        </label>
-
-        <input class="file-input" value="${defaultValues.daffodilDebugClasspath}" id="daffodilDebugClasspath"/>
-        <button id="daffodilDebugClasspathBrowse" class="browse-button" type="button" onclick="filePicker('daffodilDebugClasspath', 'Select jar files/folder with desired jars')">Browse</button>
+        <p style="margin-left: 5px">
+          <button id="daffodilDebugClasspathBrowse" class="browse-button" type="button" onclick="filePicker('daffodilDebugClasspath', 'Select jar files/folder with desired jars')">Browse</button>
+        </p>
       </div>
 
       <div id="dataDiv" class="setting-div">

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -30,6 +30,20 @@
   margin-left: 10px;
 }
 
+.debug-classpath-item {
+  color: white;
+  cursor: pointer;
+  background-color: rgb(80, 78, 78);
+  width: 375px;
+  height: 25px;
+  font-size: 12px;
+  border: none;
+  border-radius: 12px;
+  padding-left: 7px;
+  margin: 0px;
+  margin-top: 5px;
+}
+
 /* Hide the browser's default checkbox */
 .container input {
   position: absolute;
@@ -117,6 +131,20 @@
   cursor: pointer;
   width: 75px;
   height: 25px;
+}
+
+.minus-button {
+  background-color: lightgray;
+  border: none;
+  border-radius: 12px;
+  color: black;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 12px;
+  cursor: pointer;
+  width: 25px;
+  margin-top: 4px;
 }
 
 .setting-description {


### PR DESCRIPTION
Update the launch config wizard manipulation of Daffodil Debugger Classpath:

- Remove replace and append check boxes.
- Replace single box that listed the classpath items with a UI list.
  - Browse will work the same but when you select a folder or file it will be added to the list.
  - List items will have a minus button beside the text. Both button and text are clickable and when clicked it will remove that specific item from the list.
- Save now will now write the daffodil debugger classpath to the launch.json.
- Update UI list to auto-populate the classpath items if set in the configuration.

Closes #268