### PR TITLE
Fix hierarchy default values. Update how yarn scripts are ran.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,7 +19,5 @@ coverage
 out
 dist
 
-version.ts
-
 # Svelte does its own
 svelte

--- a/build/extension.webpack.config.js
+++ b/build/extension.webpack.config.js
@@ -50,7 +50,8 @@ module.exports = /** @type WebpackConfig */ {
 		path: path.resolve(__dirname, '../dist/ext'),
 		libraryTarget: 'commonjs2',
 		devtoolModuleFilenameTemplate: "../../[resource-path]",
-		hashFunction: "sha512"
+		hashFunction: "sha512",
+		clean: true, // makes sure the output directory is remade
 	},
 	devtool: 'source-map'
 }

--- a/build/scripts/yarn-scripts.ts
+++ b/build/scripts/yarn-scripts.ts
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-nocheck <-- This is needed as this file is basically a JavaScript script
+//                 but with some TypeScript niceness baked in
+const fs = require('fs')
+const glob = require('glob')
+const nodemon = require('nodemon')
+const concurrently = require('concurrently')
+
+function rmFileOrDirectory(path) {
+  if (fs.existsSync(path))
+    fs.rmSync(path, { recursive: true })
+}
+
+function genVersionTS() {
+  const version = JSON.stringify(require('../../package.json').version).replace(/"/g, "'")
+  fs.writeFileSync('./src/version.ts', `/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const LIB_VERSION = ${version}
+`)
+}
+
+const nodeclean = () =>
+  ['out', 'dist'].forEach((dir) => rmFileOrDirectory(dir))
+
+function scalaclean() {
+  glob('**/target', { cwd: '.' }, (err, files) => {
+    if (err) {
+      console.log(err)
+      return
+    }
+
+    files.forEach((dir) => rmFileOrDirectory(dir))
+  })
+}
+
+function watch() {
+  concurrently(
+    [
+      "yarn scalawatch",
+      "webpack --watch --devtool nosources-source-map --config ./build/extension.webpack.config.js",
+      "yarn watch:svelte"
+    ],
+    {
+      killOthers: ['failure', 'success'],
+    }
+  )
+}
+
+module.exports = {
+  genVersionTS: genVersionTS,
+  nodeclean: nodeclean,
+  scalaclean: scalaclean,
+  watch: watch,
+}

--- a/debugger/nodemon.json
+++ b/debugger/nodemon.json
@@ -1,0 +1,13 @@
+{
+  "ignore": [
+    "**/target/**"
+  ],
+  "verbose": true,
+  "exec": "yarn sbt",
+  "watch": [
+    "debugger",
+    "project",
+    "build.sbt"
+  ],
+  "ext": "sbt,scala,xml,xjb"
+}

--- a/package.json
+++ b/package.json
@@ -24,20 +24,23 @@
   },
   "scripts": {
     "postinstall": "cd src/svelte && yarn install",
-    "gen-version-ts": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
-    "precompile": "yarn gen-version-ts && cd src/svelte && yarn build",
+    "gen-version-ts": "run-func build/scripts/yarn-scripts.ts genVersionTS",
+    "nodeclean": "run-func build/scripts/yarn-scripts.ts nodeclean",
+    "scalaclean": "run-func build/scripts/yarn-scripts.ts scalaclean",
+    "clean": "yarn nodeclean && yarn scalaclean",
+    "precompile": "yarn nodeclean && yarn gen-version-ts && cd src/svelte && yarn build",
     "compile": "tsc -p ./ && yarn sbt",
     "lint": "yarn prettier src -c && cd src/svelte && yarn lint",
     "lint:fix": "yarn prettier src -w && cd src/svelte && yarn lint:fix",
+    "scalawatch": "nodemon --config debugger/nodemon.json",
     "prewatch": "yarn gen-version-ts",
-    "scalawatch": "nodemon --verbose -e sbt,scala,xml,xjb -w debugger -w project -w build.sbt --ignore \"**/target/**\" --exec \"yarn sbt\"",
-    "watch": "concurrently --kill-others \"yarn scalawatch\" \"webpack --watch --devtool nosources-source-map --config ./build/extension.webpack.config.js\" \"yarn watch:svelte\"",
+    "watch": "run-func build/scripts/yarn-scripts.ts watch",
     "watch:svelte": "cd src/svelte && yarn dev",
     "webpack": "webpack --mode production --config ./build/extension.webpack.config.js",
     "prepackage": "yarn install && yarn compile && yarn webpack",
     "package": "yarn package-setup && yarn package-create",
-    "package-setup": "node -e \"require('./build/scripts/package.ts').setup()\"",
-    "package-create": "node -e \"require('./build/scripts/package.ts').create()\"",
+    "package-setup": "run-func build/scripts/package.ts setup",
+    "package-create": "run-func build/scripts/package.ts create",
     "pretest": "yarn compile && yarn webpack",
     "test": "sbt test && node ./out/tests/runTest.js",
     "sbt": "sbt debugger/Universal/packageBin"
@@ -66,6 +69,7 @@
     "glob": "8.0.3",
     "mocha": "10.2.0",
     "prettier": "2.8.8",
+    "run-func": "^3.0.0",
     "ts-loader": "8.1.0",
     "ts-node": "^10.9.1",
     "typescript": "4.6.2",
@@ -419,8 +423,10 @@
                 "description": "Configuration for Data Editor. Settings are port, logFile and logLevel",
                 "default": {
                   "port": 9000,
-                  "logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
-                  "logLevel": "info"
+                  "logging": {
+                    "file": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
+                    "level": "info"
+                  }
                 }
               },
               "dfdlDebugger": {
@@ -449,6 +455,12 @@
               "type": "file",
               "path": "${workspaceFolder}/target/infoset.xml"
             },
