### PR TITLE
Data Editor File Traversal onclick Hotfix

### DIFF
--- a/src/svelte/src/components/DataDisplays/CustomByteDisplay/DataLineFeed.svelte
+++ b/src/svelte/src/components/DataDisplays/CustomByteDisplay/DataLineFeed.svelte
@@ -523,6 +523,7 @@ limitations under the License.
   <FlexContainer --dir="column">
     <FileTraversalIndicator
       totalLines={totalLinesPerFilesize}
+      selectionActive={$selectionDataStore.active}
       currentLine={lineTop}
       fileOffset={viewportData.fileOffset}
       maxDisplayLines={NUM_LINES_DISPLAYED}

--- a/src/svelte/src/components/DataDisplays/CustomByteDisplay/FileTraversalIndicator.svelte
+++ b/src/svelte/src/components/DataDisplays/CustomByteDisplay/FileTraversalIndicator.svelte
@@ -25,6 +25,7 @@ limitations under the License.
   export let bytesPerRow = 16
   export let percentageTraversed
   export let maxDisplayLines = 20
+  export let selectionActive
 
   let indicatorContainer: HTMLElement
   let indicatorClickDisabled: boolean = false
@@ -46,8 +47,8 @@ limitations under the License.
         indicatorContainer.addEventListener('click', updatePercentageTraversed)
     }
   }
-
   function updatePercentageTraversed(e: MouseEvent) {
+    if (selectionActive) return
     // Calculate the position of the click relative to the indicator container
     const relativeClickPosition =
       e.clientX - indicatorContainer.getBoundingClientRect().left


### PR DESCRIPTION
- Fixes an issue where the user could traverse the file via the file traversal pseudo scrollbar, if a selection was active.

Closes #731