### PR TITLE
Naming cleanup and remove OmegaEdit version command

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,8 +92,7 @@
     "onCommand:extension.dfdl-debug.getTDMLPath",
     "onCommand:extension.dfdl-debug.getValidatedTDMLPath",
     "onCommand:launch.config",
-    "onCommand:data.edit",
-    "onCommand:omega_edit.version",
+    "onCommand:extension.data.edit",
     "onCommand:extension.dfdl-debug.debugLastEditorContents"
   ],
   "workspaceTrust": {
@@ -189,10 +188,7 @@
           "when": "resourceLangId == dfdl"
         },
         {
-          "command": "data.edit"
-        },
-        {
-          "command": "omega_edit.version"
+          "command": "extension.data.edit"
         },
         {
           "command": "extension.dfdl-debug.debugLastEditorContents",
@@ -287,19 +283,14 @@
         "icon": "$(debug-configure)"
       },
       {
-        "command": "omega_edit.version",
-        "title": "Ωedit Version Info",
-        "category": "OmegaEdit"
-      },
-      {
-        "command": "data.edit",
+        "command": "extension.data.edit",
         "title": "Data Editor",
-        "category": "OmegaEdit"
+        "category": "Daffodil Debug"
       },
       {
         "command": "position.goto",
         "title": "Go to position",
-        "category": "OmegaEdit"
+        "category": "Daffodil Debug"
       }
     ],
     "keybindings": [

--- a/src/omega_edit/client.ts
+++ b/src/omega_edit/client.ts
@@ -18,7 +18,6 @@
 import * as fs from 'fs'
 import { createSimpleFileLogger, setLogger } from 'omega-edit/logger'
 import { startServer, stopServerUsingPID } from 'omega-edit/server'
-import * as omegaEditVersion from 'omega-edit/version'
 import { setAutoFixViewportDataLength } from 'omega-edit/viewport'
 import path from 'path'
 import * as vscode from 'vscode'
@@ -140,27 +139,7 @@ export function activate(ctx: vscode.ExtensionContext) {
 
   ctx.subscriptions.push(
     vscode.commands.registerCommand(
-      'omega_edit.version',
-      async (
-        startServ: boolean = true,
-        port: number | undefined = undefined
-      ) => {
-        await getOmegaEditPort(port)
-        if (startServ) {
-          await serverStart(ctx, omegaEditPackageVersion)
-        }
-        await initOmegaEditClient(serverPort)
-        const version = await omegaEditVersion.getServerVersion()
-        vscode.window.showInformationMessage(`Ωedit server version ${version}`)
-        if (startServ) {
-          serverStop()
-        }
-        return version
-      }
-    ),
-
-    vscode.commands.registerCommand(
-      'data.edit',
+      'extension.data.edit',
       async (
         startServ: boolean = true,
         port: number | undefined = undefined,

--- a/src/svelte/src/components/dataEditor.svelte
+++ b/src/svelte/src/components/dataEditor.svelte
@@ -1373,7 +1373,7 @@ limitations under the License.
 </main>
 <hr />
 <div class="omega-latency flex-container row center">
-  <div>Ωedit v{serverVersion} on port {serverPort}</div>
+  <div>Powered by Ωedit v{serverVersion} on port {serverPort}</div>
   <div class="latency-group flex-container row center">
     <svg class="latency-indicator">
       {#if serverLatency < 20}

--- a/src/tests/suite/dataEditor.test.ts
+++ b/src/tests/suite/dataEditor.test.ts
@@ -56,7 +56,7 @@ export async function runServerForTests() {
   )
 }
 
-suite('omega-edit Test Suite', () => {
+suite('Data Editor Test Suite', () => {
   let terminal: vscode.Terminal
 
   before(async () => {
@@ -67,16 +67,9 @@ suite('omega-edit Test Suite', () => {
     await terminal.processId.then(async (id) => await killProcess(id))
   })
 
-  test('Ωedit version command exists', async () => {
-    assert.strictEqual(
-      (await vscode.commands.getCommands()).includes('omega_edit.version'),
-      true
-    )
-  })
-
   test('data edit command exists', async () => {
     assert.strictEqual(
-      (await vscode.commands.getCommands()).includes('data.edit'),
+      (await vscode.commands.getCommands()).includes('extension.data.edit'),
       true
     )
   })
@@ -130,24 +123,11 @@ suite('omega-edit Test Suite', () => {
     assert.strictEqual(result.open, true)
   })
 
-  suite('omega-edit commands', () => {
-    test('omega_edit.version returns correct version', async () => {
-      const version = await vscode.commands.executeCommand(
-        'omega_edit.version',
-        false,
-        port
-      )
-      assert.ok(version)
-      assert.strictEqual(
-        version,
-        omegaEditClient.getOmegaEditPackageVersion(PACKAGE_PATH)
-      )
-    })
-
+  suite('Data Editor', () => {
     test('data editor opens', async () => {
       const dataEditWebView: DataEditWebView =
         await vscode.commands.executeCommand(
-          'data.edit',
+          'extension.data.edit',
           false,
           port,
           TEST_SCHEMA


### PR DESCRIPTION
Make it clear that Data Editor is part of the Daffodil Debugger extension and that while it is powered by OmegaEdit, it is not OmegaEdit.