### PR TITLE
  Significant modifications made to intellisense results

### DIFF
--- a/src/language/providers/attributeCompletion.ts
+++ b/src/language/providers/attributeCompletion.ts
@@ -21,13 +21,10 @@ import {
   nearestOpen,
   checkBraceOpen,
   lineCount,
-  checkLastItemOpen,
-  checkSequenceOpen,
-  checkElementOpen,
-  checkSimpleTypeOpen,
   createCompletionItem,
   getCommonItems,
   getXsdNsPrefix,
+  getItemsOnLineCount,
 } from './utils'
 
 import { attributeCompletion } from './intellisense/attributeItems'
@@ -66,192 +63,31 @@ export function getAttributeCompletionProvider() {
         const triggerText = document
           .lineAt(position)
           .text.substring(0, position.character)
-        var nearestOpenItem = nearestOpen(document, position)
+        let nearestOpenItem = nearestOpen(document, position)
+        let itemsOnLine = getItemsOnLineCount(triggerText)
         const nsPrefix = getXsdNsPrefix(document, position)
+        let additionalItems = getDefinedTypes(document, nsPrefix)
 
         if (
           !checkBraceOpen(document, position) &&
           !triggerText.includes('assert') &&
           !nearestOpenItem.includes('none')
         ) {
-          if (nearestOpenItem.includes('element')) {
-            var preVal = ''
-            if (!triggerText.includes(nsPrefix + 'element')) {
-              if (lineCount(document, position) === 1) {
-                preVal = '\t'
-              } else {
-                preVal = ''
-              }
-            }
-            var additionalItems = getDefinedTypes(document, nsPrefix)
+          let preVal =
+            !triggerText.includes('<' + nsPrefix + nearestOpenItem) &&
+            lineCount(document, position, nearestOpenItem) === 1 &&
+            itemsOnLine < 2
+              ? '\t'
+              : ''
 
-            if (
-              checkLastItemOpen(document, position) &&
-              (triggerText.includes('<' + nsPrefix + 'element name="') ||
-                triggerText.includes('<' + nsPrefix + 'element ref="') ||
-                checkElementOpen(document, position))
-            ) {
-              return getCompletionItems(
-                [
-                  'dfdl:defineFormat',
-                  'dfdl:defineEscapeScheme',
-                  'type=',
-                  'minOccurs=',
-                  'maxOccurs=',
-                  'dfdl:occursCount=',
-                  'dfdl:byteOrder=',
-                  'dfdl:occursCountKind=',
-                  'dfdl:length=',
-                  'dfdl:lengthKind=',
-                  'dfdl:encoding=',
-                  'dfdl:alignment=',
-                  'dfdl:lengthUnits=',
-                  'dfdl:lengthPattern=',
-                  'dfdl:inputValueCalc=',
-                  'dfdl:outputValueCalc=',
-                  'dfdl:alignmentUnits=',
-                  'dfdl:terminator=',
-                  'dfdl:outputNewLine=',
-                  'dfdl:choiceBranchKey=',
-                  'dfdl:representation',
-                ],
-                preVal,
-                additionalItems,
-                nsPrefix
-              )
-            }
-          }
-
-          if (nearestOpenItem.includes('sequence')) {
-            var preVal = ''
-            if (!triggerText.includes(nsPrefix + 'sequence')) {
-              if (lineCount(document, position) === 1) {
-                preVal = '\t'
-              } else {
-                preVal = ''
-              }
-            }
-
-            if (
-              checkLastItemOpen(document, position) &&
-              (triggerText.includes('<' + nsPrefix + 'sequence') ||
-                checkSequenceOpen(document, position))
-            ) {
-              return getCompletionItems(
-                [
-                  'dfdl:hiddenGroupRef=',
-                  'dfdl:sequenceKind=',
-                  'dfdl:separator=',
-                  'dfdl:separatorPosition=',
-                  'dfdl:separatorSuppressionPolicy',
-                ],
-                preVal,
-                undefined,
-                nsPrefix
-              )
-            }
-          }
-
-          if (triggerText.includes('choice')) {
-            if (!triggerText.includes('>')) {
-              return getCompletionItems(
-                [
-                  'dfdl:choiceLengthKind=',
-                  'dfdl:choiceLength=',
-                  'dfdl:initiatedContent=',
-                  'dfdl:choiceDispatchKey=',
-                  'dfdl:choiceBranchKey=',
-                ],
-                undefined,
-                undefined,
-                nsPrefix
-              )
-            }
-          }
-
-          if (
-            triggerText.includes('simpleType') ||
-            checkSimpleTypeOpen(document, position)
-          ) {
-            if (!triggerText.includes('>')) {
-              return getCompletionItems(
-                [
-                  'dfdl:length=',
-                  'dfdl:lengthKind=',
-                  'dfdl:simpleType',
-                  'dfdl:simpleType',
-                  nsPrefix + 'restriction',
-                ],
-                undefined,
-                undefined,
-                nsPrefix
-              )
-            }
-          }
-
-          if (triggerText.includes('defineVariable')) {
-            var preVal = ''
-            if (!triggerText.includes('dfdl:defineVariable')) {
-              if (lineCount(document, position) === 1) {
-                preVal = '\t'
-              } else {
-                preVal = ''
-              }
-            }
-            var additionalItems = getDefinedTypes(document, nsPrefix)
-
-            var xmlItems = [
-              {
-                item: 'external=',
-                snippetString: preVal + 'external="${1|true,false|}"$0',
-              },
-              {
-                item: 'defaultValue=',
-                snippetString: preVal + 'defaultValue="0$1"$0',
-              },
-            ]
-
-            if (!triggerText.includes('>')) {
-              let compItems: vscode.CompletionItem[] = []
-              xmlItems.forEach((e) => {
-                const completionItem = new vscode.CompletionItem(e.item)
-                completionItem.insertText = new vscode.SnippetString(
-                  e.snippetString
-                )
-
-                compItems.push(completionItem)
-              })
-
-              getCommonItems(['type='], '', additionalItems, nsPrefix).forEach(
-                (ci) => {
-                  compItems.push(ci)
-                }
-              )
-
-              return compItems
-            }
-          }
-
-          if (nearestOpenItem.includes('setVariable')) {
-            var preVal = ''
-            if (!triggerText.includes('dfdl:setVariable')) {
-              if (lineCount(document, position) === 1) {
-                preVal = '\t'
-              } else {
-                preVal = ''
-              }
-            }
-
-            const xmlValue = new vscode.CompletionItem('value=')
-            xmlValue.insertText = new vscode.SnippetString('value="$1"$0')
-            xmlValue.documentation = new vscode.MarkdownString('')
-
-            if (!triggerText.includes('>')) {
-              return [xmlValue]
-            }
-          }
+          return checkNearestOpenItem(
+            nearestOpenItem,
+            triggerText,
+            nsPrefix,
+            preVal,
+            additionalItems
+          )
         }
-        return undefined
       },
     },
     ' ',
