### PR TITLE
Launch wizard updates and rename data editor vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,7 +343,7 @@
               },
               "infosetOutput": {
                 "type": "object",
-                "description": "Destination for final Infoset (file-path | 'console' | 'none')",
+                "description": "Destination for final Infoset ('file' | 'console' | 'none')",
                 "default": {
                   "type": "console",
                   "path": "${workspaceFolder}/infoset.xml"
@@ -413,27 +413,14 @@
                 },
                 "default": {}
               },
-              "dataEditor.omegaEditPort": {
-                "type": "integer",
-                "description": "Editor server default port",
-                "default": 9000
-              },
-              "dataEditor.logFile": {
-                "type": "string",
-                "description": "Path to log file for data editor",
-                "default": "${workspaceFolder}/dataEditor-${omegaEditPort}.log"
-              },
-              "dataEditor.logLevel": {
-                "type": "string",
-                "description": "Log level for data editor",
-                "enum": [
-                  "error",
-                  "warn",
-                  "info",
-                  "debug",
-                  "trace"
-                ],
-                "default": "info"
+              "dataEditor": {
+                "type": "object",
+                "description": "Configuration for Data Editor. Settings are port, logFile and logLevel",
+                "default": {
+                  "port": 9000,
+                  "logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
+                  "logLevel": "info"
+                }
               }
             }
           }
@@ -464,9 +451,11 @@
             "daffodilDebugClasspath": "",
             "variables": {},
             "tunables": {},
-            "dataEditor.omegaEditPort": 9000,
-            "dataEditor.logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
-            "dataEditor.logLevel": "info"
+            "dataEditor": {
+              "port": 9000,
+              "logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
+              "logLevel": "info"
+            }
           }
         ],
         "configurationSnippets": [
@@ -498,9 +487,11 @@
               "daffodilDebugClasspath": "",
               "variables": {},
               "tunables": {},
-              "dataEditor.omegaEditPort": 9000,
-              "dataEditor.logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
-              "dataEditor.logLevel": "info"
+              "dataEditor": {
+                "port": 9000,
+                "logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
+                "logLevel": "info"
+              }
             }
           }
         ],
@@ -560,7 +551,7 @@
           },
           "infosetOutputType": {
             "type": "string",
-            "description": "Destination for final Infoset (file | 'console' | 'none')",
+            "description": "Destination for final Infoset ('file' | 'console' | 'none')",
             "enum": [
               "file",
               "console",
@@ -627,17 +618,17 @@
             },
             "default": {}
           },
