### PR TITLE
Multiple debugger updates:

### DIFF
--- a/debugger/src/main/resources/logback.xml
+++ b/debugger/src/main/resources/logback.xml
@@ -27,7 +27,17 @@
       <pattern>%date{ISO8601} [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n</pattern>
     </encoder>
   </appender>
-  <root level="DEBUG">
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+      <file>${DAFFODIL_DEBUG_LOG_FILE:-/tmp/daffodil-debugger.log}</file>
+      <append>false</append>
+      <encoder>
+          <pattern>%date{ISO8601} [%thread] %-5level %logger{15} - %msg %n</pattern>
+      </encoder>
+  </appender>
+
+  <root level="${DAFFODIL_DEBUG_LOG_LEVEL:-INFO}">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILE" />
   </root>
 </configuration>

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "compile": "tsc -p ./ && yarn sbt",
     "lint": "yarn prettier src -c && cd src/svelte && yarn lint",
     "lint:fix": "yarn prettier src -w && cd src/svelte && yarn lint:fix",
-    "prewatch": "yarn gen-version-ts && yarn sbt",
-    "watch": "concurrently --kill-others \"webpack --watch --devtool nosources-source-map --config ./build/extension.webpack.config.js\" \"yarn watch:svelte\"",
+    "prewatch": "yarn gen-version-ts",
+    "scalawatch": "nodemon --verbose -e sbt,scala,xml,xjb -w debugger -w project -w build.sbt --ignore \"**/target/**\" --exec \"yarn sbt\"",
+    "watch": "concurrently --kill-others \"yarn scalawatch\" \"webpack --watch --devtool nosources-source-map --config ./build/extension.webpack.config.js\" \"yarn watch:svelte\"",
     "watch:svelte": "cd src/svelte && yarn dev",
     "webpack": "webpack --mode production --config ./build/extension.webpack.config.js",
     "prepackage": "yarn install && yarn compile && yarn webpack",
@@ -39,13 +40,14 @@
     "package-create": "node -e \"require('./build/scripts/package.ts').create()\"",
     "pretest": "yarn compile && yarn webpack",
     "test": "sbt test && node ./out/tests/runTest.js",
-    "sbt": "sbt universal:packageBin"
+    "sbt": "sbt debugger/Universal/packageBin"
   },
   "dependencies": {
-    "@vscode/debugadapter": "1.59.0",
     "@omega-edit/client": "0.9.63",
+    "@vscode/debugadapter": "1.59.0",
     "await-notify": "1.0.1",
     "hexy": "0.3.4",
+    "nodemon": "^3.0.1",
     "unzip-stream": "0.3.1",
     "uuid": "9.0.0",
     "wait-port": "1.0.4",
@@ -345,7 +347,7 @@
                 "description": "Destination for final Infoset ('file' | 'console' | 'none')",
                 "default": {
                   "type": "file",
-                  "path": "${workspaceFolder}/target/infoset.xml" 
+                  "path": "${workspaceFolder}/target/infoset.xml"
                 }
               },
               "tdmlConfig": {
@@ -420,6 +422,16 @@
                   "logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
                   "logLevel": "info"
                 }
+              },
+              "dfdlDebugger": {
+                "type": "object",
+                "description": "Configuration for debugger. Settings are logging (level and file)",
+                "default": {
+                  "logging": {
+                    "level": "INFO",
+                    "file": "/tmp/daffodil-debugger.log"
+                  }
+                }
               }
             }
           }
@@ -435,7 +447,7 @@
             "infosetFormat": "xml",
             "infosetOutput": {
               "type": "file",
-              "path": "${workspaceFolder}/target/infoset.xml" 
+              "path": "${workspaceFolder}/target/infoset.xml"
             },
             "debugServer": 4711,
             "openHexView": false,
@@ -448,6 +460,12 @@
               "port": 9000,
               "logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
               "logLevel": "info"
+            },
+            "dfdlDebugger": {
+              "logging": {
+                "level": "INFO",
+                "file": "/tmp/daffodil-debugger.log"
+              }
             }
           }
         ],
@@ -465,7 +483,7 @@
               "infosetFormat": "xml",
               "infosetOutput": {
                 "type": "file",
-                "path": "${workspaceFolder}/target/infoset.xml" 
+                "path": "${workspaceFolder}/target/infoset.xml"
               },
               "debugServer": 4711,
               "openHexView": false,
@@ -478,6 +496,12 @@
                 "port": 9000,
                 "logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
                 "logLevel": "info"
+              },
+              "dfdlDebugger": {
+                "logging": {
+                  "level": "INFO",
+                  "file": "/tmp/daffodil-debugger.log"
+                }
               }
             }
           }