+            "tdmlConfig": {
+              "action": "none",
+              "name": "${command:AskForTDMLName}",
+              "description": "${command:AskForTDMLDescription}",
+              "path": "${command:AskForTDMLPath}"
+            },
             "debugServer": 4711,
             "openHexView": false,
             "openInfosetView": false,
@@ -458,8 +470,10 @@
             "tunables": {},
             "dataEditor": {
               "port": 9000,
-              "logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
-              "logLevel": "info"
+              "logging": {
+                "file": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
+                "level": "info"
+              }
             },
             "dfdlDebugger": {
               "logging": {
@@ -485,6 +499,12 @@
                 "type": "file",
                 "path": "${workspaceFolder}/target/infoset.xml"
               },
+              "tdmlConfig": {
+                "action": "none",
+                "name": "${command:AskForTDMLName}",
+                "description": "${command:AskForTDMLDescription}",
+                "path": "${command:AskForTDMLPath}"
+              },
               "debugServer": 4711,
               "openHexView": false,
               "openInfosetView": false,
@@ -494,8 +514,10 @@
               "tunables": {},
               "dataEditor": {
                 "port": 9000,
-                "logFile": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
-                "logLevel": "info"
+                "logging": {
+                  "file": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
+                  "level": "info"
+                }
               },
               "dfdlDebugger": {
                 "logging": {
@@ -534,45 +556,23 @@
             "description": "Absolute path to the input data file.",
             "default": "${command:AskForDataName}"
           },
-          "tdmlAction": {
-            "type": "string",
-            "description": "TDML Action to take (generate | append | execute)",
-            "enum": [
-              "generate",
-              "append",
-              "execute"
-            ],
-            "default": "none"
+          "tdmlConfig": {
+            "type": "object",
+            "description": "Configuration for TDML Actions",
+            "default": {
+              "action": "none",
+              "name": "${command:AskForTDMLName}",
+              "description": "${command:AskForTDMLDescription}",
+              "path": "${command:AskForTDMLPath}"
+            }
           },
-          "tdmlName": {
-            "type": "string",
-            "description": "Name of the TDML Test Case",
-            "default": "${command:AskForTDMLName}"
-          },
-          "tdmlDescription": {
-            "type": "string",
-            "description": "Description of the TDML Test Case",
-            "default": "${command:AskForTDMLDescription}"
-          },
-          "tdmlPath": {
-            "type": "string",
-            "description": "Path to output for TDML file (req: tdmlAction=generate)",
-            "default": "${command:AskForTDMLPath}"
-          },
-          "infosetOutputType": {
-            "type": "string",
+          "infosetOutput": {
+            "type": "object",
             "description": "Destination for final Infoset ('file' | 'console' | 'none')",
-            "enum": [
-              "file",
-              "console",
-              "none"
-            ],
-            "default": "none"
-          },
-          "infosetOutputFilePath": {
-            "type": "string",
-            "description": "Path to output for Infoset file (req: infosetOutput=file)",
-            "default": "${workspaceFolder}/target/infoset.xml"
+            "default": {
+              "type": "file",
+              "path": "${workspaceFolder}/target/infoset.xml"
+            }
           },
           "stopOnEntry": {
             "type": "boolean",
@@ -628,51 +628,25 @@
             },
             "default": {}
           },
-          "dataEditorPort": {
-            "type": "integer",
-            "description": "Editor server default port",
-            "default": 9000
-          },
-          "dataEditorLogFile": {
-            "type": "string",
-            "description": "Path to log file for data editor",
-            "default": "${workspaceFolder}/dataEditor-${omegaEditPort}.log"
-          },
-          "dataEditorLogLevel": {
-            "type": "string",
-            "description": "Log level for data editor",
-            "enum": [
-              "error",
-              "warn",
-              "info",
-              "debug",
-              "trace"
-            ],
-            "default": "info"
-          },
-          "dfdlDebuggerLogLevel": {
-            "type": "string",
-            "description": "Log level for debugger",
-            "enum": [
-              "ALL",
-              "DEBUG",
-              "ERROR",
-              "INFO",
-              "OFF",
-              "TRACE",
-              "WARN"
-            ],
-            "default": "INFO"
-          },
-          "dfdlDebuggerLogFile": {
-            "type": "string",
-            "description": "Path to log file for debugger",
-            "default": "/tmp/daffodil-debugger.log"
+          "dataEditor": {
+            "type": "object",
+            "description": "Configuration for Data Editor. Settings are port, logFile and logLevel",
+            "default": {
+              "port": 9000,
+              "logging": {
+                "file": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
+                "level": "info"
+              }
+            }
           },
           "dfdlDebugger": {
-            "logging": {
-              "level": "INFO",
-              "file": "/tmp/daffodil-debugger.log"
+            "type": "object",
+            "description": "Configuration for debugger. Settings are logging (level and file)",
+            "default": {
+              "logging": {
+                "level": "INFO",
+                "file": "/tmp/daffodil-debugger.log"
+              }
             }
           }
         }

--- a/project/Rat.scala
+++ b/project/Rat.scala
@@ -26,8 +26,8 @@ object Rat {
     file(".metal"),
     // vscode-test generated directory
     file(".vscode-test"),
-    // generate version file from sbt
-    file("src/version.ts"),
+    // nodemon config file for debugger
+    file("debugger/nodemon.json"),
     /** Can't add license headers in JSON files. Adding a license attribute breaks things in some of these files as
       * well.
       */

--- a/src/classes/dataEditor.ts
+++ b/src/classes/dataEditor.ts
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
+import { LoggingConfig } from './loggingConfig'
+
 export interface DataEditorConfig {
   port: number
-  logFile: string
-  logLevel: string
+  logging: LoggingConfig
 }

--- a/src/classes/dfdlDebugger.ts
+++ b/src/classes/dfdlDebugger.ts
@@ -15,29 +15,8 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
-import * as fs from 'fs'
-import * as path from 'path'
-import { PROJECT_ROOT } from './common'
+import { LoggingConfig } from '../classes/loggingConfig'
 
-suite('Daffodil Version', () => {
-  const versionFile = path.join(PROJECT_ROOT, 'src/version.ts')
-  const packageMapped = JSON.parse(
-    fs.readFileSync(path.join(PROJECT_ROOT, 'package.json')).toString()
-  )
-
-  suite('version', () => {
-    test('version.ts should exist', (done) => {
-      if (fs.existsSync(versionFile)) {
-        done()
-      } else {
-        new Error('version.ts not created')
-      }
-    })
-
-    test('version.ts version should be same as package.json', () => {
-      const version = require('../../version').LIB_VERSION
-      assert.strictEqual(version, packageMapped.version)
-    })
-  })
-})
+export interface DFDLDebugger {
+  logging: LoggingConfig
+}

--- a/src/classes/loggingConfig.ts
+++ b/src/classes/loggingConfig.ts
@@ -15,29 +15,7 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert'
-import * as fs from 'fs'
-import * as path from 'path'
-import { PROJECT_ROOT } from './common'
-
-suite('Daffodil Version', () => {
-  const versionFile = path.join(PROJECT_ROOT, 'src/version.ts')
-  const packageMapped = JSON.parse(
-    fs.readFileSync(path.join(PROJECT_ROOT, 'package.json')).toString()
-  )
-
-  suite('version', () => {
-    test('version.ts should exist', (done) => {
-      if (fs.existsSync(versionFile)) {
-        done()
-      } else {
-        new Error('version.ts not created')
-      }
-    })
-
-    test('version.ts version should be same as package.json', () => {
-      const version = require('../../version').LIB_VERSION
-      assert.strictEqual(version, packageMapped.version)
-    })
-  })
-})
+export interface LoggingConfig {
+  level: string
+  file: string
+}

--- a/src/classes/vscode-launch.ts
+++ b/src/classes/vscode-launch.ts
@@ -17,20 +17,8 @@
 
 import { TDMLConfig } from './tdmlConfig'
 import { DataEditorConfig } from './dataEditor'
-
-export interface InfosetOutput {
-  type: string
-  file: string
-}
-
-export interface LoggingConfig {
-  level: string
-  file: string
-}
-
-export interface DFDLDebugger {
-  logging: LoggingConfig
-}
+import { InfosetOutput } from '../daffodilDebugger'
+import { DFDLDebugger } from './dfdlDebugger'
 
 export interface VSCodeLaunchConfigArgs {
   name: string

--- a/src/daffodilDebugger/daffodil.ts
+++ b/src/daffodilDebugger/daffodil.ts
@@ -46,6 +46,7 @@ export interface LaunchArgs {
 
 export interface InfosetOutput {
   type: string
+  path: string
 }
 
 export interface BuildInfo {

--- a/src/daffodilDebugger/debugger.ts
+++ b/src/daffodilDebugger/debugger.ts
@@ -206,6 +206,7 @@ export async function getDebugger(
   context: vscode.ExtensionContext,
   config: vscode.DebugConfiguration
 ) {
+  config = getConfig(config) // make sure all config attributes are set
   const artifact = daffodilArtifact(
     daffodilVersion(context.asAbsolutePath('./package.json'))
   )
@@ -251,7 +252,7 @@ export async function getDebugger(
         daffodilDebugClasspath,
         context.asAbsolutePath('./package.json'),
         config.debugServer,
-        getConfig(config).dfdlDebugger
+        config.dfdlDebugger
       )
     }
   }

--- a/src/daffodilDebugger/utils.ts
+++ b/src/daffodilDebugger/utils.ts
@@ -22,7 +22,7 @@ import { LIB_VERSION } from '../version'
 import { deactivate } from '../adapter/extension'
 import { getDaffodilVersion } from './daffodil'
 import { Artifact } from '../classes/artifact'
-import { DFDLDebugger } from '../classes/vscode-launch'
+import { DFDLDebugger } from '../classes/dfdlDebugger'
 import { osCheck, runScript, unzipFile } from '../utils'
 
 export const daffodilVersion = (filePath: string): string => {

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -321,8 +321,6 @@ class LaunchWizard {
 
     let defaultValues = getConfigValues(fileData, configIndex)
 
-    // vscode.window.showInformationMessage(JSON.stringify(fileData))
-
     let nameVisOrHiddenStyle = newConfig
       ? 'margin-top: 10px; visibility: visible;'
       : 'visibility: hidden;'
@@ -413,8 +411,8 @@ class LaunchWizard {
     })
 
     let dataEditorPort = defaultValues.dataEditorConfig['port']
-    let dataEditorLogFile = defaultValues.dataEditorConfig['logFile']
-    let dataEditorLogLevel = defaultValues.dataEditorConfig['logLevel']
+    let dataEditorLogFile = defaultValues.dataEditorConfig['logging']['file']
+    let dataEditorLogLevel = defaultValues.dataEditorConfig['logging']['level']
 
     return `
   <!DOCTYPE html>

--- a/src/tests/suite/daffodil.test.ts
+++ b/src/tests/suite/daffodil.test.ts
@@ -72,6 +72,7 @@ suite('Daffodfil', () => {
     test('InfosetOutput functions properly', () => {
       let infosetOutput: daffodil.InfosetOutput = {
         type: 'console',
+        path: '',
       }
 
       assert.strictEqual('console', infosetOutput.type)
@@ -93,6 +94,7 @@ suite('Daffodfil', () => {
     test('LaunchArgs functions properly', () => {
       let infosetOutput: daffodil.InfosetOutput = {
         type: 'console',
+        path: '',
       }
 
       let launchArgs: daffodil.LaunchArgs = {
@@ -114,6 +116,7 @@ suite('Daffodfil', () => {
       let allVersions = '1.0.0'
       let infosetOutput: daffodil.InfosetOutput = {
         type: 'console',
+        path: '',
       }
       let buildInfo: daffodil.BuildInfo = {
         version: allVersions,
@@ -164,7 +167,6 @@ suite('Daffodfil', () => {
     const nonDebugSpecificCmds = [
       'extension.dfdl-debug.debugEditorContents',
       'extension.dfdl-debug.runEditorContents',
-      'launch.config',
     ]
 
     // This breaks when the omega-edit tests run for some reason

--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -28,7 +28,8 @@ import {
   stopDebugging,
 } from '../../daffodilDebugger'
 import { before, after } from 'mocha'
-import { DFDLDebugger } from '../../classes/vscode-launch'
+import { DFDLDebugger } from '../../classes/dfdlDebugger'
+import { DataEditorConfig } from '../../classes/dataEditor'
 
 // Not using the debug adapter like adapter.test.ts as it will not fully connect the debugger
 suite('Daffodil Debugger', () => {
@@ -56,10 +57,12 @@ suite('Daffodil Debugger', () => {
     path: TDML_PATH,
   }
 
-  const dataEditorConfig = {
+  const dataEditorConfig: DataEditorConfig = {
     port: 9000,
-    logFile: 'dataEditor-9000.log',
-    logLevel: 'info',
+    logging: {
+      file: 'dataEditor-9000.log',
+      level: 'info',
+    },
   }
 
   const dfdlDebuggers: Array<DFDLDebugger> = [

--- a/src/tests/suite/utils.test.ts
+++ b/src/tests/suite/utils.test.ts
@@ -17,13 +17,14 @@
 
 import * as assert from 'assert'
 import * as utils from '../../utils'
+import { VSCodeLaunchConfigArgs } from '../../classes/vscode-launch'
 
 suite('Utils Test Suite', () => {
   var name = 'Default Config'
   var request = 'launch'
   var type = 'dfdl'
 
-  var defaultConfig = {
+  var defaultConfig: VSCodeLaunchConfigArgs = {
     name: 'Default Config',
     request: 'launch',
     type: 'dfdl',
@@ -32,8 +33,14 @@ suite('Utils Test Suite', () => {
     debugServer: 4711,
     infosetFormat: 'xml',
     infosetOutput: {
-      type: 'none',
+      type: 'file',
       path: '${workspaceFolder}/target/infoset.xml',
+    },
+    tdmlConfig: {
+      action: 'none',
+      name: '${command:AskForTDMLName}',
+      description: '${command:AskForTDMLDescription}',
+      path: '${command:AskForTDMLPath}',
     },
     stopOnEntry: true,
     useExistingServer: false,
@@ -44,8 +51,10 @@ suite('Utils Test Suite', () => {
     daffodilDebugClasspath: '',
     dataEditorConfig: {
       port: 9000,
-      logFile: '${workspaceFolder}/dataEditor-${omegaEditPort}.log',
-      logLevel: 'info',
+      logging: {
+        file: '${workspaceFolder}/dataEditor-${omegaEditPort}.log',
+        level: 'info',
+      },
     },
     dfdlDebugger: {
       logging: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,29 +85,22 @@ export function getConfig(jsonArgs: object): vscode.DebugConfiguration {
   const launchConfigArgs: VSCodeLaunchConfigArgs = JSON.parse(
     JSON.stringify(jsonArgs)
   )
-  // Keep 'none' here as a default so that we don't always add the tdmlConfig block
-  let tdmlAction = defaultConf.get('tdmlAction', 'none')
-  let tdmlPropsNeeded = false
-  if (
-    tdmlAction === 'generate' ||
-    tdmlAction === 'append' ||
-    tdmlAction === 'execute'
-  ) {
-    tdmlPropsNeeded = true
-  }
 
   const defaultValues = {
     program: defaultConf.get('program', '${command:AskForProgramName}'),
     data: defaultConf.get('data', '${command:AskForDataName}'),
     debugServer: defaultConf.get('debugServer', 4711),
     infosetFormat: 'xml',
-    infosetOutput: {
-      type: defaultConf.get('infosetOutputType', 'none'),
-      path: defaultConf.get(
-        'infosetOutputFilePath',
-        '${workspaceFolder}/target/infoset.xml'
-      ),
-    },
+    infosetOutput: defaultConf.get('infosetOutput', {
+      type: 'file',
+      path: '${workspaceFolder}/target/infoset.xml',
+    }),
+    tdmlConfig: defaultConf.get('tdmlConfig', {
+      action: 'none',
+      name: '${command:AskForTDMLName}',
+      description: '${command:AskForTDMLDescription}',
+      path: '${command:AskForTDMLPath}',
+    }),
     stopOnEntry: defaultConf.get('stopOnEntry', true),
     useExistingServer: defaultConf.get('useExistingServer', false),
     trace: defaultConf.get('trace', true),
@@ -115,23 +108,19 @@ export function getConfig(jsonArgs: object): vscode.DebugConfiguration {
     openInfosetView: defaultConf.get('openInfosetView', false),
     openInfosetDiffView: defaultConf.get('openInfosetDiffView', false),
     daffodilDebugClasspath: defaultConf.get('daffodilDebugClasspath', ''),
-    dataEditorConfig: {
-      port: defaultConf.get('dataEditorPort', 9000),
-      logFile: defaultConf.get(
-        'dataEditorLogFile',
-        '${workspaceFolder}/dataEditor-${omegaEditPort}.log'
-      ),
-      logLevel: defaultConf.get('dataEditorLogLevel', 'info'),
-    },
-    dfdlDebugger: {
+    dataEditorConfig: defaultConf.get('dataEditor', {
+      port: 9000,
       logging: {
-        level: defaultConf.get('dfdlDebuggerLogLevel', 'INFO'),
-        file: defaultConf.get(
-          'dfdlDebuggerLogFile',
-          '/tmp/daffodil-debugger.log'
-        ),
+        level: 'info',
+        file: '${workspaceFolder}/dataEditor-${omegaEditPort}.log',
       },
-    },
+    }),
+    dfdlDebugger: defaultConf.get('dfdlDebugger', {
+      logging: {
+        level: 'INFO',
+        file: '/tmp/daffodil-debugger.log',
+      },
+    }),
   }
 
   Object.entries(defaultValues).map(
@@ -140,20 +129,6 @@ export function getConfig(jsonArgs: object): vscode.DebugConfiguration {
         ? launchConfigArgs[key]
         : defaultValue)
   )
-
-  if (tdmlPropsNeeded) {
-    launchConfigArgs.tdmlConfig = launchConfigArgs.tdmlConfig
-      ? launchConfigArgs.tdmlConfig
-      : {
-          action: tdmlAction,
-          name: defaultConf.get('tdmlName', '${command:AskforTDMLName}'),
-          description: defaultConf.get(
-            'tdmlDescription',
-            '${command:AskForTDMLDescription}'
-          ),
-          path: defaultConf.get('tdmlPath', '${workspaceFolder}/infoset.tdml'),
-        }
-  }
 
   return JSON.parse(JSON.stringify(launchConfigArgs))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,6 +2565,11 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+run-func@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/run-func/-/run-func-3.0.0.tgz#16b5802afdb8e92d3e0857d16e728295876005cb"
+  integrity sha512-RZwVzBrD7biV5CiAgwEUdaRGt0hLjBrhn4PqemBuNogH9Sc/8Bv8p+6F6AweU5bxZXsb3Mxltgu+/f+TGi0udA==
+
 rxjs@^7.0.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"


### PR DESCRIPTION
Fix hierarchy default values. Update how yarn scripts are ran.

- Remove individual default values for all attributes of an object. Instead create a default object.
- Run yarn scripts by calling a function from a TS file instead of doing it inline in the package.json.
  - Created build/scripts/yarn-scripts.ts which holds different methods that are the scripts that can be ran.
  - Added package run-func so it is easier to run the yarn TS script functions and makes the yarn scripts in the package.json look cleaner.
- Add nodemon config file debugger/nodemon.json. nodemon running through TS script seemed to cause issues so using config file instead.

Closes #698