### PR TITLE
Bind the debug server to the loopback interface.

### DIFF
--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
@@ -454,7 +454,7 @@ object DAPodil extends IOApp {
 
       state <- Ref[IO].of[State](State.Uninitialized)
 
-      address = new InetSocketAddress(options.listenPort)
+      address = new InetSocketAddress(InetAddress.getLoopbackAddress, options.listenPort)
       serverSocket = {
         val ss = new ServerSocket(address.getPort, 1, address.getAddress)
         ss.setSoTimeout(options.listenTimeout.toMillis.toInt)


### PR DESCRIPTION
A.k.a., 127.0.0.1. We think 0.0.0.0 is used by default, and want
to use a more secure local interface.

Fixes #658.