### PR TITLE
Provides the ability to re-select values of attributes items

### DIFF
--- a/src/language/dfdl.ts
+++ b/src/language/dfdl.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs'
 import { getElementCompletionProvider } from './providers/elementCompletion'
 import { getAttributeCompletionProvider } from './providers/attributeCompletion'
 import { getCloseElementProvider } from './providers/closeElement'
+import { getAttributeValueCompletionProvider } from './providers/attributeValueCompletion'
 import { getCloseElementSlashProvider } from './providers/closeElementSlash'
 
 export function activate(context: vscode.ExtensionContext) {
@@ -34,6 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     getElementCompletionProvider(dfdlFormat),
     getAttributeCompletionProvider(),
+    getAttributeValueCompletionProvider(),
     getCloseElementProvider(),
     getCloseElementSlashProvider()
   )

--- a/src/language/providers/attributeCompletion.ts
+++ b/src/language/providers/attributeCompletion.ts
@@ -25,8 +25,10 @@ import {
   getCommonItems,
   getXsdNsPrefix,
   getItemsOnLineCount,
+  cursorWithinQuotes,
   cursorWithinBraces,
   dfdlDefaultPrefix,
+  cursorAfterEquals,
 } from './utils'
 
 import { attributeCompletion } from './intellisense/attributeItems'
