### PR TITLE
Fix issue with launch wizard parsing

### DIFF
--- a/src/launchWizard/launchWizard.js
+++ b/src/launchWizard/launchWizard.js
@@ -182,13 +182,21 @@ function save() {
 
   let daffodilDebugClasspath = ''
 
-  for (var i = 0; i < list.childNodes.length; i++) {
-    let item = list.childNodes[i]
-    let classpath = item.innerHTML.split('"')[3]
+  list.childNodes.forEach((childNode) => {
+    let classpath = childNode.textContent
+      .replaceAll(' ', '') // remove any un-needed whitespace
+      .replace('-', '') // remove initial - in front of every item
+      .split('\n')
+      .filter((cp) => cp != '')
+      .join(':')
 
-    daffodilDebugClasspath +=
-      i === list.childNodes.length - 1 ? classpath : classpath + ':'
-  }
+    if (classpath != '') {
+      daffodilDebugClasspath +=
+        childNode === list.childNodes[list.childNodes.length - 1]
+          ? classpath
+          : classpath + ':'
+    }
+  })
 
   var obj = {
     version: '0.2.0',
@@ -218,7 +226,7 @@ function save() {
         openInfosetView: openInfosetView,
         openInfosetDiffView: openInfosetDiffView,
         daffodilDebugClasspath: daffodilDebugClasspath,
-        dataEditorConfig: {
+        dataEditor: {
           port: dataEditorPort,
           logFile: dataEditorLogFile,
           logLevel: dataEditorLogLevel,

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -199,10 +199,14 @@ async function createWizard(ctx: vscode.ExtensionContext) {
           return
         case 'openFilePicker':
           let result = await openFilePicker(message.description)
-          panel.webview.postMessage({
-            command: `${message.id}Update`,
-            value: result,
-          })
+
+          // don't add empty string to table
+          if (result !== '') {
+            panel.webview.postMessage({
+              command: `${message.id}Update`,
+              value: result,
+            })
+          }
           return
       }
     },


### PR DESCRIPTION
Fix issue with launch wizard parsing

- Update launch wizard to parse the daffodilDebuggerClasspathTable items textContent instead of innerHTML.
  - Using innerHTML was causing an issue where the wizard would set the classpath as the css class name "debug-classpath-item" instead of its actual value.