@@ -260,24 +96,174 @@ export function getAttributeCompletionProvider() {
 }
 
 function getDefinedTypes(document: vscode.TextDocument, nsPrefix: string) {
-  var additionalTypes = ''
-  var lineNum = 0
+  let additionalTypes = ''
+  let lineNum = 0
   const lineCount = document.lineCount
 
   while (lineNum !== lineCount) {
     const triggerText = document
       .lineAt(lineNum)
       .text.substring(0, document.lineAt(lineNum).range.end.character)
+
     if (
       triggerText.includes(nsPrefix + 'simpleType Name=') ||
       triggerText.includes(nsPrefix + 'complexType Name=')
     ) {
-      var startPos = triggerText.indexOf('"', 0)
-      var endPos = triggerText.indexOf('"', startPos + 1)
-      var newType = triggerText.substring(startPos + 1, endPos)
+      let startPos = triggerText.indexOf('"', 0)
+      let endPos = triggerText.indexOf('"', startPos + 1)
+      let newType = triggerText.substring(startPos + 1, endPos)
+
       additionalTypes = String(additionalTypes + ',' + newType)
     }
+
     ++lineNum
   }
+
   return additionalTypes
+}
+
+function checkNearestOpenItem(
+  nearestOpenItem: string,
+  triggerText: string,
+  nsPrefix: string,
+  preVal: string,
+  additionalItems: string
+): vscode.CompletionItem[] | undefined {
+  switch (nearestOpenItem) {
+    case 'element':
+      return getCompletionItems(
+        [
+          'name=',
+          'ref=',
+          'dfdl:defineFormat',
+          'dfdl:defineEscapeScheme',
+          'type=',
+          'minOccurs=',
+          'maxOccurs=',
+          'dfdl:occursCount=',
+          'dfdl:byteOrder=',
+          'dfdl:occursCountKind=',
+          'dfdl:length=',
+          'dfdl:lengthKind=',
+          'dfdl:encoding=',
+          'dfdl:alignment=',
+          'dfdl:lengthUnits=',
+          'dfdl:lengthPattern=',
+          'dfdl:inputValueCalc=',
+          'dfdl:outputValueCalc=',
+          'dfdl:alignmentUnits=',
+          'dfdl:terminator=',
+          'dfdl:outputNewLine=',
+          'dfdl:choiceBranchKey=',
+          'dfdl:representation',
+        ],
+        preVal,
+        additionalItems,
+        nsPrefix
+      )
+    case 'sequence':
+      return getCompletionItems(
+        [
+          'dfdl:hiddenGroupRef=',
+          'dfdl:sequenceKind=',
+          'dfdl:separator=',
+          'dfdl:separatorPosition=',
+          'dfdl:separatorSuppressionPolicy',
+        ],
+        preVal,
+        undefined,
+        nsPrefix
+      )
+    case 'choice':
+      return getCompletionItems(
+        [
+          'dfdl:choiceLengthKind=',
+          'dfdl:choiceLength=',
+          'dfdl:initiatedContent=',
+          'dfdl:choiceDispatchKey=',
+          'dfdl:choiceBranchKey=',
+        ],
+        undefined,
+        undefined,
+        nsPrefix
+      )
+    case 'group':
+      return getCompletionItems(
+        ['ref=', 'name='],
+        undefined,
+        undefined,
+        nsPrefix
+      )
+
+    case 'simpleType':
+      return getCompletionItems(
+        [
+          'dfdl:length=',
+          'dfdl:lengthKind=',
+          'dfdl:simpleType',
+          'dfdl:simpleType',
+          nsPrefix + 'restriction',
+        ],
+        undefined,
+        undefined,
+        nsPrefix
+      )
+    case 'format':
+      return getCompletionItems(
+        [
+          'dfdl:byteOrder=',
+          'dfdl:bitOrder=',
+          'dfdl:encoding=',
+          'dfdl:initiator=',
+          'dfdl:outputNewLine=',
+          'dfdl:separator=',
+          'dfdl:terminator=',
+          nsPrefix + 'restriction',
+        ],
+        undefined,
+        undefined,
+        nsPrefix
+      )
+
+    case 'defineVariable':
+      return getDefineVariableCompletionItems(preVal, additionalItems, nsPrefix)
+    case 'setVariable':
+      const xmlValue = new vscode.CompletionItem('value=')
+      xmlValue.insertText = new vscode.SnippetString('value="$1"$0')
+      xmlValue.documentation = new vscode.MarkdownString('')
+      return undefined
+    default:
+      return undefined
+  }
+}
+
+function getDefineVariableCompletionItems(
+  preVal: string,
+  additionalItems: string,
+  nsPrefix: string
+): vscode.CompletionItem[] {
+  let xmlItems = [
+    {
+      item: 'external=',
+      snippetString: preVal + 'external="${1|true,false|}"$0',
+    },
+    {
+      item: 'defaultValue=',
+      snippetString: preVal + 'defaultValue="0$1"$0',
+    },
+  ]
+
+  let compItems: vscode.CompletionItem[] = []
+  xmlItems.forEach((e) => {
+    const completionItem = new vscode.CompletionItem(e.item)
+    completionItem.insertText = new vscode.SnippetString(e.snippetString)
+
+    compItems.push(completionItem)
+  })
+
+  getCommonItems(['type='], '', additionalItems, nsPrefix).forEach((ci) => {
+    compItems.push(ci)
+  })
+
+  return compItems
 }