@@ -548,7 +572,7 @@
           "infosetOutputFilePath": {
             "type": "string",
             "description": "Path to output for Infoset file (req: infosetOutput=file)",
-            "default": "${workspaceFolder}/target/infoset.xml" 
+            "default": "${workspaceFolder}/target/infoset.xml"
           },
           "stopOnEntry": {
             "type": "boolean",
@@ -625,6 +649,31 @@
               "trace"
             ],
             "default": "info"
+          },
+          "dfdlDebuggerLogLevel": {
+            "type": "string",
+            "description": "Log level for debugger",
+            "enum": [
+              "ALL",
+              "DEBUG",
+              "ERROR",
+              "INFO",
+              "OFF",
+              "TRACE",
+              "WARN"
+            ],
+            "default": "INFO"
+          },
+          "dfdlDebuggerLogFile": {
+            "type": "string",
+            "description": "Path to log file for debugger",
+            "default": "/tmp/daffodil-debugger.log"
+          },
+          "dfdlDebugger": {
+            "logging": {
+              "level": "INFO",
+              "file": "/tmp/daffodil-debugger.log"
+            }
           }
         }
       }

--- a/src/classes/vscode-launch.ts
+++ b/src/classes/vscode-launch.ts
@@ -23,6 +23,15 @@ export interface InfosetOutput {
   file: string
 }
 
+export interface LoggingConfig {
+  level: string
+  file: string
+}
+
+export interface DFDLDebugger {
+  logging: LoggingConfig
+}
+
 export interface VSCodeLaunchConfigArgs {
   name: string
   request: string
@@ -41,4 +50,5 @@ export interface VSCodeLaunchConfigArgs {
   openInfosetView: boolean
   openInfosetDiffView: boolean
   daffodilDebugClasspath: string
+  dfdlDebugger: DFDLDebugger
 }

--- a/src/daffodilDebugger/debugger.ts
+++ b/src/daffodilDebugger/debugger.ts
@@ -19,11 +19,11 @@ import * as vscode from 'vscode'
 import * as fs from 'fs'
 import XDGAppPaths from 'xdg-app-paths'
 import * as path from 'path'
-import { regexp, unzipFile } from '../utils'
+import { regexp, getConfig } from '../utils'
 import {
-  buildDebugger,
   daffodilArtifact,
   daffodilVersion,
+  extractDebugger,
   runDebugger,
   stopDebugger,
   stopDebugging,
@@ -220,22 +220,7 @@ export async function getDebugger(
         fs.mkdirSync(rootPath, { recursive: true })
       }
 
-      // Code for downloading and setting up daffodil-debugger files
-      if (!fs.existsSync(`${rootPath}/${artifact.name}`)) {
-        // Get daffodil-debugger zip from extension files
-        const filePath = path
-          .join(
-            context.asAbsolutePath('./debugger/target/universal'),
-            artifact.archive
-          )
-          .toString()
-
-        // If debugging the extension without vsix installed make sure debugger is created
-        await buildDebugger(context.asAbsolutePath('.'), filePath)
-
-        // Unzip file
-        await unzipFile(filePath, rootPath)
-      }
+      await extractDebugger(context, artifact.archive, rootPath)
 
       await stopDebugger()
 
@@ -265,7 +250,8 @@ export async function getDebugger(
         rootPath,
         daffodilDebugClasspath,
         context.asAbsolutePath('./package.json'),
-        config.debugServer
+        config.debugServer,
+        getConfig(config).dfdlDebugger
       )
     }
   }

--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -28,6 +28,7 @@ import {
   stopDebugging,
 } from '../../daffodilDebugger'
 import { before, after } from 'mocha'
