### PR TITLE
Set debugServer to 4711 (default) if not specified in config.

### DIFF
--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -406,6 +406,10 @@ class DaffodilConfigurationProvider
       config = getConfig('Launch', 'launch', 'dfdl')
     }
 
+    if (!config.debugServer) {
+      config.debugServer = 4711
+    }
+
     if (!config.program) {
       return vscode.window
         .showInformationMessage('Cannot find a program to debug')


### PR DESCRIPTION
Set debugServer to 4711 (default) if not specified in config.

Closes #494