### PR TITLE
Launch Wizard updates based on 1.3.0-rc3 issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,7 +279,6 @@
         "command": "launch.config",
         "title": "Configure launch.json",
         "category": "Daffodil Debug",
-        "enablement": "!inDebugMode",
         "icon": "$(debug-configure)"
       },
       {
@@ -345,8 +344,8 @@
                 "type": "object",
                 "description": "Destination for final Infoset ('file' | 'console' | 'none')",
                 "default": {
-                  "type": "console",
-                  "path": "${workspaceFolder}/infoset.xml"
+                  "type": "file",
+                  "path": "${workspaceFolder}/target/infoset.xml" 
                 }
               },
               "tdmlConfig": {
@@ -436,7 +435,7 @@
             "infosetFormat": "xml",
             "infosetOutput": {
               "type": "file",
-              "path": "${workspaceFolder}/infoset.xml"
+              "path": "${workspaceFolder}/target/infoset.xml" 
             },
             "debugServer": 4711,
             "openHexView": false,
@@ -466,7 +465,7 @@
               "infosetFormat": "xml",
               "infosetOutput": {
                 "type": "file",
-                "path": "${workspaceFolder}/infoset.xml"
+                "path": "${workspaceFolder}/target/infoset.xml" 
               },
               "debugServer": 4711,
               "openHexView": false,
@@ -549,7 +548,7 @@
           "infosetOutputFilePath": {
             "type": "string",
             "description": "Path to output for Infoset file (req: infosetOutput=file)",
-            "default": "${workspaceFolder}/infoset.xml"
+            "default": "${workspaceFolder}/target/infoset.xml" 
           },
           "stopOnEntry": {
             "type": "boolean",

--- a/src/launchWizard/launchWizard.js
+++ b/src/launchWizard/launchWizard.js
@@ -65,6 +65,8 @@ function filePicker(id, description) {
     id: id,
     description: description,
     configIndex: getConfigIndex(),
+    selectFiles: description.includes('file(s)') ? true : false,
+    selectFolders: description.includes('folder(s)') ? true : false,
     extraData: extraData,
   })
 }

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -146,20 +146,21 @@ async function updateWebViewConfigValues(configIndex) {
 }
 
 // Function to create file picker for wizard
-async function openFilePicker(description) {
+async function openFilePicker(
+  description: string,
+  selectFiles: boolean = true,
+  selectFolders: boolean = true
+) {
   let rootPath = vscode.workspace.workspaceFolders
     ? vscode.workspace.workspaceFolders[0].uri.fsPath
-    : vscode.Uri.parse('').fsPath
-
-  let canSelectMany = !!description.includes('jar files/folder')
-  let canSelectFolders = !!description.includes('jar files/folder')
+    : vscode.Uri.file('').fsPath
 
   let chosenFile = await vscode.window
     .showOpenDialog({
-      canSelectMany: canSelectMany,
+      canSelectMany: true,
       openLabel: description,
-      canSelectFiles: true,
-      canSelectFolders: canSelectFolders,
+      canSelectFiles: selectFiles,
+      canSelectFolders: selectFolders,
       title: description,
     })
     .then(async (fileUri) => {
@@ -197,7 +198,11 @@ async function createWizard(ctx: vscode.ExtensionContext) {
           })
           return
         case 'openFilePicker':
-          let result = await openFilePicker(message.description)
+          let result = await openFilePicker(
+            message.description,
+            message.selectFiles,
+            message.selectFolders
+          )
 
           // don't add empty string to table
           if (result !== '') {
@@ -458,7 +463,8 @@ class LaunchWizard {
         ${daffodilDebugClasspathList}
 
         <p style="margin-left: 5px">
-          <button id="daffodilDebugClasspathBrowse" class="browse-button" type="button" onclick="filePicker('daffodilDebugClasspath', 'Select jar files/folder with desired jars')">Browse</button>
+          <button id="daffodilDebugClasspathAddFolders" class="browse-button" type="button" onclick="filePicker('daffodilDebugClasspath', 'Select folder(s) with desired jars')">Add Folder(s)</button>
+          <button id="daffodilDebugClasspathAddFiles" class="browse-button" type="button" onclick="filePicker('daffodilDebugClasspath', 'Select jar file(s)')">Add JAR File(s)</button>
         </p>
       </div>
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -34,14 +34,19 @@
   color: white;
   cursor: pointer;
   background-color: rgb(80, 78, 78);
-  width: 375px;
-  height: 25px;
+  width: fit-content;
+  height: fit-content;
   font-size: 12px;
   border: none;
   border-radius: 12px;
   padding-left: 7px;
+  padding-right: 10px;
+  padding-bottom: 5px;
   margin: 0px;
   margin-top: 5px;
+
+  word-wrap: break-word;
+  word-break: break-all;
 }
 
 /* Hide the browser's default checkbox */
@@ -130,7 +135,7 @@
   font-size: 12px;
   cursor: pointer;
   width: 75px;
-  height: 25px;
+  height: fit-content;
 }
 
 .minus-button {

--- a/src/tests/suite/utils.test.ts
+++ b/src/tests/suite/utils.test.ts
@@ -33,7 +33,7 @@ suite('Utils Test Suite', () => {
     infosetFormat: 'xml',
     infosetOutput: {
       type: 'none',
-      path: '${workspaceFolder}/infoset.xml',
+      path: '${workspaceFolder}/target/infoset.xml',
     },
     stopOnEntry: true,
     useExistingServer: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,7 +129,7 @@ export function getConfig(
           type: defaultConf.get('infosetOutputType', 'none'),
           path: defaultConf.get(
             'infosetOutputFilePath',
-            '${workspaceFolder}/infoset.xml'
+            '${workspaceFolder}/target/infoset.xml'
           ),
         },
     stopOnEntry: stopOnEntry


### PR DESCRIPTION
Launch Wizard updates based on 1.3.0-rc3 issues:

- Update daffodil debug classpath items CSS to make the items height and width match the content.
- Make launch wizard always available. Before was only available whenever not debugging.
- Fix issue with tdml config throw errors if action was not set.
- infosetOutput bug fixed, was defaulting to type console when it was supposed to file.

Closes #672
Closes #674
Closes #675