### PR TITLE
Throw parse errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ src/version.ts
 
 # scala metals vscode extension compiled folder
 .metals
+.bloop
+project
+metals.sbt
 
 # application build
 # todo;; the build logic needs refactored to write these elsewhere

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -474,6 +474,7 @@ export const workspaceFileAccessor: FileAccessor = {
   },
 }
 
+// TODO: Move to extension.ts
 class InlineDebugAdapterFactory
   implements vscode.DebugAdapterDescriptorFactory
 {

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -1,3 +1,5 @@
+// NOTE: Might be able to removed. Only used for a test
+
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/adapter/extension.ts
+++ b/src/adapter/extension.ts
@@ -66,6 +66,7 @@ export function deactivate() {
   position.deactivate()
 }
 
+// NOTE: Can this be removed? Its never used we only ever use inline and provide no way to change it
 class DebugAdapterExecutableFactory
   implements vscode.DebugAdapterDescriptorFactory
 {
@@ -102,6 +103,7 @@ class DebugAdapterExecutableFactory
   }
 }
 
+// NOTE: Can this be removed? Its never used we only ever use inline and provide no way to change it
 class DaffodilDebugAdapterServerDescriptorFactory
   implements vscode.DebugAdapterDescriptorFactory
 {
@@ -140,6 +142,7 @@ class DaffodilDebugAdapterServerDescriptorFactory
   }
 }
 
+// NOTE: Can this be removed? Its never used we only ever use inline and provide no way to change it
 class DaffodilDebugAdapterNamedPipeServerDescriptorFactory
   implements vscode.DebugAdapterDescriptorFactory
 {


### PR DESCRIPTION
Throw parse errors

- Update debugger to check if the parse errored. If it does it will throw the error.
- Add some notes to the typescript for code that possibly be removed and moved.

Closes #648