### PR TITLE
	Modifications to try to ensure intellisense offers relevant

### DIFF
--- a/src/language/providers/closeElement.ts
+++ b/src/language/providers/closeElement.ts
@@ -16,7 +16,12 @@
  */
 
 import * as vscode from 'vscode'
-import { getXsdNsPrefix, insertSnippet, nearestOpen } from './utils'
+import {
+  getXsdNsPrefix,
+  insertSnippet,
+  nearestOpen,
+  getItemsOnLineCount,
+} from './utils'
 
 export function getCloseElementProvider() {
   return vscode.languages.registerCompletionItemProvider(
@@ -27,98 +32,207 @@ export function getCloseElementProvider() {
         position: vscode.Position
       ) {
         var backpos = position.with(position.line, position.character - 1)
+        var backpos3 = position.with(position.line, position.character - 3)
         const nsPrefix = getXsdNsPrefix(document, position)
         const nearestOpenItem = nearestOpen(document, position)
         const triggerText = document
           .lineAt(position)
           .text.substring(0, position.character)
+        var itemsOnLine = getItemsOnLineCount(triggerText)
 
         if (
-          !triggerText.includes('</') &&
           triggerText.endsWith('>') &&
-          (triggerText.includes('<' + nsPrefix + 'element') ||
-            nearestOpenItem.includes('element') ||
-            triggerText.includes('<' + nsPrefix + 'group') ||
-            nearestOpenItem.includes('group') ||
-            triggerText.includes('<' + nsPrefix + 'sequence') ||
-            nearestOpenItem.includes('sequence') ||
-            triggerText.includes('<' + nsPrefix + 'simpleType') ||
-            nearestOpenItem.includes('simpleType') ||
-            triggerText.includes('<' + nsPrefix + 'choice') ||
-            nearestOpenItem.includes('choice') ||
-            triggerText.includes('dfdl:defineVariable') ||
-            nearestOpenItem.includes('Variable'))
+          ((triggerText.includes('<' + nsPrefix + 'element') &&
+            nearestOpenItem.includes('element')) ||
+            (triggerText.includes('<' + nsPrefix + 'group') &&
+              nearestOpenItem.includes('group')) ||
+            (triggerText.includes('<' + nsPrefix + 'sequence') &&
+              nearestOpenItem.includes('sequence')) ||
+            (triggerText.includes('<' + nsPrefix + 'simpleType') &&
+              nearestOpenItem.includes('simpleType')) ||
+            (triggerText.includes('<' + nsPrefix + 'choice') &&
+              nearestOpenItem.includes('choice')) ||
+            (triggerText.includes('dfdl:defineVariable') &&
+              nearestOpenItem.includes('Variable')) ||
+            itemsOnLine == 0)
         ) {
           var range = new vscode.Range(backpos, position)
           vscode.window.activeTextEditor?.edit((editBuilder) => {
             editBuilder.replace(range, '')
           })
-          if (
-            triggerText.endsWith('>') &&
-            (triggerText.includes('<' + nsPrefix + 'element ref') ||
-              triggerText.includes('<' + nsPrefix + 'group ref'))
-          ) {
-            insertSnippet(' />\n$0', backpos)
-          } else if (
-            triggerText.endsWith('>') &&
-            (triggerText.includes('<' + nsPrefix + 'element') ||
-              nearestOpenItem.includes('element'))
-          ) {
-            insertSnippet('>\n\t$0\n</' + nsPrefix + 'element>', backpos)
-          } else if (
-            triggerText.endsWith('>') &&
-            (triggerText.includes('<' + nsPrefix + 'group') ||
-              nearestOpenItem.includes('group'))
-          ) {
-            insertSnippet('>\n\t$0\n</' + nsPrefix + 'group>', backpos)
-          } else if (
-            (triggerText.endsWith('>') &&
-              triggerText.includes('<' + nsPrefix + 'sequence')) ||
-            nearestOpenItem.includes('sequence')
-          ) {
-            insertSnippet('>\n\t$0\n</' + nsPrefix + 'sequence>', backpos)
-          } else if (
-            (triggerText.endsWith('>') &&
-              triggerText.includes('<' + nsPrefix + 'choice')) ||
-            nearestOpenItem.includes('choice')
-          ) {
-            insertSnippet('>\n\t$0\n</' + nsPrefix + 'choice>', backpos)
-          } else if (
-            (triggerText.endsWith('>') &&
-              triggerText.includes('<' + nsPrefix + 'simpleType')) ||
-            nearestOpenItem.includes('simpleType')
-          ) {
-            insertSnippet('>\n\t$0\n</' + nsPrefix + 'simpleType>', backpos)
-          } else if (
-            (triggerText.endsWith('>') &&
-              triggerText.includes('dfdl:defineVariable')) ||
-            nearestOpenItem.includes('defineVariable')
-          ) {
-            var startPos = document.lineAt(position).text.indexOf('<', 0)
-            var range = new vscode.Range(backpos, position)
-            vscode.window.activeTextEditor?.edit((editBuilder) => {
-              editBuilder.replace(range, '')
-            })
-            insertSnippet('>\n</dfdl:defineVariable>\n', backpos)
-            var backpos2 = position.with(position.line + 2, startPos - 2)
-            insertSnippet('</<' + nsPrefix + 'appinfo>\n', backpos2)
-            var backpos3 = position.with(position.line + 3, startPos - 4)
-            insertSnippet('</<' + nsPrefix + 'annotation>$0', backpos3)
-          } else if (
-            (triggerText.endsWith('>') &&
-              triggerText.includes('dfdl:setVariable')) ||
-            nearestOpenItem.includes('setVariable')
-          ) {
-            var startPos = document.lineAt(position).text.indexOf('<', 0)
-            var range = new vscode.Range(backpos, position)
-            vscode.window.activeTextEditor?.edit((editBuilder) => {
-              editBuilder.replace(range, '')
-            })
-            insertSnippet('>\n</dfdl:setVariable>\n', backpos)
-            var backpos2 = position.with(position.line + 2, startPos - 2)
-            insertSnippet('</' + nsPrefix + 'appinfo>\n', backpos2)
-            var backpos3 = position.with(position.line + 3, startPos - 4)
-            insertSnippet('</' + nsPrefix + 'annotation>$0', backpos3)
+          if (itemsOnLine == 1 || itemsOnLine == 0) {
+            if (!triggerText.includes('</')) {
+              if (itemsOnLine == 0) {
+                insertSnippet(
+                  '</' + nsPrefix + nearestOpenItem + '>$0',
+                  backpos3
+                )
+              } else {
+                if (
+                  triggerText.endsWith('>') &&
+                  (triggerText.includes('<' + nsPrefix + 'element ref') ||
+                    triggerText.includes('<' + nsPrefix + 'group ref'))
+                ) {
+                  insertSnippet(' />\n$0', backpos)
+                } else if (
+                  triggerText.endsWith('>') &&
+                  triggerText.includes('<' + nsPrefix + 'element') &&
+                  nearestOpenItem.includes('element')
+                ) {
+                  insertSnippet('>\n\t$0\n</' + nsPrefix + 'element>', backpos)
+                } else if (
+                  triggerText.endsWith('>') &&
+                  triggerText.includes('<' + nsPrefix + 'group') &&
+                  nearestOpenItem.includes('group')
+                ) {
+                  insertSnippet('>\n\t$0\n</' + nsPrefix + 'group>', backpos)
+                } else if (
+                  triggerText.endsWith('>') &&
+                  triggerText.includes('<' + nsPrefix + 'sequence') &&
+                  nearestOpenItem.includes('sequence')
+                ) {
+                  insertSnippet('>\n\t$0\n</' + nsPrefix + 'sequence>', backpos)
+                } else if (
+                  triggerText.endsWith('>') &&
+                  triggerText.includes('<' + nsPrefix + 'choice') &&
+                  nearestOpenItem.includes('choice')
+                ) {
+                  insertSnippet('>\n\t$0\n</' + nsPrefix + 'choice>', backpos)
+                } else if (
+                  triggerText.endsWith('>') &&
+                  triggerText.includes('<' + nsPrefix + 'simpleType') &&
+                  nearestOpenItem.includes('simpleType')
+                ) {
+                  insertSnippet(
+                    '>\n\t$0\n</' + nsPrefix + 'simpleType>',
+                    backpos
+                  )
+                } else if (
+                  triggerText.endsWith('>') &&
+                  triggerText.includes('dfdl:defineVariable') &&
+                  nearestOpenItem.includes('defineVariable')
+                ) {
+                  var startPos = document.lineAt(position).text.indexOf('<', 0)
+                  var range = new vscode.Range(backpos, position)
+                  vscode.window.activeTextEditor?.edit((editBuilder) => {
+                    editBuilder.replace(range, '')
+                  })
+                  insertSnippet('>\n</dfdl:defineVariable>\n', backpos)
+                  var backpos2 = position.with(position.line + 2, startPos - 2)
+                  insertSnippet('</<' + nsPrefix + 'appinfo>\n', backpos2)
+                  var backpos3 = position.with(position.line + 3, startPos - 4)
+                  insertSnippet('</<' + nsPrefix + 'annotation>$0', backpos3)
+                } else if (
+                  (triggerText.endsWith('>') &&
+                    triggerText.includes('dfdl:setVariable')) ||
+                  nearestOpenItem.includes('setVariable')
+                ) {
+                  var startPos = document.lineAt(position).text.indexOf('<', 0)
+                  var range = new vscode.Range(backpos, position)
+                  vscode.window.activeTextEditor?.edit((editBuilder) => {
+                    editBuilder.replace(range, '')
+                  })
+                  insertSnippet('>\n</dfdl:setVariable>\n', backpos)
+                  var backpos2 = position.with(position.line + 2, startPos - 2)
+                  insertSnippet('</' + nsPrefix + 'appinfo>\n', backpos2)
+                  var backpos3 = position.with(position.line + 3, startPos - 4)
+                  insertSnippet('</' + nsPrefix + 'annotation>$0', backpos3)
+                }
+              }
+            }
+          }
+          if (itemsOnLine > 1) {
+            if (
+              triggerText.endsWith('>') &&
+              (triggerText.includes('<' + nsPrefix + 'element ref') ||
+                triggerText.includes('<' + nsPrefix + 'group ref'))
+            ) {
+              insertSnippet(' />\n$0', backpos)
+            } else if (
+              triggerText.endsWith('>') &&
+              triggerText.includes('<' + nsPrefix + 'element') &&
+              nearestOpenItem.includes('element')
+            ) {
+              var tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'element')
+              var tagEndPos = triggerText.indexOf('>', tagPos)
+              if (tagPos != -1) {
+                if (
+                  !triggerText.substr(tagEndPos - 1, 2).includes('/>') &&
+                  !triggerText.includes('</' + nsPrefix + 'element')
+                ) {
+                  if (
+                    triggerText.substr(backpos.character - 1, 1).includes('>')
+                  ) {
+                    insertSnippet('</' + nsPrefix + 'element>$0', backpos)
+                  } else {
+                    insertSnippet('></' + nsPrefix + 'element>$0', backpos)
+                  }
+                }
+              }
+            } else if (
+              triggerText.endsWith('>') &&
+              triggerText.includes('<' + nsPrefix + 'sequence') &&
+              nearestOpenItem.includes('sequence')
+            ) {
+              var tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'sequence')
+              var tagEndPos = triggerText.indexOf('>', tagPos)
+              if (tagPos != -1) {
+                if (
+                  !triggerText.substr(tagEndPos - 1, 2).includes('/>') &&
+                  !triggerText.includes('</' + nsPrefix + 'sequence')
+                ) {
+                  if (
+                    triggerText.substr(backpos.character - 1, 1).includes('>')
+                  ) {
+                    insertSnippet('</' + nsPrefix + 'sequence>$0', backpos)
+                  } else {
+                    insertSnippet('></' + nsPrefix + 'sequence>$0', backpos)
+                  }
+                }
+              }
+            } else if (
+              triggerText.endsWith('>') &&
+              triggerText.includes('<' + nsPrefix + 'group') &&
+              nearestOpenItem.includes('group')
+            ) {
+              var tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'group')
+              var tagEndPos = triggerText.indexOf('>', tagPos)
+              if (tagPos != -1) {
+                if (
+                  !triggerText.substr(tagEndPos - 1, 2).includes('/>') &&
+                  !triggerText.includes('</' + nsPrefix + 'group')
+                ) {
+                  if (
+                    triggerText.substr(backpos.character - 1, 1).includes('>')
+                  ) {
+                    insertSnippet('</' + nsPrefix + 'group>$0', backpos)
+                  } else {
+                    insertSnippet('></' + nsPrefix + 'group>$0', backpos)
+                  }
+                }
+              }
+            } else if (
+              triggerText.endsWith('>') &&
+              triggerText.includes('<' + nsPrefix + 'choice') &&
+              nearestOpenItem.includes('choice')
+            ) {
+              var tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'choice')
+              var tagEndPos = triggerText.indexOf('>', tagPos)
+              if (tagPos != -1) {
+                if (
+                  !triggerText.substr(tagEndPos - 1, 2).includes('/>') &&
+                  !triggerText.includes('</' + nsPrefix + 'choice')
+                ) {
+                  if (
+                    triggerText.substr(backpos.character - 1, 1).includes('>')
+                  ) {
+                    insertSnippet('</' + nsPrefix + 'choice>$0', backpos)
+                  } else {
+                    insertSnippet('></' + nsPrefix + 'choice>$0', backpos)
+                  }
+                }
+              }
+            }
           }
         }
         return undefined

