### PR TITLE
move error msg and add instrux in edit vpt in single byte mode

### DIFF
--- a/src/svelte/src/components/dataEditor.svelte
+++ b/src/svelte/src/components/dataEditor.svelte
@@ -1095,6 +1095,13 @@ limitations under the License.
         on:click={moveEditByteWindow}>&#8647;</button
       >
     {/if}
+    {#if !$commitable && $commitErrMsg.length > 0}
+      <div
+        style="background-color: black; opacity: 0.75; border-radius: 5px; margin: 4px; padding: 4px;"
+      >
+        <span class="errMsg">{$commitErrMsg}</span>
+      </div>
+    {/if}
   </div>
   <textarea
     class="address_vw"
@@ -1161,7 +1168,11 @@ limitations under the License.
         on:input={handleEditorEvent}
       />
     {:else}
-      <div class="selectedContent" id="editor" />
+      <div class="selectedContent" id="editor">
+        <em class="instructions" style="opacity: 0.5;"
+          >Multiple Byte Editing is <u>disabled</u> in Single Byte Editing Mode</em
+        >
+      </div>
     {/if}
     <!-- Full Mode Content Controls -->
     {#if $editMode === 'full'}
@@ -1275,12 +1286,7 @@ limitations under the License.
       <!-- Simple Mode Content Controls -->
     {:else}
       <fieldset class="box margin-top">
-        <legend
-          >Content Controls
-          {#if !$commitable}
-            <span class="errMsg">{$commitErrMsg}</span>
-          {/if}
-        </legend>
+        <legend>Content Controls </legend>
         <div class="contentControls" id="content_controls">
           <span>
             {#if $undoCount > 0}


### PR DESCRIPTION
Relocates the error message in single byte mode closer to where the error is taking place.  Also adds an instruction message in the edit viewport in single byte mode.  Here is the screenshot with this patch applied:

<img width="1048" alt="Screenshot 2023-03-22 at 9 15 24 AM" src="https://user-images.githubusercontent.com/2205472/226917008-3afe6f5c-2ced-43a6-962b-7767481d9182.png">
