### PR TITLE
Multiple Launch Wizard updates

### DIFF
--- a/src/classes/vscode-launch.ts
+++ b/src/classes/vscode-launch.ts
@@ -30,7 +30,7 @@ export interface VSCodeLaunchConfigArgs {
   infosetFormat: string | null
   infosetOutput: InfosetOutput | null
   tdmlConfig: TDMLConfig | null
-  dataEditorConfig: DataEditorConfig | null
+  dataEditor: DataEditorConfig | null
   stopOnEntry: boolean
   useExistingServer: boolean
   trace: boolean

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -18,6 +18,9 @@
 import * as fs from 'fs'
 import * as vscode from 'vscode'
 import { getConfig, osCheck } from '../utils'
+import { DFDLDebugger } from '../classes/dfdlDebugger'
+import { VSCodeLaunchConfigArgs } from '../classes/vscode-launch'
+import { DataEditorConfig } from '../classes/dataEditor'
 
 const defaultConf = getConfig({
   name: 'Wizard Config',
@@ -37,7 +40,8 @@ export async function activate(ctx: vscode.ExtensionContext) {
 // Function to get config values
 function getConfigValues(data, configIndex) {
   if (data && configIndex !== -1) {
-    let currentConfig = data.configurations[configIndex]
+    let configs: Array<VSCodeLaunchConfigArgs> = data.configurations
+    var currentConfig = configs[configIndex]
 
     // make sure config has needed items set, if not update it
     for (var key of Object.keys(defaultConf)) {
@@ -379,8 +383,8 @@ class LaunchWizard {
       }
     })
 
-    let tdmlActionSelect = ''
-    let tdmlActions = ['generate', 'append', 'execute']
+    let tdmlActionSelect = 'none'
+    let tdmlActions = ['none', 'generate', 'append', 'execute']
     let tdmlAction =
       'tdmlConfig' in defaultValues ? defaultValues.tdmlConfig['action'] : null
     let tdmlName =
@@ -410,9 +414,8 @@ class LaunchWizard {
       }
     })
 
-    let dataEditorPort = defaultValues.dataEditorConfig['port']
-    let dataEditorLogFile = defaultValues.dataEditorConfig['logging']['file']
-    let dataEditorLogLevel = defaultValues.dataEditorConfig['logging']['level']
+    let dfdlDebugger: DFDLDebugger = defaultValues.dfdlDebugger
+    let dataEditor: DataEditorConfig = defaultValues.dataEditor
 
     return `
   <!DOCTYPE html>
@@ -477,10 +480,17 @@ class LaunchWizard {
         <button id="dataBrowse" class="browse-button" type="button" onclick="filePicker('data', 'Select input data file to debug')">Browse</button>
       </div>
 
-      <div id="debugServerDiv" class="setting-div">
-        <p>Debug Server:</p>
+      <div id="dfdlDebuggerDiv" class="setting-div">
+        <p>Daffodil Debugger Settings:</p>
+
         <p class="setting-description">Port debug server running on.</p>
         <input class="file-input" value="${defaultValues.debugServer}" id="debugServer"/>
+
+        <p id="dfdlDebuggerLogFileLabel" style="margin-top: 10px;" class="setting-description">Log File:</p>
+        <input class="file-input" value="${dfdlDebugger.logging.file}" id="dfdlDebuggerLogFile">
+        
+        <p id="dfdlDebuggerLogLevelLabel" style="margin-top: 10px;" class="setting-description">Log Level:</p>
+        <input class="file-input" value="${dfdlDebugger.logging.level}" id="dfdlDebuggerLogLevel">
       </div>
 
       <div id="infosetFormatDiv" class="setting-div">
@@ -529,7 +539,7 @@ class LaunchWizard {
 
       <div id="tdmlActionDiv" class="setting-div">
         <p>TDML Action:</p>
-        <p class="setting-description">TDML Action (generate | append | execute)</p>
+        <p class="setting-description">TDML Action (none | generate | append | execute)</p>
         <select onChange="updateTDMLAction()" class="file-input" style="width: 200px;" id="tdmlAction">
           ${tdmlActionSelect}
         </select>
@@ -571,13 +581,13 @@ class LaunchWizard {
         <p>Data Editor Settings:</p>
         
         <p id="dataEditorPortLabel" class="setting-description">omega-edit Port:</p>
-        <input class="file-input" value="${dataEditorPort}" id="dataEditorPort">
+        <input class="file-input" value="${dataEditor.port}" id="dataEditorPort">
 
         <p id="dataEditorLogFileLabel" style="margin-top: 10px;" class="setting-description">Log File:</p>
-        <input class="file-input" value="${dataEditorLogFile}" id="dataEditorLogFile">
+        <input class="file-input" value="${dataEditor.logging.file}" id="dataEditorLogFile">
         
         <p id="dataEditorLogLevelLabel" style="margin-top: 10px;" class="setting-description">Log Level:</p>
-        <input class="file-input" value="${dataEditorLogLevel}" id="dataEditorLogLevel">
+        <input class="file-input" value="${dataEditor.logging.level}" id="dataEditorLogLevel">
       </div>
 
       <div id="useExistingServerDiv" class="setting-div" onclick="check('useExistingServer')">

--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -57,7 +57,7 @@ suite('Daffodil Debugger', () => {
     path: TDML_PATH,
   }
 
-  const dataEditorConfig: DataEditorConfig = {
+  const dataEditor: DataEditorConfig = {
     port: 9000,
     logging: {
       file: 'dataEditor-9000.log',
@@ -134,7 +134,7 @@ suite('Daffodil Debugger', () => {
           path: XML_INFOSET_PATH,
         },
         tdmlConfig: tdmlConf,
-        dataEditorConfig: dataEditorConfig,
+        dataEditor: dataEditor,
       }),
       {
         noDebug: true,
@@ -160,7 +160,7 @@ suite('Daffodil Debugger', () => {
           path: JSON_INFOSET_PATH,
         },
         tdmlConfig: tdmlConf,
-        dataEditorConfig: dataEditorConfig,
+        dataEditor: dataEditor,
       }),
       {
         noDebug: true,

--- a/src/tests/suite/utils.test.ts
+++ b/src/tests/suite/utils.test.ts
@@ -49,7 +49,7 @@ suite('Utils Test Suite', () => {
     openInfosetView: false,
     openInfosetDiffView: false,
     daffodilDebugClasspath: '',
-    dataEditorConfig: {
+    dataEditor: {
       port: 9000,
       logging: {
         file: '${workspaceFolder}/dataEditor-${omegaEditPort}.log',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -108,7 +108,7 @@ export function getConfig(jsonArgs: object): vscode.DebugConfiguration {
     openInfosetView: defaultConf.get('openInfosetView', false),
     openInfosetDiffView: defaultConf.get('openInfosetDiffView', false),
     daffodilDebugClasspath: defaultConf.get('daffodilDebugClasspath', ''),
-    dataEditorConfig: defaultConf.get('dataEditor', {
+    dataEditor: defaultConf.get('dataEditor', {
       port: 9000,
       logging: {
         level: 'info',


### PR DESCRIPTION
Multiple Launch Wizard updates:

- Rename dataEditorConfig attribute to dataEditor to be more consistent.
- Fix issue caused by the tdmlAction being an empty string. When its empty set it to 'none'
- Update setting of dataEditor config for launch wizard to match new config.
- Add dfdlDebugger (logging.level and logging.file) to the launch wizard.
- Clear out daffodil debugger classpath items when switching config.
  - This fixes an issue where the debugger classpath would have duplicate items or just wouldn't be proper for the config.

Closes #678
Closes #693