### PR TITLE
add Hitesh Dalsania as a project collaborator

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,6 +25,7 @@ github:
     merge:    false
     rebase:   true
   collaborators:
+    - hdalsania
     - michael-hoke
     - NolanMatt
     - rthomas320
@@ -33,4 +34,3 @@ notifications:
     commits:      commits@daffodil.apache.org
     issues:       commits@daffodil.apache.org
     pullrequests: commits@daffodil.apache.org
-


### PR DESCRIPTION
This commit will allow Hitesh Dalsania to be a project collaborator.  Hitesh will be able to assist with issue triage, labeling, milestone assignment, and developer assignment.  Hitesh can also assist with milestone development, requirements, and documentation.