### PR TITLE
add rthomas320 as a collaborator to this repo

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,6 +26,7 @@ github:
     rebase:   true
   collaborators:
     - michael-hoke
+    - rthomas320
     - stricklandrbls
 notifications:
     commits:      commits@daffodil.apache.org


### PR DESCRIPTION
Add Regis Thomas (rthomas320) as a collaborator to the Daffodil-VSCode repository.