### PR TITLE
add Larry Barber as a Daffodil-VSCode collaborator

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,6 +26,7 @@ github:
     rebase:   true
   collaborators:
     - hdalsania
+    - lrbarber
     - michael-hoke
     - nlewis05
     - NolanMatt


### PR DESCRIPTION
This PR is to add Larry Barber to the Daffodil-VSCode project as a collaborator.  Larry has been responsible for testing and guiding the user experience.  He also plans to develop some instructional media to help promote and gain more adoption of the Daffodil technology by leveraging the Daffodil-VSCode extension.

closes #633.