### PR TITLE
Depend on another extension to load schema files from jars.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
 		"webpack-cli": "4.10.0"
 	},
 	"extensionDependencies": [
-		"vincaslt.highlight-matching-tag"
+		"vincaslt.highlight-matching-tag",
+		"wmanth.jar-viewer"
 	],
 	"main": "./dist/ext/extension.js",
 	"activationEvents": [

--- a/src/tests/runTest.ts
+++ b/src/tests/runTest.ts
@@ -69,7 +69,13 @@ async function main() {
     // Install required extensions
     cp.spawnSync(
       cli,
-      [...args, '--install-extension', 'vincaslt.highlight-matching-tag'],
+      [
+        ...args,
+        '--install-extension',
+        'vincaslt.highlight-matching-tag',
+        '--install-extension',
+        'wmanth.jar-viewer',
+      ],
       {
         encoding: 'utf-8',
         stdio: 'inherit',


### PR DESCRIPTION
It registers a content handler which provides virtual document support for jar URIs. Requires the Metals extension >=1.13.0, but the latest version is 1.21.0 anyway.

Fixes #265.