### PR TITLE
Catch arbitrary exception thrown during CI

### DIFF
--- a/src/omega_edit/utils.ts
+++ b/src/omega_edit/utils.ts
@@ -70,6 +70,10 @@ export async function viewportSubscribe(
       getLogger().debug(`viewport event received: ${viewportId}`)
       await setViewportDataForPanel(panel, viewportId)
     })
+    .on('error', (err) => {
+      // Call cancelled thrown sometimes when server is shutdown
+      if (!err.message.includes('Call cancelled')) throw err
+    })
 }
 
 export class DisplayState {


### PR DESCRIPTION
- Added `.on()` error callback for catching "Call cancelled" for `viewportSubscribe()` in `./src/omega_edit/utils.ts`.