### PR TITLE
Save debugger output to a file

### DIFF
--- a/src/daffodilDebuggerUtils.ts
+++ b/src/daffodilDebuggerUtils.ts
@@ -52,11 +52,20 @@ export const stopDebugger = (id: number | undefined = undefined) =>
 export const shellPath = (scriptName: string) =>
   osCheck(scriptName, '/bin/bash')
 
-export const shellArgs = (scriptName: string, port: number) =>
-  osCheck(
+export const shellArgs = (scriptName: string, port: number) => {
+  const logPath = vscode.workspace.workspaceFolders
+    ? vscode.workspace.workspaceFolders[0].uri.fsPath
+    : '/tmp'
+
+  return osCheck(
     ['--listenPort', `${port}`],
-    ['--login', '-c', `${scriptName} --listenPort ${port}`]
+    [
+      '--login',
+      '-c',
+      `${scriptName} --listenPort ${port} | tee ${logPath}/debugger-${port}-output.txt`,
+    ]
   )
+}
 
 export async function runDebugger(
   rootPath: string,


### PR DESCRIPTION
Save debugger output to a file

- Use "tee" for mac/linux to save debugger output to a file.

Closes #614