+import { DFDLDebugger } from '../../classes/vscode-launch'
 
 // Not using the debug adapter like adapter.test.ts as it will not fully connect the debugger
 suite('Daffodil Debugger', () => {
@@ -61,13 +62,42 @@ suite('Daffodil Debugger', () => {
     logLevel: 'info',
   }
 
+  const dfdlDebuggers: Array<DFDLDebugger> = [
+    {
+      logging: {
+        level: 'INFO',
+        file: 'daffodil-debugger-4711.log',
+      },
+    },
+    {
+      logging: {
+        level: 'INFO',
+        file: 'daffodil-debugger-4712.log',
+      },
+    },
+  ]
+
   before(async () => {
     await unzipFile(SCALA_PATH, PROJECT_ROOT)
     debuggers.push(
-      await runDebugger(PROJECT_ROOT, '', PACKAGE_PATH, 4711, true)
+      await runDebugger(
+        PROJECT_ROOT,
+        '',
+        PACKAGE_PATH,
+        4711,
+        dfdlDebuggers[0],
+        true
+      )
     )
     debuggers.push(
-      await runDebugger(PROJECT_ROOT, '', PACKAGE_PATH, 4712, true)
+      await runDebugger(
+        PROJECT_ROOT,
+        '',
+        PACKAGE_PATH,
+        4712,
+        dfdlDebuggers[1],
+        true
+      )
     )
   })
 
@@ -79,6 +109,10 @@ suite('Daffodil Debugger', () => {
     fs.rmSync(EXTRACTED_FOLDER, { recursive: true })
     if (fs.existsSync(XML_INFOSET_PATH)) fs.rmSync(XML_INFOSET_PATH)
     if (fs.existsSync(JSON_INFOSET_PATH)) fs.rmSync(JSON_INFOSET_PATH)
+    dfdlDebuggers.forEach((dfdlDebugger) => {
+      if (fs.existsSync(dfdlDebugger.logging.file))
+        fs.rmSync(dfdlDebugger.logging.file)
+    })
   })
 
   test('should output xml infoset', async () => {

--- a/src/tests/suite/utils.test.ts
+++ b/src/tests/suite/utils.test.ts
@@ -47,6 +47,12 @@ suite('Utils Test Suite', () => {
       logFile: '${workspaceFolder}/dataEditor-${omegaEditPort}.log',
       logLevel: 'info',
     },
+    dfdlDebugger: {
+      logging: {
+        level: 'INFO',
+        file: '/tmp/daffodil-debugger.log',
+      },
+    },
   }
 
   test('Default config', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,6 +123,15 @@ export function getConfig(jsonArgs: object): vscode.DebugConfiguration {
       ),
       logLevel: defaultConf.get('dataEditorLogLevel', 'info'),
     },
+    dfdlDebugger: {
+      logging: {
+        level: defaultConf.get('dfdlDebuggerLogLevel', 'INFO'),
+        file: defaultConf.get(
+          'dfdlDebuggerLogFile',
+          '/tmp/daffodil-debugger.log'
+        ),
+      },
+    },
   }
 
   Object.entries(defaultValues).map(

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,6 +508,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -876,7 +881,7 @@ cheerio@^1.0.0-rc.9:
     parse5 "^7.0.0"
     parse5-htmlparser2-tree-adapter "^7.0.0"
 
-chokidar@3.5.3:
+chokidar@3.5.3, chokidar@^3.5.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -1075,6 +1080,13 @@ debug@4, debug@4.3.4, debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^4.0.0:
   version "4.0.0"
@@ -1597,6 +1609,11 @@ ieee754@^1.1.13, ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+ignore-by-default@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+  integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
+
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
@@ -1973,7 +1990,7 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.1:
+minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -2047,7 +2064,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -2093,6 +2110,29 @@ node-releases@^2.0.8:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
   integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
+
+nodemon@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-3.0.1.tgz#affe822a2c5f21354466b2fc8ae83277d27dadc7"
+  integrity sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==
+  dependencies:
+    chokidar "^3.5.2"
+    debug "^3.2.7"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.1.2"
+    pstree.remy "^1.1.8"
+    semver "^7.5.3"
+    simple-update-notifier "^2.0.0"
+    supports-color "^5.5.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.5"
+
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  integrity sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==
+  dependencies:
+    abbrev "1"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -2355,6 +2395,11 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==
 
+pstree.remy@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
+  integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
+
 pump@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
@@ -2584,6 +2629,13 @@ semver@^7.3.4, semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.3:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-javascript@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
@@ -2667,6 +2719,13 @@ simple-get@^4.0.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+simple-update-notifier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz#d70b92bdab7d6d90dfd73931195a30b6e3d7cebb"
+  integrity sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==
+  dependencies:
+    semver "^7.5.3"
+
 sonic-boom@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.3.0.tgz#cffab6dafee3b2bcb88d08d589394198bee1838c"
@@ -2749,7 +2808,7 @@ supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -2876,6 +2935,13 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
+  dependencies:
+    nopt "~1.0.10"
+
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
@@ -2968,6 +3034,11 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+undefsafe@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
+  integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
 underscore@^1.12.1:
   version "1.13.6"


### PR DESCRIPTION
Multiple debugger updates:

- Always extract the debugger zip.
- Update debugger to log to both console and file.
- Allow the setting of the debugger's log level and log filepath from the launch.json.
  - the logback.xml uses environment variables LOG_LEVEL and LOG_FILE to do this. This get set when the debugger is ran.
  - default log level is INFO
  - default log filepath is /tmp/daffodil-debugger.log
- Add "devMode" variable to launch.json
  - When enabled and the extension is being ran locally, it will run "sbt universal:packageBin" everytime before running the debugger. It will display a little loading in the bottom bar.
  - This can be used later to enable other features that are only available during development.

Closes #471
Closes #679
Closes #691

Loading symbol when devMode is enabled

<img width="528" alt="Screenshot 2023-07-10 at 7 57 26 PM" src="https://github.com/apache/daffodil-vscode/assets/32347414/c68d2b73-4a89-4463-991e-35e97754c616">