--- a/src/language/providers/closeElementSlash.ts
+++ b/src/language/providers/closeElementSlash.ts
@@ -21,6 +21,7 @@ import {
   nearestOpen,
   checkBraceOpen,
   getXsdNsPrefix,
+  getItemsOnLineCount,
 } from './utils'
 
 export function getCloseElementSlashProvider() {
@@ -36,42 +37,95 @@ export function getCloseElementSlashProvider() {
         const triggerText = document
           .lineAt(position)
           .text.substring(0, position.character)
-        const nearestOpenItem = nearestOpen(document, position)
+        var nearestOpenItem = nearestOpen(document, position)
+        const itemsOnLine = getItemsOnLineCount(triggerText)
         if (checkBraceOpen(document, position)) {
           return undefined
         }
-        if (
-          triggerText.endsWith('/') &&
-          (triggerText.includes('<' + nsPrefix + 'element') ||
-            nearestOpenItem.includes('element') ||
-            triggerText.includes('<' + nsPrefix + 'group') ||
-            nearestOpenItem.includes('group') ||
-            triggerText.includes('<' + nsPrefix + 'sequence') ||
-            nearestOpenItem.includes('sequence'))
-        ) {
+        if (triggerText.endsWith('/')) {
           var range = new vscode.Range(backpos, position)
           vscode.window.activeTextEditor?.edit((editBuilder) => {
             editBuilder.replace(range, '')
           })
-          insertSnippet(' />$0', backpos)
-        }
-        if (
-          triggerText.endsWith('/') &&
-          (triggerText.includes('dfdl:defineVariable') ||
-            triggerText.includes('dfdl:setVariable') ||
-            nearestOpenItem.includes('defineVariable') ||
-            nearestOpenItem.includes('setVariable'))
-        ) {
-          var startPos = document.lineAt(position).text.indexOf('<', 0)
-          var range = new vscode.Range(backpos, position)
-          vscode.window.activeTextEditor?.edit((editBuilder) => {
-            editBuilder.replace(range, '')
-          })
-          insertSnippet('/>\n', backpos)
-          var backpos2 = position.with(position.line + 1, startPos - 2)
-          insertSnippet('</<' + nsPrefix + 'appinfo>\n', backpos2)
-          var backpos3 = position.with(position.line + 2, startPos - 4)
-          insertSnippet('</<' + nsPrefix + 'annotation>$0', backpos3)
+          if (itemsOnLine == 1 || itemsOnLine == 0) {
+            if (
+              nearestOpenItem.includes('element') ||
+              nearestOpenItem.includes('group') ||
+              nearestOpenItem.includes('sequence')
+            ) {
+              if (itemsOnLine == 1) {
+                insertSnippet(' />$0', backpos)
+              }
+              if (itemsOnLine == 0) {
+                const backpos3 = position.with(
+                  position.line,
+                  position.character - 3
+                )
+                insertSnippet(
+                  '</' + nsPrefix + nearestOpenItem + '>$0',
+                  backpos3
+                )
+              }
+            }
+            if (
+              nearestOpenItem.includes('defineVariable') ||
+              nearestOpenItem.includes('setVariable')
+            ) {
+              var startPos = document.lineAt(position).text.indexOf('<', 0)
+              var range = new vscode.Range(backpos, position)
+              vscode.window.activeTextEditor?.edit((editBuilder) => {
+                editBuilder.replace(range, '')
+              })
+              insertSnippet('/>\n', backpos)
+              var backpos2 = position.with(position.line + 1, startPos - 2)
+              insertSnippet('</' + nsPrefix + 'appinfo>\n', backpos2)
+              var backpos3 = position.with(position.line + 2, startPos - 4)
+              insertSnippet('</' + nsPrefix + 'annotation>$0', backpos3)
+            }
+          }
+          if (itemsOnLine > 1) {
+            if (nearestOpenItem.includes('element')) {
+              //check that tag is not self closing
+              if (
+                triggerText
+                  .substring(
+                    triggerText.lastIndexOf('<' + nsPrefix + 'element')
+                  )
+                  .includes('>')
+              ) {
+                insertSnippet('</' + nsPrefix + 'element>$0', backpos)
+              } else {
+                insertSnippet(' />$0', backpos)
+              }
+            } else if (nearestOpenItem.includes('sequence')) {
+              //check that tag is not self closing
+              if (
+                triggerText
+                  .substring(
+                    triggerText.lastIndexOf('<' + nsPrefix + 'sequence')
+                  )
+                  .includes('sequence>')
+              ) {
+                insertSnippet('</' + nsPrefix + 'sequence>$0', backpos)
+              } else {
+                insertSnippet(' />$0', backpos)
+              }
+            } else if (
+              triggerText.includes('<' + nsPrefix + 'group') &&
+              nearestOpenItem.includes('group')
+            ) {
+              const tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'group')
+              const nextTagPos = triggerText.indexOf('<', tagPos + 1)
+              if (
+                triggerText.substr(tagPos, nextTagPos).includes('>') ||
+                triggerText.includes('</' + nsPrefix + 'group')
+              ) {
+                insertSnippet('</' + nsPrefix + 'group>$0', backpos)
+              } else {
+                insertSnippet(' />$0', backpos)
+              }
+            }
+          }
         }
         return undefined
       },

--- a/src/language/providers/elementCompletion.ts
+++ b/src/language/providers/elementCompletion.ts
@@ -18,7 +18,6 @@
 import * as vscode from 'vscode'
 import { checkBraceOpen, getXsdNsPrefix } from './utils'
 import { elementCompletion } from './intellisense/elementItems'
-import { createCompletionItem } from './utils'
 
 export function getElementCompletionProvider(dfdlFormatString: string) {
   return vscode.languages.registerCompletionItemProvider('dfdl', {
@@ -45,17 +44,16 @@ export function getElementCompletionProvider(dfdlFormatString: string) {
         dfdlFormatString,
         nsPrefix
       ).items.forEach((e) => {
-        const line = document
-          .lineAt(position)
-          .text.substring(0, position.character)
+        const completionItem = new vscode.CompletionItem(e.item)
+        completionItem.insertText = new vscode.SnippetString(e.snippetString)
 
-        if (line.includes('<') && e.snippetString.startsWith('<')) {
-          e.snippetString = e.snippetString.substring(1, e.snippetString.length)
+        if (e.markdownString) {
+          completionItem.documentation = new vscode.MarkdownString(
+            e.markdownString
+          )
         }
-
-        compItems.push(createCompletionItem(e, '', nsPrefix))
+        compItems.push(completionItem)
       })
-
       return compItems
     },
   })

--- a/src/language/providers/utils.ts
+++ b/src/language/providers/utils.ts
@@ -37,21 +37,51 @@ export function checkLastItemOpen(
   position: vscode.Position
 ) {
   var lineNum = position.line
-  const triggerText = document.lineAt(lineNum).text
+  const nsPrefix = getXsdNsPrefix(document, position)
+  const triggerText = document.lineAt(lineNum).text.trim()
   while (triggerText.length === 0) {
     --lineNum
   }
-  const previousLine = document.lineAt(lineNum).text
-  return !(
-    previousLine.includes('</') ||
-    previousLine.includes('/>') ||
-    ((triggerText.includes('element') ||
-      triggerText.includes('sequence') ||
-      triggerText.includes('choice') ||
-      triggerText.includes('group') ||
-      triggerText.includes('Variable')) &&
-      (triggerText.includes('</') || triggerText.includes('/>')))
-  )
+  if (lineNum > 0 && triggerText.lastIndexOf('<') == 0) {
+    const previousLine = document
+      .lineAt(lineNum)
+      .text.substr(0, document.lineAt(lineNum - 1).range.end.character)
+    if (
+      (previousLine.includes('</') ||
+        previousLine.includes('/>') ||
+        triggerText.includes('element') ||
+        triggerText.includes('sequence') ||
+        triggerText.includes('choice') ||
+        triggerText.includes('group') ||
+        triggerText.includes('Variable')) &&
+      (triggerText.includes('</') || triggerText.includes('/>'))
+    ) {
+      return false
+    }
+  }
+  if (
+    triggerText.lastIndexOf('<') > 0 &&
+    triggerText.lastIndexOf('>') < triggerText.lastIndexOf('<')
+  ) {
+    const lastOpenItem = triggerText.substring(
+      triggerText.indexOf('<'),
+      triggerText.length - triggerText.lastIndexOf('<')
+    )
+    if (
+      (lastOpenItem.includes('<' + nsPrefix + 'group') &&
+        !triggerText.includes('</' + nsPrefix + 'group')) ||
+      (lastOpenItem.includes('<' + nsPrefix + 'sequence') &&
+        !triggerText.includes('</' + nsPrefix + 'sequence')) ||
+      (lastOpenItem.includes('<' + nsPrefix + 'choice') &&
+        !triggerText.includes('</' + nsPrefix + 'choice')) ||
+      (lastOpenItem.includes('<' + nsPrefix + 'element') &&
+        !triggerText.includes('</' + nsPrefix + 'element')) ||
+      lastOpenItem.includes('Variable')
+    ) {
+      return true
+    }
+  }
+  return true
 }
 
 export function lineCount(
@@ -81,21 +111,82 @@ export function nearestOpen(
   position: vscode.Position
 ) {
   var lineNum = position.line
+  const itemsOnLine = getItemsOnLineCount(document.lineAt(lineNum).text)
   const nsPrefix = getXsdNsPrefix(document, position)
-  while (lineNum !== -1) {
+  if (itemsOnLine > 1) {
     const triggerText = document.lineAt(lineNum).text
-    if (triggerText.includes('element') && !triggerText.includes('/>')) {
+    if (triggerText.includes('<' + nsPrefix + 'element')) {
+      const tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'element')
+      const tagEndPos = triggerText.indexOf('>', tagPos)
+      if (tagPos != -1) {
+        if (
+          !triggerText.substr(tagEndPos - 1, 2).includes('/>') &&
+          !triggerText.includes('</' + nsPrefix + 'element')
+        ) {
+          return 'element'
+        }
+      }
+    }
+    if (triggerText.includes('<' + nsPrefix + 'sequence')) {
+      const tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'sequence')
+      const tagEndPos = triggerText.indexOf('>', tagPos)
+      if (tagPos != -1) {
+        if (
+          !triggerText.substr(tagEndPos - 1, 2).includes('/>') &&
+          !triggerText.includes('</' + nsPrefix + 'sequence')
+        ) {
+          return 'sequence'
+        }
+      }
+    }
+    if (triggerText.includes('<' + nsPrefix + 'choice')) {
+      const tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'choice')
+      const tagEndPos = triggerText.indexOf('>', tagPos)
+      if (tagPos != -1) {
+        if (
+          !triggerText.substr(tagEndPos - 1, 2).includes('/>') &&
+          !triggerText.includes('</' + nsPrefix + 'choice')
+        ) {
+          return 'choice'
+        }
+      }
+    }
+    if (triggerText.includes('<' + nsPrefix + 'group')) {
+      const tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'group')
+      const tagEndPos = triggerText.indexOf('>', tagPos)
+      if (tagPos != -1) {
+        if (
+          !triggerText.substr(tagEndPos - 1, 2).includes('/>') &&
+          !triggerText.includes('</' + nsPrefix + 'group')
+        ) {
+          return 'group'
+        }
+      }
+    }
+    if (triggerText.includes('<' + nsPrefix + 'simpleType')) {
+      const tagPos = triggerText.lastIndexOf('<' + nsPrefix + 'simpleType')
+      const tagEndPos = triggerText.indexOf('>', tagPos)
+      if (tagPos != -1) {
+        if (
+          !triggerText.substr(tagEndPos - 1, 2).includes('/>') &&
+          !triggerText.includes('</' + nsPrefix + 'simpleType')
+        ) {
+          return 'simpleType'
+        }
+      }
+    }
+  }
+  while (lineNum !== -1) {
+    var triggerText = document.lineAt(lineNum).text
+    if (triggerText.includes('element')) {
       if (checkElementOpen(document, position)) {
         return 'element'
       }
-    } else if (
-      triggerText.includes('sequence') &&
-      !triggerText.includes('/>')
-    ) {
+    } else if (triggerText.includes('sequence')) {
       if (checkSequenceOpen(document, position)) {
         return 'sequence'
       }
-    } else if (triggerText.includes('choice') && !triggerText.includes('/>')) {
+    } else if (triggerText.includes('choice')) {
       if (checkChoiceOpen(document, position)) {
         return 'choice'
       }
@@ -108,10 +199,7 @@ export function nearestOpen(
       ) {
         return 'group'
       }
-    } else if (
-      triggerText.includes('simpleType') &&
-      !triggerText.includes('/>')
-    ) {
+    } else if (triggerText.includes('simpleType')) {
       if (checkSimpleTypeOpen(document, position)) {
         return 'simpleType'
       }
@@ -122,15 +210,10 @@ export function nearestOpen(
       if (checkDefineVariableOpen(document, position)) {
         return 'defineVariable'
       }
-    } else if (
-      triggerText.includes('setVariable') &&
-      !triggerText.includes('/>')
-    ) {
+    } else if (triggerText.includes('setVariable')) {
       if (checkSetVariableOpen(document, position)) {
         return 'setVariable'
       }
-    } else if (triggerText.includes('/>')) {
-      return 'none'
     }
     --lineNum
   }
@@ -143,8 +226,39 @@ export function checkElementOpen(
 ) {
   const nsPrefix = getXsdNsPrefix(document, position)
   var lineNum = position.line
-  while (lineNum !== -1) {
+  const itemsOnLine = getItemsOnLineCount(document.lineAt(lineNum).text)
+
+  if (itemsOnLine > 1) {
     const triggerText = document.lineAt(lineNum).text
+    if (triggerText.includes('<' + nsPrefix + 'element')) {
+      const tagPos = triggerText.indexOf('<' + nsPrefix + 'element')
+      const tagEndPos = triggerText.indexOf('>', tagPos)
+      if (tagPos != -1) {
+        if (
+          triggerText.substring(tagEndPos - 1, 2).includes('/>') ||
+          triggerText
+            .substring(tagEndPos + 1, triggerText.length - (tagEndPos + 1))
+            .includes('<' + nsPrefix + 'element') ||
+          triggerText.includes('</' + nsPrefix + 'element>')
+        ) {
+          return false
+        } else {
+          return true
+        }
+      }
+    }
+  }
+
+  while (lineNum !== -1) {
+    var triggerText = document.lineAt(lineNum).text
+    if (
+      triggerText.includes('<' + nsPrefix + 'element') &&
+      triggerText.indexOf('<' + nsPrefix + 'element') ==
+        triggerText.lastIndexOf('<') &&
+      triggerText.lastIndexOf('>') > triggerText.lastIndexOf('<')
+    ) {
+      return true
+    }
     if (
       triggerText.includes('<' + nsPrefix + 'element') &&
       (triggerText.includes('>') ||
@@ -160,7 +274,7 @@ export function checkElementOpen(
       triggerText.includes('<' + nsPrefix + 'element') &&
       !triggerText.includes('</' + nsPrefix + 'element') &&
       !triggerText.includes('/>') &&
-      !triggerText.includes('>')
+      !triggerText.includes('/element>')
     ) {
       return true
     }
@@ -175,8 +289,38 @@ export function checkSequenceOpen(
 ) {
   const nsPrefix = getXsdNsPrefix(document, position)
   var lineNum = position.line
-  while (lineNum !== 0) {
+  const itemsOnLine = getItemsOnLineCount(document.lineAt(lineNum).text)
+
+  if (itemsOnLine > 1) {
     const triggerText = document.lineAt(lineNum).text
+    if (triggerText.includes('<' + nsPrefix + 'sequence')) {
+      const tagPos = triggerText.indexOf('<' + nsPrefix + 'sequence')
+      const tagEndPos = triggerText.indexOf('>', tagPos)
+      if (tagPos != -1) {
+        if (
+          triggerText.substring(tagEndPos - 1, 2).includes('/>') ||
+          triggerText
+            .substring(tagEndPos + 1, triggerText.length - (tagEndPos + 1))
+            .includes('<' + nsPrefix + 'sequence') ||
+          triggerText.includes('</' + nsPrefix + 'sequence>')
+        ) {
+          return false
+        } else {
+          return true
+        }
+      }
+    }
+  }
+  while (lineNum !== -1) {
+    const triggerText = document.lineAt(lineNum).text
+    if (
+      triggerText.includes('<' + nsPrefix + 'sequence') &&
+      triggerText.indexOf('<' + nsPrefix + 'sequence') ==
+        triggerText.lastIndexOf('<') &&
+      triggerText.lastIndexOf('>') < triggerText.lastIndexOf('<')
+    ) {
+      return true
+    }
     if (
       (triggerText.includes('<' + nsPrefix + 'sequence') &&
         (triggerText.includes('</' + nsPrefix + 'sequence') ||
@@ -203,8 +347,37 @@ export function checkChoiceOpen(
 ) {
   const nsPrefix = getXsdNsPrefix(document, position)
   var lineNum = position.line
-  while (lineNum !== 0) {
+  const itemsOnLine = getItemsOnLineCount(document.lineAt(lineNum).text)
+
+  if (itemsOnLine > 1) {
     const triggerText = document.lineAt(lineNum).text
+    if (triggerText.includes('<' + nsPrefix + 'choice')) {
+      const tagPos = triggerText.indexOf('<' + nsPrefix + 'choice')
+      const tagEndPos = triggerText.indexOf('>', tagPos)
+      if (tagPos != -1) {
+        if (
+          triggerText.substring(tagEndPos - 1, 2).includes('/>') ||
+          triggerText
+            .substring(tagEndPos + 1, triggerText.length - (tagEndPos + 1))
+            .includes('<' + nsPrefix + 'choice')
+        ) {
+          return false
+        } else {
+          return true
+        }
+      }
+    }
+  }
+  while (lineNum !== -1) {
+    const triggerText = document.lineAt(lineNum).text
+    if (
+      triggerText.includes('<' + nsPrefix + 'choice') &&
+      triggerText.indexOf('<' + nsPrefix + 'choice') ==
+        triggerText.lastIndexOf('<') &&
+      triggerText.lastIndexOf('>') < triggerText.lastIndexOf('<')
+    ) {
+      return true
+    }
     if (
       (triggerText.includes('<' + nsPrefix + 'choice') &&
         (triggerText.includes('</' + nsPrefix + 'choice') ||
@@ -230,8 +403,37 @@ export function checkSimpleTypeOpen(
 ) {
   const nsPrefix = getXsdNsPrefix(document, position)
   var lineNum = position.line
-  while (lineNum !== 0) {
+  const itemsOnLine = getItemsOnLineCount(document.lineAt(lineNum).text)
+
+  if (itemsOnLine > 1) {
     const triggerText = document.lineAt(lineNum).text
+    if (triggerText.includes('<' + nsPrefix + 'simpleType')) {
+      const tagPos = triggerText.indexOf('<' + nsPrefix + 'simpleType')
+      const tagEndPos = triggerText.indexOf('>', tagPos)
+      if (tagPos != -1) {
+        if (
+          triggerText.substring(tagEndPos - 1, 2).includes('/>') ||
+          triggerText
+            .substring(tagEndPos + 1, triggerText.length - (tagEndPos + 1))
+            .includes('<' + nsPrefix + 'simpleType')
+        ) {
+          return false
+        } else {
+          return true
+        }
+      }
+    }
+  }
+  while (lineNum !== -1) {
+    const triggerText = document.lineAt(lineNum).text
+    if (
+      triggerText.includes('<' + nsPrefix + 'simpletype') &&
+      triggerText.indexOf('<' + nsPrefix + 'simpleType') ==
+        triggerText.lastIndexOf('<') &&
+      triggerText.lastIndexOf('>') < triggerText.lastIndexOf('<')
+    ) {
+      return true
+    }
     if (
       triggerText.includes('<' + nsPrefix + 'simpleType') &&
       !triggerText.includes('</' + nsPrefix + 'simpleType') &&
@@ -302,6 +504,20 @@ export function getXsdNsPrefix(
   return defaultXsdNsPrefix + ':'
 }
 
+export function getItemsOnLineCount(triggerText: String) {
+  var itemsOnLine = 0
+  var nextPos = 0
+  var result = 0
+  while (result != -1) {
+    result = triggerText.indexOf('<', nextPos)
+    nextPos = result + 1
+    if (result != -1) {
+      ++itemsOnLine
+    }
+  }
+  return itemsOnLine
+}
+
 export function checkBraceOpen(
   document: vscode.TextDocument,
   position: vscode.Position
@@ -312,10 +528,13 @@ export function checkBraceOpen(
     const triggerText = document.lineAt(lineNum).text
     //.text.substring(0, document.lineAt(lineNum).range.end.character)
 
+    if (!triggerText.includes('{')) {
+      return false
+    }
     if (
       triggerText.includes('"{') &&
       triggerText.includes('}"') &&
-      triggerText.includes('..') &&
+      (triggerText.includes('..') || triggerText.includes('.')) &&
       !triggerText.includes('}"/') &&
       !triggerText.includes('>')
     ) {
@@ -333,6 +552,16 @@ export function checkBraceOpen(
       triggerText.includes('}"') &&
       !triggerText.includes('}"/') &&
       !triggerText.includes('>')
+    ) {
+      return true
+    }
+    if (
+      triggerText
+        .substr(
+          triggerText.lastIndexOf('{'),
+          triggerText.indexOf('}', triggerText.lastIndexOf('{'))
+        )
+        .includes('/')
     ) {
       return true
     }


### PR DESCRIPTION
	suggestions when there are multiple tags on a single line and
	when one or more end tags have been removed

	-Logic was introduced to determine if multiple tags are on a
	single line
	-The nearestOpen funtion was modified to take in to account
	multiple tags on a single line
	-The logic for closeElement and cloesElementSlash was modified to
	supply the end tag for previous items whether on a single line
	or multiple lines where the end tag is missing or has been
	deleted. The triggers '/' or '>' should now provide end tags if
	they are missing

	Closes #309