### PR TITLE
Keep terminal open after debug ends

### DIFF
--- a/src/daffodilDebuggerUtils.ts
+++ b/src/daffodilDebuggerUtils.ts
@@ -49,20 +49,17 @@ export async function buildDebugger(baseFolder: string, filePath: string) {
 export const stopDebugger = (id: number | undefined = undefined) =>
   child_process.exec(osCheck(`taskkill /F /PID ${id}`, `kill -9 ${id}`))
 
-export const shellPath = (scriptName: string) =>
-  osCheck(scriptName, '/bin/bash')
-
-export const shellArgs = (scriptName: string, port: number) =>
-  osCheck(
-    ['--listenPort', `${port}`],
-    ['--login', '-c', `${scriptName} --listenPort ${port}`]
-  )
+export const shellArgs = (scriptName: string, port: number) => [
+  '--listenPort',
+  `${port}`,
+]
 
 export async function runDebugger(
   rootPath: string,
   daffodilDebugClasspath: string,
   filePath: string,
-  serverPort: number
+  serverPort: number,
+  createTerminal: boolean = false
 ): Promise<vscode.Terminal> {
   const dfdlVersion = daffodilVersion(filePath)
   const artifact = daffodilArtifact(dfdlVersion)
@@ -80,7 +77,7 @@ export async function runDebugger(
   return await runScript(
     scriptPath,
     artifact.scriptName,
-    shellPath(artifact.scriptName),
+    createTerminal,
     shellArgs(artifact.scriptName, serverPort),
     {
       DAFFODIL_DEBUG_CLASSPATH: daffodilDebugClasspath,

--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -50,8 +50,12 @@ suite('Daffodil Debugger', () => {
 
   before(async () => {
     await unzipFile(SCALA_PATH, PROJECT_ROOT)
-    debuggers.push(await runDebugger(PROJECT_ROOT, '', PACKAGE_PATH, 4711))
-    debuggers.push(await runDebugger(PROJECT_ROOT, '', PACKAGE_PATH, 4712))
+    debuggers.push(
+      await runDebugger(PROJECT_ROOT, '', PACKAGE_PATH, 4711, true)
+    )
+    debuggers.push(
+      await runDebugger(PROJECT_ROOT, '', PACKAGE_PATH, 4712, true)
+    )
   })
 
   after(async () => {


### PR DESCRIPTION
Keep terminal open after debug ends

- Grab active terminal if its a proper shell that can run a command, otherwise create a new one.
- Send command to run debugger to terminal.
- This allows for the terminal to stay open after the debugger exists.
- Allow for option to always create new terminal. This is mostly to support testing purposes.

Closes #614 