### PR TITLE
Add runtime jvm info to startup banner.

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
@@ -436,6 +436,8 @@ object DAPodil extends IOApp {
         |  daffodilVersion: ${BuildInfo.daffodilVersion}
         |  scalaVersion: ${BuildInfo.scalaVersion}
         |  sbtVersion: ${BuildInfo.sbtVersion}
+        |Runtime info:
+        |  JVM version: ${System.getProperty("java.version")} (${System.getProperty("java.home")})
         |******************************************************""".stripMargin
 
   def run(args: List[String]): IO[ExitCode] =


### PR DESCRIPTION
To help with JVM-related issues like #676.