--- a/src/language/providers/closeElementSlash.ts
+++ b/src/language/providers/closeElementSlash.ts
@@ -16,66 +16,125 @@
  */
 
 import * as vscode from 'vscode'
+import { checkMissingCloseTag } from './closeUtils'
 import {
   insertSnippet,
-  nearestOpen,
   checkBraceOpen,
   getXsdNsPrefix,
+  getItemPrefix,
+  getItemsOnLineCount,
 } from './utils'
 
 export function getCloseElementSlashProvider() {
   return vscode.languages.registerCompletionItemProvider(
     'dfdl',
     {
-      provideCompletionItems(
+      async provideCompletionItems(
         document: vscode.TextDocument,
         position: vscode.Position
       ) {
-        var backpos = position.with(position.line, position.character - 1)
+        let backpos = position.with(position.line, position.character - 1)
         const nsPrefix = getXsdNsPrefix(document, position)
         const triggerText = document
           .lineAt(position)
           .text.substring(0, position.character)
-        const nearestOpenItem = nearestOpen(document, position)
+        let nearestTagNotClosed = checkMissingCloseTag(
+          document,
+          position,
+          nsPrefix
+        )
+        const itemsOnLine = getItemsOnLineCount(triggerText)
+
         if (checkBraceOpen(document, position)) {
           return undefined
         }
-        if (
-          triggerText.endsWith('/') &&
-          (triggerText.includes('<' + nsPrefix + 'element') ||
-            nearestOpenItem.includes('element') ||
-            triggerText.includes('<' + nsPrefix + 'group') ||
-            nearestOpenItem.includes('group') ||
-            triggerText.includes('<' + nsPrefix + 'sequence') ||
-            nearestOpenItem.includes('sequence'))
-        ) {
-          var range = new vscode.Range(backpos, position)
-          vscode.window.activeTextEditor?.edit((editBuilder) => {
+
+        if (triggerText.endsWith('/')) {
+          let range = new vscode.Range(backpos, position)
+
+          await vscode.window.activeTextEditor?.edit((editBuilder) => {
             editBuilder.replace(range, '')
           })
-          insertSnippet(' />$0', backpos)
+
+          checkItemsOnLine(
+            document,
+            position,
+            itemsOnLine,
+            nearestTagNotClosed,
+            backpos,
+            nsPrefix,
+            triggerText
+          )
         }
-        if (
-          triggerText.endsWith('/') &&
-          (triggerText.includes('dfdl:defineVariable') ||
-            triggerText.includes('dfdl:setVariable') ||
-            nearestOpenItem.includes('defineVariable') ||
-            nearestOpenItem.includes('setVariable'))
-        ) {
-          var startPos = document.lineAt(position).text.indexOf('<', 0)
-          var range = new vscode.Range(backpos, position)
-          vscode.window.activeTextEditor?.edit((editBuilder) => {
-            editBuilder.replace(range, '')
-          })
-          insertSnippet('/>\n', backpos)
-          var backpos2 = position.with(position.line + 1, startPos - 2)
-          insertSnippet('</<' + nsPrefix + 'appinfo>\n', backpos2)
-          var backpos3 = position.with(position.line + 2, startPos - 4)
-          insertSnippet('</<' + nsPrefix + 'annotation>$0', backpos3)
-        }
+
         return undefined
       },
     },
-    '/' // triggered whenever a '/' is typed
+    '/'
+    // triggered whenever a '/' is typed
   )
+}
+
+function checkItemsOnLine(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  itemsOnLine: number,
+  nearestTagNotClosed: string,
+  backpos: vscode.Position,
+  nsPrefix: string,
+  triggerText: string
+) {
+  nsPrefix = getItemPrefix(nearestTagNotClosed, nsPrefix)
+  if (itemsOnLine == 1 || itemsOnLine == 0) {
+    if (itemsOnLine == 1) {
+      insertSnippet('/>$0', backpos)
+    }
+    if (itemsOnLine == 0) {
+      const backpos3 = position.with(position.line, position.character - 3)
+      insertSnippet('</' + nsPrefix + nearestTagNotClosed + '>$0', backpos3)
+    }
+
+    if (
+      nearestTagNotClosed.includes('defineVariable') ||
+      nearestTagNotClosed.includes('setVariable')
+    ) {
+      let startPos = document.lineAt(position).text.indexOf('<', 0)
+      let range = new vscode.Range(backpos, position)
+      vscode.window.activeTextEditor?.edit((editBuilder) => {
+        editBuilder.replace(range, '')
+      })
+
+      insertSnippet('/>\n', backpos)
+
+      let backpos2 = position.with(position.line + 1, startPos - 2)
+      insertSnippet('</' + nsPrefix + 'appinfo>\n', backpos2)
+
+      let backpos3 = position.with(position.line + 2, startPos - 4)
+      insertSnippet('</' + nsPrefix + 'annotation>$0', backpos3)
+    }
+  }
+
+  if (itemsOnLine > 1) {
+    if (
+      triggerText.endsWith('/') &&
+      triggerText.includes('<' + nsPrefix + nearestTagNotClosed)
+    ) {
+      let tagPos = triggerText.lastIndexOf('<' + nsPrefix + nearestTagNotClosed)
+      let tagEndPos = triggerText.indexOf('>', tagPos)
+      if (
+        tagPos != -1 &&
+        !triggerText.substring(tagEndPos - 1, 2).includes('/>') &&
+        triggerText
+          .substring(backpos.character - 1, backpos.character)
+          .includes('>') &&
+        !triggerText
+          .substring(tagEndPos)
+          .includes('</' + nsPrefix + nearestTagNotClosed)
+      ) {
+        insertSnippet('</' + nsPrefix + nearestTagNotClosed + '>$0', backpos)
+      } else {
+        insertSnippet('/>$0', backpos)
+      }
+    }
+  }
 }

--- a/src/language/providers/closeUtils.ts
+++ b/src/language/providers/closeUtils.ts
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode'
+import { getItemsOnLineCount, getItemPrefix, getItems } from './utils'
+
+export function checkMissingCloseTag(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  nsPrefix: string
+) {
+  const triggerLine = position.line
+  const triggerPos = position.character
+  const triggerText = document.lineAt(triggerLine).text
+  const itemsOnLine = getItemsOnLineCount(triggerText)
+  const origPrefix = nsPrefix
+
+  const items = getItems()
+  for (let i = 0; i < items.length; ++i) {
+    const textBeforeTrigger = triggerText.substring(0, triggerPos)
+
+    nsPrefix = getItemPrefix(items[i], origPrefix)
+
+    if (itemsOnLine > 1) {
+      if (textBeforeTrigger.lastIndexOf('<' + nsPrefix + items[i]) > -1) {
+        let gt1res = getItemsForLineGT1(
+          triggerText,
+          triggerPos,
+          nsPrefix,
+          items,
+          i
+        )
+
+        if (gt1res != undefined) {
+          return gt1res
+        }
+      }
+    }
+
+    if (itemsOnLine < 2) {
+      let lt2res = getItemsForLineLT2(
+        document,
+        triggerText,
+        triggerLine,
+        nsPrefix,
+        items,
+        i
+      )
+
+      if (lt2res != undefined) {
+        return lt2res
+      }
+    }
+  }
+
+  return 'none'
+}
+
+export function getCloseTag(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  nsPrefix: string,
+  tag: string,
+  startLine: number,
+  startPos: number
+): [string, number, number] {
+  let lineNum = startLine
+  let tagOpen = startPos
+  const triggerLine = position.line
+  const triggerPos = position.character
+  const triggerText = document.lineAt(startLine).text
+  const itemsOnLine = getItemsOnLineCount(document.lineAt(lineNum).text)
+  let endPos = triggerText.lastIndexOf('>')
+  nsPrefix = getItemPrefix(tag, nsPrefix)
+
+  if (itemsOnLine > 1 && startPos < endPos) {
+    while (tagOpen > -1 && tagOpen <= triggerPos) {
+      tagOpen = triggerText.indexOf('<', tagOpen)
+      let tagClose = triggerText.indexOf('>', tagOpen)
+      let tagPart = triggerText.substring(tagOpen, tagClose)
+
+      if (
+        tagPart.includes(tag) &&
+        (tagPart.includes('</') || tagPart.includes('/>'))
+      ) {
+        return [tag, startLine, tagOpen]
+      }
+
+      tagOpen = tagClose + 1
+    }
+  } else {
+    let endPos = triggerText.indexOf('>', startPos)
+
+    if (
+      (triggerText.includes('</') || triggerText.includes('/>')) &&
+      triggerText.includes(tag) &&
+      endPos > -1 &&
+      itemsOnLine < 2
+    ) {
+      return [tag, startLine, startPos]
+    }
+
+    while (lineNum > -1 && lineNum < document.lineCount) {
+      let currentText = document.lineAt(lineNum).text
+      startPos = currentText.indexOf('<')
+
+      if (getItemsOnLineCount(currentText) < 2) {
+        //skip lines until the close tag for this item
+        if (
+          currentText.includes('<' + nsPrefix + tag) &&
+          (currentText.includes('>') || tag === 'schema') &&
+          !currentText.includes('/>')
+        ) {
+          //skipping to closing tag
+          while (!currentText.includes('</' + nsPrefix + tag)) {
+            currentText = document.lineAt(++lineNum).text
+            if (getItemsOnLineCount(currentText) > 1) {
+              currentText = document.lineAt(++lineNum).text
+            }
+          }
+        }
+
+        if (currentText.includes('</' + nsPrefix + tag)) {
+          //if the cursor is after the closing tag
+          if (
+            lineNum == triggerLine &&
+            currentText.indexOf('>', triggerPos) === -1
+          ) {
+            return ['none', lineNum, startPos]
+          }
+          return [tag, lineNum, startPos]
+        }
+      }
+
+      ++lineNum
+    }
+  }
+
+  return ['none', 0, 0]
+}
+
+export function getItemsForLineGT1(
+  triggerText: string,
+  triggerPos: number,
+  nsPrefix: string,
+  items: string[],
+  i: number
+) {
+  let openTagArray: number[] = []
+  let closeTagArray: number[] = []
+  let [nextCloseCharPos, nextOpenTagPos] = [0, 0, 0]
+
+  while (
+    (nextOpenTagPos = triggerText.indexOf(
+      '<' + nsPrefix + items[i],
+      nextOpenTagPos
+    )) > -1
+  ) {
+    openTagArray.push(nextOpenTagPos)
+
+    if ((nextCloseCharPos = triggerText.indexOf('>', nextOpenTagPos)) > -1) {
+      //if tag is self closing remove it from the openTagArray
+      if (
+        triggerText.substring(nextCloseCharPos - 1, nextCloseCharPos + 1) ===
+        '/>'
+      ) {
+        openTagArray.splice(-1, 1)
+      }
+
+      nextOpenTagPos = nextOpenTagPos + 1
+    }
+  }
+
+  while (
+    (nextCloseCharPos = triggerText.indexOf(
+      '</' + nsPrefix + items[i],
+      nextCloseCharPos
+    )) > -1
+  ) {
+    closeTagArray.push(nextCloseCharPos)
+    nextCloseCharPos = nextCloseCharPos + 1
+  }
+
+  if (openTagArray.length > closeTagArray.length) {
+    return items[i]
+  }
+
+  return undefined
+}
+
+export function getItemsForLineLT2(
+  document: vscode.TextDocument,
+  triggerText: string,
+  triggerLine: number,
+  nsPrefix: string,
+  items: string[],
+  i: number
+) {
+  let [currentText, currentLine] = [triggerText, triggerLine]
+  let [lineBefore, lineAfter] = [triggerLine, triggerLine]
+  let openTagArray: number[] = []
+  let closeTagArray: number[] = []
+
+  while (
+    currentText.indexOf('<' + nsPrefix + items[i]) === -1 &&
+    currentLine > -1
+  ) {
+    --currentLine
+
+    if (currentLine > -1) {
+      currentText = document.lineAt(currentLine).text
+    }
+
+    if (getItemsOnLineCount(currentText) > 1) {
+      --currentLine
+    }
+  }
+
+  if (currentText.indexOf('<' + nsPrefix + items[i]) > -1) {
+    while (lineBefore > -1) {
+      currentText = document.lineAt(lineBefore).text
+      if (getItemsOnLineCount(currentText) < 2) {
+        if (currentText.indexOf('<' + nsPrefix + items[i]) > -1) {
+          openTagArray.push(lineBefore)
+
+          //if selfclosing remove from the array
+          if (currentText.indexOf('/>') > -1) {
+            openTagArray.splice(openTagArray.length - 1, 1)
+          }
+        }
+
+        if (currentText.indexOf('</' + nsPrefix + items[i]) > -1) {
+          closeTagArray.push(lineBefore)
+        }
+      }
+
+      --lineBefore
+    }
+
+    ++lineAfter
+
+    while (lineAfter < document.lineCount) {
+      currentText = document.lineAt(lineAfter).text
+
+      if (getItemsOnLineCount(currentText) < 2) {
+        if (currentText.indexOf('<' + nsPrefix + items[i]) > -1) {
+          openTagArray.push(lineAfter)
+
+          //if selfclosing remove from the array
+          if (currentText.indexOf('/>') > -1) {
+            openTagArray.splice(openTagArray.length - 1, 1)
+          }
+        }
+
+        if (currentText.indexOf('</' + nsPrefix + items[i]) > -1) {
+          closeTagArray.push(lineAfter)
+        }
+      }
+
+      ++lineAfter
+    }
+
+    if (openTagArray.length > closeTagArray.length) {
+      return items[i]
+    }
+  }
+
+  return undefined
+}

--- a/src/language/providers/intellisense/attributeItems.ts
+++ b/src/language/providers/intellisense/attributeItems.ts
@@ -20,14 +20,12 @@ export const attributeCompletion = (additionalItems, nsPrefix: string) => {
   return {
     items: [
       {
-        item: 'dfdl:defineFormat',
-        snippetString: '<dfdl:defineFormat name="$1" >\n\t$2\n</dfdl:defineFormat>\n$0',
-        markdownString: 'dfdl format name and configuration',
+        item: 'name=',
+        snippetString: 'name="$1"$0',
       },
       {
-        item: 'dfdl:defineEscapeScheme',
-        snippetString: '<dfdl:defineEscapeScheme name=$1 >\n\t$0,/dfdl:defineEscapeScheme>\n',
-        markdownString: 'dfdl escape character definition',
+        item: 'ref=',
+        snippetString: 'ref="$1"$0',
       },
       {
         item: 'minOccurs=',

--- a/src/language/providers/intellisense/elementItems.ts
+++ b/src/language/providers/intellisense/elementItems.ts
@@ -25,7 +25,7 @@ export const elementCompletion = (definedVariables, dfdlFormatString, nsPrefix) 
       },
       {
         item: nsPrefix + 'schema',
-        snippetString: '<' + nsPrefix + 'schema xmlns:xs="http://www.w3.org/2001/xmlSchema"\n\t\txmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"\n\t\txmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"\n\t\txmlns:fn="http:/www.w3.org/2005/xpath-functions"\n\t\txmlns:math="www.w3.org/2005/xpath-functions/math" elementFormDefault="qualified">\n$0\n</' + nsPrefix + 'schema>',
+        snippetString: '<' + nsPrefix + 'schema xmlns:xs="http://www.w3.org/2001/xmlSchema"\n\t\txmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"\n\t\txmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"\n\t\txmlns:fn="http:/www.w3.org/2005/xpath-functions"\n\t\t elementFormDefault="unqualified">\n$0\n</' + nsPrefix + 'schema>',
       },
       {
         item: nsPrefix + 'element name',
@@ -48,12 +48,12 @@ export const elementCompletion = (definedVariables, dfdlFormatString, nsPrefix) 
       },
       {
         item: 'dfdl:assert',
-        snippetString: '<' + nsPrefix + 'annotation>\n\t<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t\t<dfdl:assert>"<$1>"</dfdl:assert>\n\t</' + nsPrefix + 'appinfo>\n</' + nsPrefix + 'annotation>$0',
+        snippetString: '<dfdl:assert>"<$1>"</dfdl:assert>$0',
         markdownString: 'dfdl assertion test',
       },
       {
-        item: 'dfdL:discriminator',
-        snippetString: '<' + nsPrefix + 'annotation>\n\t<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t\t<dfdl:discriminator test="{$1}"/>\n\t</' + nsPrefix + 'appinfo>\n</' + nsPrefix + 'annotation>$0',
+        item: 'dfdl:discriminator',
+        snippetString: '<dfdl:discriminator test="{$1}"/>$0',
         markdownString: 'dfdl discriminator test',
       },
       {
@@ -62,15 +62,15 @@ export const elementCompletion = (definedVariables, dfdlFormatString, nsPrefix) 
       },
       {
         item: 'dfdl:format',
-        snippetString: dfdlFormatString,
+        snippetString: '<dfdl:format $0/>',
       },
       {
         item: nsPrefix + 'annotation',
-        snippetString: '<' + nsPrefix + 'annotation>\n\t<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t\t$0\n\t</' + nsPrefix + 'appinfo>\n</' + nsPrefix + 'annotation>',
+        snippetString: '<' + nsPrefix + 'annotation>\n\t$0\n\</' + nsPrefix + 'annotation>',
       },
       {
         item: nsPrefix + 'appinfo',
-        snippetString: '<' + nsPrefix + 'annotation>\n\t<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t\t$0\n\t</' + nsPrefix + 'appinfo>\n</' + nsPrefix + 'annotation>',
+        snippetString: '<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t$0\n</' + nsPrefix + 'appinfo>',
       },
       {
         item: nsPrefix + 'complexType',
@@ -102,12 +102,42 @@ export const elementCompletion = (definedVariables, dfdlFormatString, nsPrefix) 
       },
       {
         item: 'dfdl:defineVariable',
-        snippetString: '<' + nsPrefix + 'annotation>\n\t<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t\t<dfdl:defineVariable name="$1"$0',
+        snippetString: '\t<dfdl:defineVariable name="$1"$0',
       },
       {
         item: 'dfdl:setVariable',
-        snippetString: '<' + nsPrefix + 'annotation>\n\t<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t\t<dfdl:setVariable ref="${1|' + definedVariables + '|}"$0',
+        snippetString: '\t<dfdl:setVariable ref="${1|' + definedVariables + '"|}, value="$2"$0',
       },
+      {
+        item: 'dfdl:defineFormat',
+        snippetString: '<dfdl:defineFormat name="$1" >\n\t$2\n</dfdl:defineFormat>$0',
+        markdownString: 'dfdl format name and configuration',
+      },
+      {
+        item: 'dfdl:defineEscapeScheme',
+        snippetString: '<dfdl:defineEscapeScheme name=$1 >\n\t$0,/dfdl:defineEscapeScheme>',
+        markdownString: 'dfdl escape character definition',
+      },
+      /*TODO not sure how to make dfdl:element work without braking xs:element 
+      {
+        item: 'dfdl:element',
+        snippetString: '\t<dfdl:defineVariable name="$1"$0',
+      },
+      //these items have been separated into individual tags... not sure if I should keep this code around
+      */
+      /*{
+        item: nsPrefix + 'annotation+appinfo',
+        snippetString: '<' + nsPrefix + 'annotation>\n\t<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t\t$0\n\t</' + nsPrefix + 'appinfo>\n</' + nsPrefix + 'annotation>',
+      },
+      item: 'dfdl:assert+appinfo+annotation',
+        snippetString: '<' + nsPrefix + 'annotation>\n\t<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t\t<dfdl:assert>"<$1>"</dfdl:assert>\n\t</' + nsPrefix + 'appinfo>\n</' + nsPrefix + 'annotation>$0',
+        markdownString: 'dfdl assertion test',
+      },
+      {
+        item: 'dfdl:discriminator+appinfo+annotation',
+        snippetString: '<' + nsPrefix + 'annotation>\n\t<' + nsPrefix + 'appinfo source="http://www.ogf.org/dfdl/">\n\t\t<dfdl:discriminator test="{$1}"/>\n\t</' + nsPrefix + 'appinfo>\n</' + nsPrefix + 'annotation>$0',
+        markdownString: 'dfdl discriminator test',
+      },*/
     ],
   }
 }

--- a/src/tests/suite/language/items.test.ts
+++ b/src/tests/suite/language/items.test.ts
@@ -23,30 +23,34 @@ import { elementCompletion } from '../../../language/providers/intellisense/elem
 suite('Items Test Suite', () => {
   const expectedElementItems = [
     'xml version',
-    'xs:schema',
-    'xs:element name',
-    'xs:element ref',
-    'xs:group name',
-    'xs:group ref',
+    'schema',
+    'element name',
+    'element ref',
+    'group name',
+    'group ref',
     'dfdl:assert',
-    'dfdL:discriminator',
+    'dfdl:discriminator',
     'dfdl:hiddenGroupRef',
     'dfdl:format',
-    'xs:annotation',
-    'xs:appinfo',
-    'xs:complexType',
-    'xs:complexType name=',
-    'xs:simpleType',
-    'xs:simpleType name=',
-    'xs:sequence',
-    'xs:choice',
+    'annotation',
+    'appinfo',
+    'complexType',
+    'complexType name=',
+    'simpleType',
+    'simpleType name=',
+    'sequence',
+    'choice',
     'dfdl:defineVariable',
     'dfdl:setVariable',
+    'dfdl:defineFormat',
+    'dfdl:defineEscapeScheme',
   ]
   const expectedAttributeItems = [
     'dfdl:defineFormat',
     'dfdl:defineEscapeScheme',
     'type=',
+    'name=',
+    'ref=',
     'minOccurs=',
     'maxOccurs=',
     'dfdl:occursCount=',
@@ -75,7 +79,7 @@ suite('Items Test Suite', () => {
     'dfdl:initiatedContent=',
     'dfdl:choiceDispatchKey=',
     'dfdl:simpleType',
-    'xs:restriction',
+    'restriction',
   ]
 
   test('all commonItems available', async () => {
@@ -85,13 +89,13 @@ suite('Items Test Suite', () => {
   })
 
   test('all elementItems available', async () => {
-    elementCompletion('', '', 'xs:').items.forEach((item) => {
+    elementCompletion('', '', '').items.forEach((item) => {
       assert.strictEqual(expectedElementItems.includes(item.item), true)
     })
   })
 
   test('all attributeItems available', async () => {
-    attributeCompletion('', 'xs:').items.forEach((item) => {
+    attributeCompletion('', '').items.forEach((item) => {
       assert.strictEqual(expectedAttributeItems.includes(item.item), true)
     })
   })


### PR DESCRIPTION
- context logic change to use line and cursor position at trigger
    - functions developed to:
      - determine the tag at the context position
      - determine if the tag is open
      - determine if the trigger occured between tags
      - determine if a close tag is missing

    - Additional modifications made to:
      - provide above functionality if line contains multiple tags
      - provide intellisense based on tag at context position
      - simplify the logic to determine context
      - minimize if/else logic
      - fixes close tag completion for schema when close tag is missing
      - fixes tag end symbol missing problem in issue 459

    - Also fixes a bug with context when intellisense is trigger at the
    start of the line of a multi-tag line, and also if trigger at the
    end of the line of a multi-tag line

    - Incorporates modifications made by Shane Dell

    Closes https://github.com/apache/daffodil-vscode/issues/438
    Closes https://github.com/apache/daffodil-vscode/issues/459
    Closes https://github.com/apache/daffodil-vscode/issues/460