-          "dataEditor.omegaEditPort": {
+          "dataEditorPort": {
             "type": "integer",
             "description": "Editor server default port",
             "default": 9000
           },
-          "dataEditor.logFile": {
+          "dataEditorLogFile": {
             "type": "string",
             "description": "Path to log file for data editor",
             "default": "${workspaceFolder}/dataEditor-${omegaEditPort}.log"
           },
-          "dataEditor.logLevel": {
+          "dataEditorLogLevel": {
             "type": "string",
             "description": "Log level for data editor",
             "enum": [

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -23,6 +23,7 @@ import * as dataEditClient from '../dataEdit/client'
 import { getConfig, getCurrentConfig, setCurrentConfig } from '../utils'
 import { DaffodilDebugSession } from './daffodilDebug'
 import { FileAccessor } from './daffodilRuntime'
+import { TDMLConfig } from '../classes/tdmlConfig'
 
 /** Method to file path for program and data
  * Details:
@@ -491,11 +492,4 @@ class InlineDebugAdapterFactory
       new DaffodilDebugSession(workspaceFileAccessor)
     )
   }
-}
-
-export interface TDMLConfig {
-  action: String
-  name: String
-  description: String
-  path: String
 }

--- a/src/classes/dataEditor.ts
+++ b/src/classes/dataEditor.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface DataEditorConfig {
+  port: number
+  logFile: string
+  logLevel: string
+}

--- a/src/classes/tdmlConfig.ts
+++ b/src/classes/tdmlConfig.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface TDMLConfig {
+  action: String
+  name: String
+  description: String
+  path: String
+}

--- a/src/dataEdit/client.ts
+++ b/src/dataEdit/client.ts
@@ -95,8 +95,8 @@ async function getOmegaEditPort() {
       .get<Array<Object>>('configurations')
       ?.forEach((config) => {
         omegaEditPort =
-          'dataEditor.omegaEditPort' in config
-            ? (config['dataEditor.omegaEditPort'] as number)
+          'dataEditor' in config && 'port' in (config['dataEditor'] as object)
+            ? ((config['dataEditor'] as object)['port'] as number)
             : omegaEditPort
       })
 

--- a/src/launchWizard/launchWizard.js
+++ b/src/launchWizard/launchWizard.js
@@ -74,6 +74,7 @@ function updateInfosetOutputType() {
 }
 
 // Function to update select TDML action
+// tdml items need 0 height and width when hidden so there is no large empty space
 function updateTDMLAction() {
   var tdmlSelectionBox = document.getElementById('tdmlAction')
   var tdmlSelectedValue =
@@ -82,20 +83,33 @@ function updateTDMLAction() {
   if (tdmlSelectedValue !== 'none') {
     document.getElementById('tdmlNameLabel').style =
       'margin-top: 10px; visibility: visible;'
+    document.getElementById('tdmlName').style =
+      'margin-top: 10px; visibility: visible;'
     document.getElementById('tdmlDescriptionLabel').style =
       'margin-top: 10px; visibility: visible;'
+    document.getElementById('tdmlDescription').style =
+      'margin-top: 10px; visibility: visible;'
   } else {
+    document.getElementById('tdmlNameLabel').style =
+      'width: 0px; height: 0px; visibility: hidden;'
+    document.getElementById('tdmlName').style =
+      'width: 0px; height: 0px; visibility: hidden;'
     document.getElementById('tdmlDescriptionLabel').style =
-      'visibility: hidden;'
-    document.getElementById('tdmlDescriptionLabel').style =
-      'visibility: hidden;'
+      'width: 0px; height: 0px; visibility: hidden;'
+    document.getElementById('tdmlDescription').style =
+      'width: 0px; height: 0px; visibility: hidden;'
   }
 
   if (tdmlSelectedValue === 'generate') {
+    document.getElementById('tdmlPathLabel').style =
+      'margin-top: 10px; visibility: visible;'
     document.getElementById('tdmlPath').style =
       'margin-top: 10px; visibility: visible;'
   } else {
-    document.getElementById('tdmlPath').style = 'visibility: hidden;'
+    document.getElementById('tdmlPathLabel').style =
+      'width: 0px; height: 0px; visibility: hidden;'
+    document.getElementById('tdmlPath').style =
+      'width: 0px; height: 0px; visibility: hidden;'
   }
 }
 
@@ -158,6 +172,11 @@ function save() {
   const stopOnEntry = document.getElementById('stopOnEntry').checked
   const trace = document.getElementById('trace').checked
   const useExistingServer = document.getElementById('useExistingServer').checked
+  const dataEditorPort = parseInt(
+    document.getElementById('dataEditorPort').value
+  )
+  const dataEditorLogFile = document.getElementById('dataEditorLogFile').value
+  const dataEditorLogLevel = document.getElementById('dataEditorLogLevel').value
 
   let list = document.getElementById('daffodilDebugClasspathTable')
 
@@ -199,6 +218,11 @@ function save() {
         openInfosetView: openInfosetView,
         openInfosetDiffView: openInfosetDiffView,
         daffodilDebugClasspath: daffodilDebugClasspath,
+        dataEditorConfig: {
+          port: dataEditorPort,
+          logFile: dataEditorLogFile,
+          logLevel: dataEditorLogLevel,
+        },
       },
     ],
   }
@@ -251,6 +275,12 @@ async function updateConfigValues(config) {
   document.getElementById('trace').checked = config.trace
   document.getElementById('useExistingServer').checked =
     config.useExistingServer
+  document.getElementById('dataEditorPort').value = parseInt(
+    config.dataEditorPort
+  )
+  document.getElementById('dataEditorLogFile').value = config.dataEditorLogFile
+  document.getElementById('dataEditorLogLevel').value =
+    config.dataEditorLogLevel
 
   updateInfosetOutputType()
   updateTDMLAction()

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -32,9 +32,20 @@ export async function activate(ctx: vscode.ExtensionContext) {
 
 // Function to get config values
 function getConfigValues(data, configIndex) {
-  return data && configIndex !== -1
-    ? data.configurations[configIndex]
-    : defaultConf
+  if (data && configIndex !== -1) {
+    let currentConfig = data.configurations[configIndex]
+
+    // make sure config has needed items set, if not update it
+    for (var key of Object.keys(defaultConf)) {
+      if (!currentConfig.hasOwnProperty(key)) {
+        currentConfig[key] = defaultConf[key]
+      }
+    }
+
+    return currentConfig
+  } else {
+    return defaultConf
+  }
 }
 
 /**
@@ -280,6 +291,8 @@ class LaunchWizard {
 
     let defaultValues = getConfigValues(fileData, configIndex)
 
+    // vscode.window.showInformationMessage(JSON.stringify(fileData))
+
     let nameVisOrHiddenStyle = newConfig
       ? 'margin-top: 10px; visibility: visible;'
       : 'visibility: hidden;'
@@ -324,11 +337,7 @@ class LaunchWizard {
     let infosetOutputTypeSelect = ''
     let infosetOutputTypes = ['none', 'console', 'file']
     let infosetOutputType = defaultValues.infosetOutput['type']
-      ? defaultValues.infosetOutput['type']
-      : defaultValues.infosetOutputType
     let infosetOutputPath = defaultValues.infosetOutput['path']
-      ? defaultValues.infosetOutput['path']
-      : defaultValues.infosetOutputFilePath
     let infosetPathVisOrHiddenStyle =
       infosetOutputType === 'file'
         ? 'margin-top: 10px; visibility: visible;'
@@ -345,25 +354,19 @@ class LaunchWizard {
     let tdmlActionSelect = ''
     let tdmlActions = ['none', 'generate', 'append', 'execute']
     let tdmlAction = defaultValues.tdmlConfig['action']
-      ? defaultValues.tdmlConfig['type']
-      : defaultValues.tdmlAction
     let tdmlName = defaultValues.tdmlConfig['name']
-      ? defaultValues.tdmlConfig['name']
-      : defaultValues.tdmlName
     let tdmlDescription = defaultValues.tdmlConfig['description']
-      ? defaultValues.tdmlConfig['description']
-      : defaultValues.tdmlDescription
     let tdmlPath = defaultValues.tdmlConfig['path']
-      ? defaultValues.tdmlConfig['path']
-      : defaultValues.tdmlPath
+
+    // tdml items need 0 height and width when hidden so there is no large empty space
     let tdmlNameDesVisOrHiddenStyle =
       tdmlAction !== 'none'
         ? 'margin-top: 10px; visibility: visible;'
-        : 'visibility: hidden'
+        : 'width: 0px; height: 0px; visibility: hidden'
     let tdmlPathVisOrHiddenStyle =
       tdmlAction === 'generate'
         ? 'margin-top: 10px; visibility: visible;'
-        : 'visibility: hidden'
+        : 'width: 0px; height: 0px; visibility: hidden'
 
     tdmlActions.forEach((action) => {
       if (action === tdmlAction) {
@@ -372,6 +375,10 @@ class LaunchWizard {
         tdmlActionSelect += `<option value="${action}">${action}</option>`
       }
     })
+
+    let dataEditorPort = defaultValues.dataEditorConfig['port']
+    let dataEditorLogFile = defaultValues.dataEditorConfig['logFile']
+    let dataEditorLogLevel = defaultValues.dataEditorConfig['logLevel']
 
     return `
   <!DOCTYPE html>
@@ -492,17 +499,14 @@ class LaunchWizard {
           ${tdmlActionSelect}
         </select>
 
-        <p id="tdmlNameLabel" style="${tdmlNameDesVisOrHiddenStyle}" class="setting-description">
-          TDML Name: <input class="setting-div" value="${tdmlName}" id="tdmlName">
-        </p>
+        <p id="tdmlNameLabel" style="${tdmlNameDesVisOrHiddenStyle}" class="setting-description">TDML Name:</p>
+        <input style="${tdmlNameDesVisOrHiddenStyle}" class="file-input" value="${tdmlName}" id="tdmlName">
 
-        <p id="tdmlDescriptionLabel" style="${tdmlNameDesVisOrHiddenStyle}" class="setting-description">
-          TDML Description: <input class="setting-div" value="${tdmlDescription}" id="tdmlDescription">
-        </p>
+        <p id="tdmlDescriptionLabel" style="${tdmlNameDesVisOrHiddenStyle}" class="setting-description">TDML Description:</p>
+        <input style="${tdmlNameDesVisOrHiddenStyle}" class="file-input" value="${tdmlDescription}" id="tdmlDescription">
 
-        <p id="tdmlPathLabel" style="${tdmlPathVisOrHiddenStyle}" class="file-input">
-          TDML File Path: <input class="file-input" value="${tdmlPath}" id="tdmlPath">
-        </p>
+        <p id="tdmlPathLabel" style="${tdmlPathVisOrHiddenStyle}" class="setting-description">TDML File Path:</p>
+        <input style="${tdmlPathVisOrHiddenStyle}" class="file-input" value="${tdmlPath}" id="tdmlPath">
       </div>
 
       <div id="programDiv" class="setting-div">
@@ -526,6 +530,19 @@ class LaunchWizard {
           <input type="checkbox" id="trace" ${trace}>
           <span class="checkmark"></span>
         </label>
+      </div>
+
+      <div id="dataEditorDiv" class="setting-div">
+        <p>Data Editor Settings:</p>
+        
+        <p id="dataEditorPortLabel" class="setting-description">omega-edit Port:</p>
+        <input class="file-input" value="${dataEditorPort}" id="dataEditorPort">
+
+        <p id="dataEditorLogFileLabel" style="margin-top: 10px;" class="setting-description">Log File:</p>
+        <input class="file-input" value="${dataEditorLogFile}" id="dataEditorLogFile">
+        
+        <p id="dataEditorLogLevelLabel" style="margin-top: 10px;" class="setting-description">Log Level:</p>
+        <input class="file-input" value="${dataEditorLogLevel}" id="dataEditorLogLevel">
       </div>
 
       <div id="useExistingServerDiv" class="setting-div" onclick="check('useExistingServer')">

--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -48,6 +48,19 @@ suite('Daffodil Debugger', () => {
   const JSON_INFOSET_PATH = path.join(PROJECT_ROOT, 'testinfoset.json')
   const debuggers: vscode.Terminal[] = []
 
+  const tdmlConf = {
+    action: 'none',
+    name: 'tdmlConf',
+    description: 'testtdml',
+    path: TDML_PATH,
+  }
+
+  const dataEditorConfig = {
+    port: 9000,
+    logFile: 'dataEditor-9000.log',
+    logLevel: 'info',
+  }
+
   before(async () => {
     await unzipFile(SCALA_PATH, PROJECT_ROOT)
     debuggers.push(
@@ -67,12 +80,7 @@ suite('Daffodil Debugger', () => {
     if (fs.existsSync(XML_INFOSET_PATH)) fs.rmSync(XML_INFOSET_PATH)
     if (fs.existsSync(JSON_INFOSET_PATH)) fs.rmSync(JSON_INFOSET_PATH)
   })
-  const tdmlConf = {
-    action: 'none',
-    name: 'tdmlConf',
-    description: 'testtdml',
-    path: TDML_PATH,
-  }
+
   test('should output xml infoset', async () => {
     await vscode.debug.startDebugging(
       undefined,
@@ -88,7 +96,8 @@ suite('Daffodil Debugger', () => {
           type: 'file',
           path: XML_INFOSET_PATH,
         },
-        tdmlConf
+        tdmlConf,
+        dataEditorConfig
       ),
       { noDebug: true }
     )
@@ -111,7 +120,8 @@ suite('Daffodil Debugger', () => {
           type: 'file',
           path: JSON_INFOSET_PATH,
         },
-        tdmlConf
+        tdmlConf,
+        dataEditorConfig
       ),
       { noDebug: true }
     )

--- a/src/tests/suite/utils.test.ts
+++ b/src/tests/suite/utils.test.ts
@@ -48,6 +48,11 @@ suite('Utils Test Suite', () => {
     openInfosetView: false,
     openInfosetDiffView: false,
     daffodilDebugClasspath: '',
+    dataEditorConfig: {
+      port: 9000,
+      logFile: '${workspaceFolder}/dataEditor-${omegaEditPort}.log',
+      logLevel: 'info',
+    },
   }
 
   test('Default config', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,8 @@ import * as unzip from 'unzip-stream'
 import * as os from 'os'
 import * as child_process from 'child_process'
 import path from 'path'
-import { TDMLConfig } from './adapter/activateDaffodilDebug'
+import { TDMLConfig } from './classes/tdmlConfig'
+import { DataEditorConfig } from './classes/dataEditor'
 
 const defaultConf = vscode.workspace.getConfiguration()
 let currentConfig: vscode.DebugConfiguration
@@ -90,6 +91,7 @@ export function getConfig(
   infosetFormat: string | null = null,
   infosetOutput: object | null = null,
   tdmlConfig: TDMLConfig | null = null,
+  dataEditorConfig: DataEditorConfig | null = null,
   stopOnEntry = false,
   useExistingServer = false,
   trace = false,
@@ -149,6 +151,16 @@ export function getConfig(
     daffodilDebugClasspath: daffodilDebugClasspath
       ? daffodilDebugClasspath
       : defaultConf.get('daffodilDebugClasspath', ''),
+    dataEditorConfig: dataEditorConfig
+      ? dataEditorConfig
+      : {
+          port: defaultConf.get('dataEditorPort', 9000),
+          logFile: defaultConf.get(
+            'dataEditorLogFile',
+            '${workspaceFolder}/dataEditor-${omegaEditPort}.log'
+          ),
+          logLevel: defaultConf.get('dataEditorLogLevel', 'info'),
+        },
   }
 }
 


### PR DESCRIPTION
Launch wizard updates and rename data editor vars:

- Rename variables dataEditor.* to be under an object called dataEditorConfig.
  - The variables that can be inside of that object are omegaEditPort, logFile and logLevel
- Add missing config keys and values to parsed configs.
  - If not done this causes the launch wizard to not open.
- Fix a issue with some TDML settings not showing up properly.
- Update TDML config settings styling to better match the rest of the launch wizard.
  - When these items are hidden, the height and width are set to 0 so no large black space would be created in the UI.
- Add support for setting data editor settings. These were omegaEditPort, logFile and logLevel.
- Don't show TDML name field when action is set to "none".

Closes #617
Closes #619
Closes #621