### PR TITLE
omega-edit release fix

### DIFF
--- a/build/package/.vscodeignore
+++ b/build/package/.vscodeignore
@@ -28,7 +28,8 @@
 !src/styles/styles.css
 !src/omega_edit/omega_edit.js
 !src/omega_edit/interface.html
-!node_modules/omega-edit/omega-edit-grpc-server*.zip
+!node_modules/@omega-edit/server/bin
+!node_modules/@omega-edit/server/lib
 !src/language/providers/intellisense/DFDLGeneralFormat.dfdl.xsd
 !dist/styles.css
 !dist/views/dataEditor/index.js


### PR DESCRIPTION
Was preparing a release but testing locally I found the omega-edit data editor did not run when the extension was installed via VSIX. This update fixes that issue as the server binary could not be found when installed via VSIX because it was not bundled into the VSIX.