### PR TITLE
Fix Java11+ build issues by adding run/fork true

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,9 @@
 import com.github.retronym.sbtxjc.SbtXjcPlugin
 import Classpaths.managedJars
 
+//Fixes build issues on java11+
+run / fork := true
+
 val packageJsonStr = scala.io.Source.fromFile("package.json").mkString
 
 val daffodilVer = {


### PR DESCRIPTION
On Java11+ issues were found during compliation that this fixes.  Backtested that it doesn't break any Java 8 builds.