### PR TITLE
Reordered OE server kill & added verbose vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -599,7 +599,7 @@
             },
             "default": {}
           },
-          "dataEditor.serverPort": {
+          "dataEditor.omegaEditPort": {
             "type": "integer",
             "description": "Editor server default port",
             "default": 9000
@@ -607,7 +607,7 @@
           "dataEditor.logFile": {
             "type": "string",
             "description": "Path to log file for data editor",
-            "default": "${workspaceFolder}/dataEditor-${serverPort}.log"
+            "default": "${workspaceFolder}/dataEditor-${omegaEditPort}.log"
           },
           "dataEditor.logLevel": {
             "type": "string",

--- a/src/omega_edit/dataEditWebView.ts
+++ b/src/omega_edit/dataEditWebView.ts
@@ -22,7 +22,7 @@ import { CountKind } from 'omega-edit/session'
 import * as omegaEditViewport from 'omega-edit/viewport'
 import * as vscode from 'vscode'
 import { EditorMessage, MessageCommand } from '../svelte/src/utilities/message'
-import { serverPort } from './client'
+import { omegaEditPort } from './client'
 import { SvelteWebviewInitializer } from './svelteWebviewInitializer'
 import {
   dataToEncodedStr,
@@ -144,7 +144,7 @@ export class DataEditWebView implements vscode.Disposable {
         this.panel.webview.postMessage({
           command: MessageCommand.heartBeat,
           data: {
-            serverPort: serverPort,
+            omegaEditPort: omegaEditPort,
             serverVersion: heartbeat.resp,
             serverLatency: heartbeat.latency,
           },

--- a/src/svelte/src/components/dataEditor.svelte
+++ b/src/svelte/src/components/dataEditor.svelte
@@ -105,7 +105,7 @@ limitations under the License.
   let logicalOffsetText: string
   let logicalDisplayText: string = ''
   let currentScrollEvt: string | null, scrollSyncTimer: NodeJS.Timeout
-  let serverPort: number
+  let omegaEditPort: number
   let serverVersion: string = 'Connecting...'
   let serverLatency: number
   let physical_vwRef: HTMLTextAreaElement
@@ -722,7 +722,7 @@ limitations under the License.
         break
 
       case MessageCommand.heartBeat:
-        serverPort = msg.data.data.serverPort
+        omegaEditPort = msg.data.data.omegaEditPort
         serverVersion = msg.data.data.serverVersion
         serverLatency = msg.data.data.serverLatency
         break
@@ -1408,7 +1408,7 @@ limitations under the License.
 </main>
 <hr />
 <div class="omega-latency flex-container row center">
-  <div>Powered by Ωedit v{serverVersion} on port {serverPort}</div>
+  <div>Powered by Ωedit v{serverVersion} on port {omegaEditPort}</div>
   <div class="latency-group flex-container row center">
     <svg class="latency-indicator">
       {#if serverLatency < 20}


### PR DESCRIPTION
- The Omega Edit server kill on DataEditWebviewPanel disposal now nullifies port
- Variables related to Omega Edit server connection were changed to be more verbose/specific, in the chance of potentially additional "serverPorts" that may be needed in the future.

Closes #528