### PR TITLE
Remove blocking dialogs for debugger errors

### DIFF
--- a/server/core/src/main/scala/org.apache.daffodil.debugger.dap/ErrorEvents.scala
+++ b/server/core/src/main/scala/org.apache.daffodil.debugger.dap/ErrorEvents.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.debugger.dap
+
+import com.microsoft.java.debug.core.protocol.Events.DebugEvent
+
+/** Case classes for errors that we want to relay back to the extension */
+object ErrorEvents {
+  case object UnexpectedError extends DebugEvent("daffodil.error.unexpected")
+  case object UnhandledRequest extends DebugEvent("daffodil.error.requestunhandled")
+  case object LaunchArgsParseError extends DebugEvent("daffodil.error.launchargparse")
+  case object RequestError extends DebugEvent("daffodil.error.request")
+  case object SourceError extends DebugEvent("daffodil.error.source")
+  case object ScopeNotFoundError extends DebugEvent("daffodil.error.scopenotfound")
+}

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -24,6 +24,7 @@ import { getConfig, getCurrentConfig, setCurrentConfig } from '../utils'
 import { DaffodilDebugSession } from './daffodilDebug'
 import { FileAccessor } from './daffodilRuntime'
 import { TDMLConfig } from '../classes/tdmlConfig'
+import { handleDebugEvent } from './daffodilEvent'
 
 /** Method to file path for program and data
  * Details:
@@ -376,6 +377,10 @@ export function activateDaffodilDebug(
         return allValues
       },
     })
+  )
+
+  context.subscriptions.push(
+    vscode.debug.onDidReceiveDebugSessionCustomEvent(handleDebugEvent)
   )
 
   dfdlLang.activate(context)

--- a/src/adapter/daffodilEvent.ts
+++ b/src/adapter/daffodilEvent.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode'
+import * as fs from 'fs'
+
+import * as daf from '../daffodil'
+import { ensureFile, tmpFile } from '../utils'
+
+export function handleDebugEvent(e: vscode.DebugSessionCustomEvent) {
+  switch (e.event) {
+    case daf.infosetEvent:
+      let update: daf.InfosetEvent = e.body
+      let path = ensureFile(tmpFile(e.session.id))
+      fs.copyFileSync(path, `${path}.prev`)
+      fs.writeFileSync(path, update.content)
+      break
+    // this allows for any error event to be caught in this case
+    case e.event.startsWith('daffodil.error') ? e.event : '':
+      vscode.window.showErrorMessage(`debugger ${e.event}`)
+      break
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -348,3 +348,14 @@ export async function findExistingOmegaEditServer(
   }
   return ret
 }
+
+export function tmpFile(sid: string): string {
+  return `${os.tmpdir()}/infoset-${sid}.${getCurrentConfig().infosetFormat}`
+}
+
+export function ensureFile(path: string): string {
+  if (!fs.existsSync(path)) {
+    fs.writeFileSync(path, '')
+  }
+  return path
+}


### PR DESCRIPTION
Remove blocking dialogs for debugger errors

- When some errors happen in the debugger they would cause a large blocking dialog in the extension.
  - This didn't looks good and didn't allow you to quickly fix issues.
- The errors now show in the terminal and small message in the bottom right corner.
  - The message will state the debugger crashed with some information as to why. Then states to look at debugger output for more information.
- Created a new case class for error events to relay back to the extension.
- Update extension to catch error events relayed from the debugger.
- Create class for handling debugEvents so we don't have too many places changing onDidReceiveDebugSessionCustomEvent, on when absolutely necessary like in the hexview.

Closes #649