### PR TITLE
Tab name to be the filepath of the file being edited

### DIFF
--- a/src/omega_edit/dataEditWebView.ts
+++ b/src/omega_edit/dataEditWebView.ts
@@ -34,6 +34,7 @@ import {
   setViewportDataForPanel,
   viewportSubscribe,
 } from './utils'
+import path from 'path'
 
 const VIEWPORT_CAPACITY_MAX = 1000000 // Maximum viewport size in Ωedit is 1048576 (1024 * 1024)
 const HEARTBEAT_INTERVAL_MS = 1000 // 1 second (1000 ms)
@@ -96,6 +97,7 @@ export class DataEditWebView implements vscode.Disposable {
         .then(async (fileUri) => {
           if (fileUri && fileUri[0]) {
             this.fileToEdit = fileUri[0].fsPath
+            this.panel.title = path.basename(this.fileToEdit)
             await this.setupDataEditor()
           }
         })


### PR DESCRIPTION

The panel object has a title property that is writable, but I don't see a way to do that and hover text.

Here is what it looks like if we use the full path:

<img width="1526" alt="Screenshot 2023-03-21 at 4 43 47 PM" src="https://user-images.githubusercontent.com/2205472/226736206-bceae73d-4a05-4940-a0fa-2a16fac571bc.png">

I chose to use the base name of the file, though it's not unique if we open say 2 different `package.json` files, then we have 2 tabs named the same thing even though the paths are different.  Here is what it looks like with this patch:

<img width="935" alt="Screenshot 2023-03-21 at 4 49 18 PM" src="https://user-images.githubusercontent.com/2205472/226737415-81f86042-8240-47a3-a185-15585e43185e.png">

Fixes #507.