### PR TITLE
Fix issue of duplicate descriptions for different views.

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,12 +403,12 @@
               },
               "openInfosetView": {
                 "type": "boolean",
-                "description": "Open hexview on debug start",
+                "description": "Open infoset view on debug start",
                 "default": false
               },
               "openInfosetDiffView": {
                 "type": "boolean",
-                "description": "Open hexview on debug start",
+                "description": "Open infoset diff view on debug start",
                 "default": false
               },
               "daffodilDebugClasspath": {
@@ -613,12 +613,12 @@
           },
           "openInfosetView": {
             "type": "boolean",
-            "description": "Open hexview on debug start",
+            "description": "Open infoset view on debug start",
             "default": false
           },
           "openInfosetDiffView": {
             "type": "boolean",
-            "description": "Open hexview on debug start",
+            "description": "Open infoset diff view on debug start",
             "default": false
           },
           "daffodilDebugClasspath": {

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -523,7 +523,7 @@ class LaunchWizard {
 
       <div id="openInfosetDiffViewDiv" class="setting-div" onclick="check('openInfosetDiffView')">
         <p>Open Infoset Diff View:</p>
-        <label class="container">Open hexview on debug start.
+        <label class="container">Open infoset view on debug start.
           <input type="checkbox" id="openInfosetDiffView" ${openInfosetDiffView}>
           <span class="checkmark"></span>
         </label>
@@ -531,7 +531,7 @@ class LaunchWizard {
 
       <div id="openInfosetViewDiv" class="setting-div" onclick="check('openInfosetView')">
         <p>Open Infoset View:</p>
-        <label class="container">Open hexview on debug start.
+        <label class="container">Open infoset diff on debug start.
           <input type="checkbox" id="openInfosetView" ${openInfosetView}>
           <span class="checkmark"></span>
         </label>


### PR DESCRIPTION
Fix issue of duplicate descriptions for different views.

- Update package.json to fix the description of the openInfosetView and openInfosetDiffView variables.
- Update launchWizard to fix the description of the openInfosetView and openInfosetDiffView display items.

Closes #730