### PR TITLE
Remove debugger extension config from launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,24 +19,6 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"type": "dfdl",
-			"request": "launch",
-			"name": "DfdlDeb",
-			"program": "${command:AskForProgramName}",
-			"stopOnEntry": true,
-			"data": "${command:AskForDataName}",
-			"infosetFormat": "xml",
-			"infosetOutput": {
-				"type": "file",
-				"path": "${workspaceFolder}/infoset.xml"
-			},
-			"debugServer": 4711,
-			"openHexView": false,
-			"openInfosetView": false,
-			"openInfosetDiffView": false,
-			"daffodilDebugClasspath": ""
-		},
-		{
 			"name": "Extension",
 			"type": "extensionHost",
 			"request": "launch",


### PR DESCRIPTION
Remove debugger extension config from launch.json

- The removed config from .vscode/launch.json is a config for running a debug session.
  - We don't want this in this .vscode/launch.json as it should be used for running the extension, running extension tests or running the debugger. It won't be able to launch an interactive debug session, that type of config needs to added to the workspaces .vscode/launch.json instead.