@@ -76,6 +78,8 @@ export function getAttributeCompletionProvider() {
         if (
           checkBraceOpen(document, position) ||
           cursorWithinBraces(document, position) ||
+          cursorWithinQuotes(document, position) ||
+          cursorAfterEquals(document, position) ||
           nearestOpenItem.includes('none')
         ) {
           return undefined
@@ -101,7 +105,10 @@ export function getAttributeCompletionProvider() {
   )
 }
 
-function getDefinedTypes(document: vscode.TextDocument, nsPrefix: string) {
+export function getDefinedTypes(
+  document: vscode.TextDocument,
+  nsPrefix: string
+) {
   let additionalTypes = ''
   let lineNum = 0
   const lineCount = document.lineCount
@@ -229,7 +236,7 @@ function checkNearestOpenItem(
         ''
       )
     case 'discriminator':
-      return getCompletionItems(['message'], '', '', nsPrefix, '')
+      return getCompletionItems(['test', 'message'], '', '', nsPrefix, '')
     case 'format':
       return getCompletionItems(
         [

--- a/src/language/providers/attributeValueCompletion.ts
+++ b/src/language/providers/attributeValueCompletion.ts
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode'
+
+import { checkBraceOpen, cursorWithinBraces, getXsdNsPrefix } from './utils'
+import { getDefinedTypes } from './attributeCompletion'
+import {
+  attributeValues,
+  noChoiceAttributes,
+} from './intellisense/attributeValueItems'
+
+export function getAttributeValueCompletionProvider() {
+  return vscode.languages.registerCompletionItemProvider(
+    'dfdl',
+    {
+      async provideCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position
+      ) {
+        if (
+          checkBraceOpen(document, position) ||
+          cursorWithinBraces(document, position)
+        ) {
+          return undefined
+        }
+        const nsPrefix = getXsdNsPrefix(document, position)
+        let additionalItems = getDefinedTypes(document, nsPrefix)
+        let [attributeName, startPos, endPos] = getAttributeDetails(
+          document,
+          position
+        )
+
+        if (attributeName !== 'none') {
+          let replaceValue = ''
+          if (startPos === endPos) {
+            replaceValue = ' '
+          }
+
+          if (attributeName.includes(':')) {
+            attributeName = attributeName.substring(
+              attributeName.indexOf(':') + 1
+            )
+          }
+
+          if (noChoiceAttributes.includes(attributeName)) {
+            return undefined
+          }
+
+          let startPosition = position.with(position.line, startPos)
+          let endPosition = position.with(position.line, endPos + 1)
+
+          let range = new vscode.Range(startPosition, endPosition)
+
+          await vscode.window.activeTextEditor?.edit((editBuilder) => {
+            editBuilder.replace(range, replaceValue)
+          })
+
+          attributeValues(attributeName, startPosition, additionalItems)
+        }
+        return undefined
+      },
+    },
+    ' ' // triggered whenever a newline is typed
+  )
+}
+
+function getAttributeDetails(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): [attributeName: string, valueStartPos: number, valueEndPos: number] {
+  const quoteChar: string[] = ["'", '"']
+  const triggerLine = position.line
+  const triggerPos = position.character
+  let currentLine = triggerLine
+  let currentPos = triggerPos
+  let endPos = -1
+  let currentText = document.lineAt(currentLine).text
+  let textBeforeTrigger = currentText.substring(0, triggerPos)
+  let attributeName = 'none'
+  let attributeStartPos = 0
+
+  while (
+    !currentText.includes("'") &&
+    !currentText.includes('"') &&
+    !currentText.includes('=') &&
+    !currentText.includes('<') &&
+    !currentText.includes('>') &&
+    currentLine > 0 &&
+    currentLine < document.lineCount
+  ) {
+    currentText = document.lineAt(--currentLine).text
+  }
+
+  if (currentLine === 0 || currentLine === document.lineCount) {
+    return ['none', 0, 0]
+  }
+
+  if ((currentPos = textBeforeTrigger.lastIndexOf('=')) !== -1) {
+    if (triggerPos === currentPos + 1) {
+      attributeStartPos = textBeforeTrigger.lastIndexOf(' ') + 1
+      attributeName = textBeforeTrigger.substring(attributeStartPos, currentPos)
+      return [attributeName, currentPos + 1, currentPos + 1]
+    }
+  }
+
+  for (let i = 0; i < quoteChar.length; ++i) {
+    if (currentText.includes(quoteChar[i])) {
+      if (currentLine === triggerLine) {
+        currentPos = textBeforeTrigger.lastIndexOf(quoteChar[i])
+
+        if (
+          currentPos < triggerPos &&
+          textBeforeTrigger.lastIndexOf('=') === currentPos - 1
+        ) {
+          endPos = currentText.indexOf(quoteChar[i], currentPos + 1)
+          attributeStartPos = textBeforeTrigger.lastIndexOf(' ')
+          attributeName = textBeforeTrigger.substring(
+            attributeStartPos + 1,
+            currentPos - 1
+          )
+        }
+      }
+    }
+
+    if (attributeName !== 'none') {
+      break
+    }
+  }
+  return [attributeName, currentPos, endPos]
+}

--- a/src/language/providers/closeElementSlash.ts
+++ b/src/language/providers/closeElementSlash.ts
@@ -24,6 +24,8 @@ import {
   getItemPrefix,
   getItemsOnLineCount,
   cursorWithinBraces,
+  cursorWithinQuotes,
+  cursorAfterEquals,
 } from './utils'
 
 export function getCloseElementSlashProvider() {
@@ -48,7 +50,9 @@ export function getCloseElementSlashProvider() {
 
         if (
           checkBraceOpen(document, position) ||
-          cursorWithinBraces(document, position)
+          cursorWithinBraces(document, position) ||
+          cursorWithinQuotes(document, position) ||
+          cursorAfterEquals(document, position)
         ) {
           return undefined
         }
@@ -89,8 +93,10 @@ function checkItemsOnLine(
   triggerText: string
 ) {
   nsPrefix = getItemPrefix(nearestTagNotClosed, nsPrefix)
+
   if (itemsOnLine == 1 || itemsOnLine == 0) {
     insertSnippet('/>$0', backpos)
+
     if (
       nearestTagNotClosed.includes('defineVariable') ||
       nearestTagNotClosed.includes('setVariable')
@@ -111,6 +117,7 @@ function checkItemsOnLine(
     ) {
       let tagPos = triggerText.lastIndexOf('<' + nsPrefix + nearestTagNotClosed)
       let tagEndPos = triggerText.indexOf('>', tagPos)
+
       if (
         tagPos != -1 &&
         !triggerText.substring(tagEndPos - 1, 2).includes('/>') &&

--- a/src/language/providers/intellisense/attributeItems.ts
+++ b/src/language/providers/intellisense/attributeItems.ts
@@ -236,7 +236,7 @@ export const attributeCompletion = (additionalItems, nsPrefix: string, dfdlPrefi
       },
       {
         item: 'dfdl:leadingSkip',
-        snippetString: dfdlPrefix + 'trailingSkip="0$1"$0',
+        snippetString: dfdlPrefix + 'leadingSkip="0$1"$0',
         markdownString: 'A non-negative number of bytes or bits to skip before alignment is applied',
       },
       {

--- a/src/language/providers/intellisense/attributeValueItems.ts
+++ b/src/language/providers/intellisense/attributeValueItems.ts
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode'
+import { insertSnippet } from '../utils'
+
+export const noChoiceAttributes = [
+  'name',
+  'ref',
+  'occursCount',
+  'length',
+  'prefixLengthType',
+  'nilValue',
+  'lengthPattern',
+  'inputValueCalc',
+  'outputValueCalc',
+  'hiddenGroupRef',
+  'choiceBranchKey',
+  'textNumberRoundingIncrement',
+  'separator',
+  'terminator',
+  'choiceLength',
+  'fillByte',
+  'initiator',
+  'choiceDispatchKey',
+  'escapeSchemeRef',
+  'test',
+  'testPattern',
+  'message',
+]
+
+export function attributeValues(
+  attributeName: string,
+  startPos: vscode.Position,
+  additionalTypes: string
+) {
+  switch (attributeName) {
+    case 'minOccurs':
+      insertSnippet('"${1|0,1|}"$0', startPos)
+      break
+    case 'maxOccurs':
+      insertSnippet('"${1|0,1,unbounded|}"$0', startPos)
+      break
+    case 'occursCount':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'byteOrder':
+      insertSnippet('"${1|bigEndian,littleEndian|}"$0', startPos)
+      break
+    case 'bitOrder':
+      insertSnippet(
+        '"${1|mostSignificantBitFirst,leastSignificantBitFirst|}"$0',
+        startPos
+      )
+      break
+    case 'occursCountKind':
+      insertSnippet(
+        '"${1|expression,fixed,implicit,parsed,stopValue|}"$0',
+        startPos
+      )
+      break
+    case 'length':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'lengthKind':
+      insertSnippet(
+        '"${1|delimited,fixed,explicit,implicit,prefixed,patternendOfParent|}"$0',
+        startPos
+      )
+      break
+    case 'prefixIncludesPrefixLength':
+      insertSnippet('"${1|yes,no|}"$0', startPos)
+      break
+    case 'prefixLengthType':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'utf16Width':
+      insertSnippet('"${1|fixed,variable|}"$0', startPos)
+      break
+    case 'encoding':
+      insertSnippet(
+        '"${1|US-ASCII,ASCII,UTF-8,UTF-16,UTF-16BE,UTF-16LE,ISO-8859-1|}"$0',
+        startPos
+      )
+      break
+    case 'encodingErrorPolicy':
+      insertSnippet('"${1|error,replace|}"$0', startPos)
+      break
+    case 'nilKind':
+      insertSnippet(
+        '"${1|literalCharacter,literalValue,logicalValue|}"$0',
+        startPos
+      )
+      break
+    case 'nilValue':
+      insertSnippet('nilValue="$1"$0', startPos)
+      break
+    case 'nilValueDelimiterPolicy':
+      insertSnippet('"${1|initiator,terminator,both,none|}"$0', startPos)
+      break
+    case 'alignment':
+      insertSnippet('"${1|1,2,implicit|}"$0', startPos)
+      break
+    case 'lengthUnits':
+      insertSnippet('"${1|bits,bytes,characters|}"$0', startPos)
+      break
+    case 'lengthPattern':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'inputValueCalc':
+      insertSnippet('"{$1}"$0', startPos)
+      break
+    case 'outputValueCalc':
+      insertSnippet('"{$1}"$0', startPos)
+      break
+    case 'alignmentUnits':
+      insertSnippet('"${1|bits,bytes|}"$0', startPos)
+      break
+    case 'outputNewLine':
+      insertSnippet('"${1|%CR;,%LF;,%CR;%LF;,%NEL;,%LS;|}"$0', startPos)
+      break
+    case 'choiceBranchKey':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'representation':
+      insertSnippet('"${1|binary,text|}"$0', startPos)
+      break
+    case 'textStringJustification':
+      insertSnippet('"${1|left,right,center|}"$0', startPos)
+      break
+    case 'textStandardZeroRep':
+      insertSnippet('"0"$0', startPos)
+      break
+    case 'textStandardInfinityRep':
+      insertSnippet('"Inf"$0', startPos)
+      break
+    case 'textStandardExponentRep':
+      insertSnippet('"E"$0', startPos)
+      break
+    case 'textStandardNaNRep':
+      insertSnippet('"NaN"$0', startPos)
+      break
+    case 'textNumberPattern':
+      insertSnippet('"#,##0.###;-#,##0.###"$0', startPos)
+      break
+    case 'textNumberRep':
+      insertSnippet('"${1|standard,zoned|}"$0', startPos)
+      break
+    case 'textNumberRoundingMode':
+      insertSnippet(
+        '"${1|roundCeiling,roundFloor,roundDown,roundUp,roundHalfEven,roundHalfDown,roundHalfUp,roundUnnecessary|}"$0',
+        startPos
+      )
+      break
+    case 'textNumberRoundingIncrement':
+      insertSnippet('"0"$0', startPos)
+      break
+    case 'textNumberRounding':
+      insertSnippet('"${1|explicit,pattern|}"$0', startPos)
+      break
+    case 'textNumberCheckPolicy':
+      insertSnippet('"${1|lax,strict|}"$0', startPos)
+      break
+    case 'textOutputMinLength':
+      insertSnippet('"0"$0', startPos)
+      break
+    case 'textStandardGroupingSeparator':
+      insertSnippet('","$0', startPos)
+      break
+    case 'textPadKind':
+      insertSnippet('"${1|none,padChar|}"$0', startPos)
+      break
+    case 'textStandardBase':
+      insertSnippet('"${1|2,8,10,16|}"$0', startPos)
+      break
+    case 'textTrimKind':
+      insertSnippet('"${1|none,padChar|}"$0', startPos)
+      break
+    case 'leadingSkip':
+      insertSnippet('"0$1"$0', startPos)
+      break
+    case 'trailingSkip':
+      insertSnippet('"0$1"$0', startPos)
+      break
+    case 'truncateSpecifiedLengthString':
+      insertSnippet('"${1|no,yes|}"$0', startPos)
+      break
+    case 'sequenceKind':
+      insertSnippet('"${1|ordered,unordered|}"$0', startPos)
+      break
+    case 'separator':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'separatorPosition':
+      insertSnippet('"${1|infix,postfix,prefix|}"$0', startPos)
+      break
+    case 'separatorSuppressionPolicy':
+      insertSnippet(
+        '"${1|anyEmpty,never,trailingEmpty,trailingEmptyStrict|}"$0',
+        startPos
+      )
+      break
+    case 'terminator':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'textBidi':
+      insertSnippet('"${1|no,yes|}"$0', startPos)
+      break
+    case 'hiddenGroupRef':
+      insertSnippet('"$1"\n$0', startPos)
+      break
+    case 'choiceLengthKind':
+      insertSnippet('"${1|explicit,implicit|}"$0', startPos)
+      break
+    case 'choiceLength':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'fillByte':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'ignoreCase':
+      insertSnippet('"${1|no,yes|}"$0', startPos)
+      break
+    case 'initiatedContent':
+      insertSnippet('"${1|yes,no|}"$0', startPos)
+      break
+    case 'initiator':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'choiceDispatchKey':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'binaryNumberRep':
+      insertSnippet('"${1|binary,packed,bcd,ibm4690Packed|}"$0', startPos)
+      break
+    case 'floating':
+      insertSnippet('"${1|no,yes|}"$0', startPos)
+      break
+    case 'binaryFloatRep':
+      insertSnippet('"${1|ieee,ibm390Hex|}"$0', startPos)
+      break
+    case 'calendarPatternKind':
+      insertSnippet('"${1|explicit,implicit|}"$0', startPos)
+      break
+    case 'documentFinalTerminatorCanBeMissing':
+      insertSnippet('"${1|yes,no|}"$0', startPos)
+      break
+    case 'emptyValueDelimiterPolicy':
+      insertSnippet('"${1|initiator,terminator,both,none|}"$0', startPos)
+      break
+    case 'escapeSchemeRef':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'testKind':
+      insertSnippet('"${1|expression,pattern|}"$0', startPos)
+      break
+    case 'test':
+      insertSnippet('"{$1}"$0', startPos)
+      break
+    case 'testPattern':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'message':
+      insertSnippet('"$1"$0', startPos)
+      break
+    case 'failureType':
+      insertSnippet('"${1|processingError,recoverableError|}"$0', startPos)
+      break
+    case 'type':
+      insertSnippet(
+        '"${1|xs:string,xs:decimal,xs:float,xs:double,xs:integer,xs:nonNegativeInteger,xs:int,xs:unsignedInt,xs:short,xs:unsignedShort,xs:long,xs:unsignedLong,xs:byte,xs:unsignedByte,xs:hexBinary,xs:boolean' +
+          additionalTypes +
+          '|}"$0',
+        startPos
+      )
+      break
+  }
+}

--- a/src/language/providers/intellisense/elementItems.ts
+++ b/src/language/providers/intellisense/elementItems.ts
@@ -53,12 +53,12 @@ export const elementCompletion = (definedVariables, dfdlFormatString, nsPrefix) 
       },
       {
         item: 'dfdl:assert',
-        snippetString: '<dfdl:assert>$1\n</dfdl:assert>$0',
+        snippetString: '<dfdl:assert $0',
         markdownString: 'Used to assert truths about a DFDL model',
       },
       {
         item: 'dfdl:discriminator',
-        snippetString: '<dfdl:discriminator test="{$1}"/>$0',
+        snippetString: '<dfdl:discriminator $0',
         markdownString: 'Used during parsing to resolve points or uncertainity, remove ambiguity during speculative parsing, improve diagnostic behavior',
       },
       {
@@ -159,6 +159,21 @@ export const elementCompletion = (definedVariables, dfdlFormatString, nsPrefix) 
         item: 'maxExclusive',
         snippetString: '<' + nsPrefix + 'maxExclusive value="$1"/>$0',
         markdownString: 'Used to check the validity of an element'
+      },
+      {
+        item: '<[CDATA[]]>',
+        snippetString: '<[CDATA[$1]]>$0',
+        markdownString: ''
+      },
+      {
+        item: '<![CDATA[]]>',
+        snippetString: '<![CDATA[$1]]>$0',
+        markdownString: ''
+      },
+      {
+        item: '{}',
+        snippetString: '{$1}$0',
+        markdownString: ''
       },
     ],
   }

--- a/src/tests/suite/language/items.test.ts
+++ b/src/tests/suite/language/items.test.ts
@@ -51,6 +51,9 @@ suite('Items Test Suite', () => {
     'minExclusive',
     'maxInclusive',
     'maxExclusive',
+    '<[CDATA[]]>',
+    '<![CDATA[]]>',
+    '{}',
   ]
   const expectedAttributeItems = [
     'name',


### PR DESCRIPTION
- add logic to mitigate missing dfdl prefixes
- tweak logic to determine if cursor is between quotes
- Fixes incorrect velues triggered by nested elements
- fixes the resulting choice when intellisense is trigger between two closing tags on a multi tag line
- fix wrong suggestions at end of schema open tag
- fix incorrect suggestion at beginning and end of a multi tag line
- fix broken attribute suggestions from inside multiline tag
- fixed cursor between alert open and close tags was returning
    results for appinfo
- Change logic to for assert and discriminator auto complete

Closes #573
Closes #577
Closes #578