### PR TITLE
Add missing dependencies to LICENSE, NOTICE and NONOTICE.

### DIFF
--- a/build/package/LICENSE
+++ b/build/package/LICENSE
@@ -210,6 +210,7 @@ the source code for these subcomponents is subject to the terms and
 conditions of the following licenses.
 
 - 'abort-controller' in extension/dist/ext/extension.js
+- 'abort-controller' in node_modules/@omega-edit/client
   This product bundles 'abort-controller' from the above files.
   These packages are available under the MIT License:
     MIT License
@@ -235,6 +236,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'atomic-sleep' in extension/dist/ext/extension.js
+- 'atomic-sleep' in node_modules/@omega-edit/client
   This product bundles 'atomic-sleep' from the above files.
   These packages are available under the MIT License:
     The MIT License (MIT)
@@ -260,9 +262,13 @@ conditions of the following licenses.
     OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'ansi-regex' in extension/dist/ext/extension.js
+- 'ansi-regex' in node_modules/@omega-edit/client
 - 'ansi-styles' in extension/dist/ext/extension.js
+- 'ansi-styles' in node_modules/@omega-edit/client
 - 'string-width' in extension/dist/ext/extension.js
+- 'string-width' in node_modules/@omega-edit/client
 - 'wrap-ansi' in extension/dist/ext/extension.js
+- 'wrap-ansi' in node_modules/@omega-edit/client
   This product bundles 'ansi-regex', 'ansi-styles', 'string-width' and 'wrap-ansi' from the above files.
   These packages are available under the MIT License:
     MIT License
@@ -282,6 +288,7 @@ conditions of the following licenses.
     https://github.com/davidaq/node-await-notify
 
 - 'base64-js' in extension/dist/ext/extension.js
+- 'base64-js' in node_modules/@omega-edit/client
   This product bundles 'base64-js' from the above files.
   These files are available under the MIT License:
     The MIT License (MIT)
@@ -316,6 +323,7 @@ conditions of the following licenses.
     http://www.opensource.org/licenses/mit-license.php
 
 - 'buffer' in extension/dist/ext/extension.js
+- 'buffer' in node_modules/@omega-edit/client
   This product bundles 'buffer' from the above files.
   These files are available under the MIT License:
     The MIT License (MIT)
@@ -359,8 +367,11 @@ conditions of the following licenses.
     http://www.opensource.org/licenses/mit-license.php
 
 - 'cliui' in extension/dist/ext/extension.js
+- 'cliui' in node_modules/@omega-edit/client
 - 'y18n' in extension/dist/ext/extension.js
+- 'y18n' in node_modules/@omega-edit/client
 - 'yargs-parser' in extension/dist/ext/extension.js
+- 'yargs-parser' in node_modules/@omega-edit/client
   This product bundles 'cliui', 'y18n' and 'yargs-parser' from the above files.
   These packages are available under the ISC License:
     Copyright (c) 2015, Contributors
@@ -378,8 +389,8 @@ conditions of the following licenses.
     WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
     ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-
 - 'color-convert' in extension/dist/ext/extension.js
+- 'color-convert' in node_modules/@omega-edit/client
   This product bundles 'color-convert' from the above files.
   This package is available under the MIT License:
     Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>.
@@ -405,6 +416,7 @@ conditions of the following licenses.
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'color-name' in extension/dist/ext/extension.js
+- 'color-name' in node_modules/@omega-edit/client
   This product bundles 'color-name' from the above files.
   This package is available under the MIT License:
     The MIT License (MIT)
@@ -417,6 +429,7 @@ conditions of the following licenses.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'emoji-regex' in extension/dist/ext/extension.js
+- 'emoji-regex' in node_modules/@omega-edit/client
   This product bundles 'emoji-regex' from the above files.
   This package is available under the MIT License:
     Copyright Mathias Bynens <https://mathiasbynens.be/>
@@ -441,6 +454,7 @@ conditions of the following licenses.
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'escalade' in extension/dist/ext/extension.js
+- 'escalade' in node_modules/@omega-edit/client
   This product bundles 'escalade' from the above files.
   This package is available under the MIT License:
     MIT License
@@ -454,6 +468,7 @@ conditions of the following licenses.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'event-target-shim' in extension/dist/ext/extension.js
+- 'event-target-shim' in node_modules/@omega-edit/client
   This product bundles 'event-target-shim' from the above files.
   This package is available under the MIT License:
     The MIT License (MIT)
@@ -479,6 +494,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'events' in extension/dist/ext/extension.js
+- 'events' in node_modules/@omega-edit/client
   This product bundles 'events' from the above files.
   This package is available under the MIT License:
     MIT
@@ -505,6 +521,7 @@ conditions of the following licenses.
     USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'fast-redact' in extension/dist/ext/extension.js
+- 'fast-redact' in node_modules/@omega-edit/client
   This product bundles 'fast-redact' from the above files.
   This package is available under the MIT License:
     The MIT License (MIT)
@@ -556,6 +573,7 @@ conditions of the following licenses.
     THE SOFTWARE.
 
 - 'get-caller-file' in extension/dist/ext/extension.js
+- 'get-caller-file' in node_modules/@omega-edit/client
   This product bundles 'get-caller-file' from the above files.
   This package is available under the ISC License:
     ISC License (ISC)
@@ -565,8 +583,8 @@ conditions of the following licenses.
 
     THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-
 - 'has-flag' in extension/dist/ext/extension.js
+- 'has-flag' in node_modules/@omega-edit/client
   This product bundles 'has-flag' from the above files.
   This package is available under the MIT LICENSE:
 
@@ -609,6 +627,7 @@ conditions of the following licenses.
     OTHER DEALINGS IN THE SOFTWARE.
 
 - 'ieee754' in in extension/dist/ext/extension.js
+- 'ieee754' in node_modules/@omega-edit/client
   This product bundles 'ieee754' from the above files.
   This package is available under the BSD-3-Clause License:
     Copyright 2008 Fair Oaks Labs, Inc.
@@ -624,6 +643,7 @@ conditions of the following licenses.
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 - 'is-fullwidth-code-point' in extension/dist/ext/extension.js
+- 'is-fullwidth-code-point' in node_modules/@omega-edit/client
   This product bundles 'is-fullwidth-code-point' from the above files.
   These files are available under the MIT License:
     MIT License
@@ -637,6 +657,7 @@ conditions of the following licenses.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'lodash.camelcase' in extension/dist/ext/extension.js
+- 'lodash.camelcase' in node_modules/@omega-edit/client
   This product bundles 'lodash.camelcase' from the above files.
   This package is available under the MIT License:
     The MIT License
@@ -739,6 +760,7 @@ conditions of the following licenses.
     THE SOFTWARE.
 
 - 'ms' in extension/dist/ext/extension.js
+- 'ms' in node_modules/@omega-edit/client
   This product bundles 'ms' from the above files.
   This package is available under the MIT LICENSE:
 
@@ -765,6 +787,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'on-exit-leak-free' in extension/dist/ext/extension.js
+- 'on-exit-leak-free' in node_modules/@omega-edit/client
   This product bundles 'on-exit-leak-free' from the above files.
   These files are available under the MIT License:
     MIT License
@@ -818,6 +841,7 @@ conditions of the following licenses.
     OTHER DEALINGS IN THE SOFTWARE.
 
 - 'pino-abstract-transport' in extension/dist/ext/extension.js
+- 'pino-abstract-transport' in node_modules/@omega-edit/client
   This product bundles 'pino-abstract-transport' from the above files.
   These files are available under the MIT License:
     MIT License
@@ -843,6 +867,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'pino-std-serializers' in extension/dist/ext/extension.js
+- 'pino-std-serializers' in node_modules/@omega-edit/client
   This product bundles 'pino-std-serializers' from the above files.
   These files are available under the MIT License:
     Copyright Mateo Collina, David Mark Clements, James Sumners
@@ -854,6 +879,7 @@ conditions of the following licenses.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'pino' in extension/dist/ext/extension.js
+- 'pino' in node_modules/@omega-edit/client
   This product bundles 'pino' from the above files.
   These files are available under the MIT License:
     The MIT License (MIT)
@@ -882,6 +908,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'process-warning' in extension/dist/ext/extension.js
+- 'process-warning' in node_modules/@omega-edit/client
   This product bundles 'process-warning' from the above files.
   These files are available under the MIT License:
     MIT License
@@ -907,6 +934,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'process' in extension/dist/ext/extension.js
+- 'process' in node_modules/@omega-edit/client
   This product bundles 'process' from the above files.
   These files are available under the MIT License:
     (The MIT License)
@@ -933,6 +961,7 @@ conditions of the following licenses.
     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'protobufjs' in extension/dist/ext/extension.js
+- 'protobufjs' in node_modules/@omega-edit/client
   This product bundles 'protobufjs' from the above files.
   These packages are available under the BSD-3-Clause License:
     This license applies to all parts of protobuf.js except those files
@@ -975,8 +1004,9 @@ conditions of the following licenses.
     standalone and requires a support library to be linked with it. This
     support library is itself covered by the above license.
 
-- 'quick-format-unescape' in extension/dist/ext/extension.js
-  This product bundles 'quick-format-unescape' from the above files.
+- 'quick-format-unescaped' in extension/dist/ext/extension.js
+- 'quick-format-unescaped' in node_modules/@omega-edit/client
+  This product bundles 'quick-format-unescaped' from the above files.
   These files are available under the MIT License:
     The MIT License (MIT)
 
@@ -1001,6 +1031,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'readable-stream' in extension/dist/ext/extension.js
+- 'readable-stream' in node_modules/@omega-edit/client
   This product bundles 'readable-stream' from the above files.
   These files are available under the MIT License:
     Node.js is licensed for use as follows:
@@ -1052,6 +1083,7 @@ conditions of the following licenses.
     """
 
 - 'real-require' in extension/dist/ext/extension.js
+- 'real-require' in node_modules/@omega-edit/client
   This product bundles 'real-require' from the above files.
   These files are available under the MIT License:
     The MIT License (MIT)
@@ -1077,6 +1109,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'require-directory' in extension/dist/ext/extension.js
+- 'require-directory' in node_modules/@omega-edit/client
   This product bundles 'require-directory' from the above files.
   This package is available under the MIT License:
     The MIT License (MIT)
@@ -1102,7 +1135,33 @@ conditions of the following licenses.
     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+- 'safe-buffer' in node_modules/@omega-edit/client
+  This product bundles 'safe-buffer' from the above files.
+  These files are available under the MIT License:
+    The MIT License (MIT)
+
+    Copyright (c) Feross Aboukhadijeh
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
 - 'safe-stable-stringify' in extension/dist/ext/extension.js
+- 'safe-stable-stringify' in node_modules/@omega-edit/client
   This product bundles 'safe-stable-stringify' from the above files.
   These files are available under the MIT License:
     The MIT License (MIT)
@@ -1128,6 +1187,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'sonic-boom' in extension/dist/ext/extension.js
+- 'sonic-boom' in node_modules/@omega-edit/client
   This product bundles 'sonic-boom' from the above files.
   These files are available under the MIT License:
     MIT License
@@ -1153,6 +1213,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'split2' in in extension/dist/ext/extension.js
+- 'split2' in node_modules/@omega-edit/client
   This product bundles 'split2' from the above files.
   This package is available under the ISC License:
     Copyright (c) 2014-2018, Matteo Collina <hello@matteocollina.com>
@@ -1169,7 +1230,59 @@ conditions of the following licenses.
     ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
     IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+- 'string_decoder' in node_modules/@omega-edit/client
+  This product bundles 'string_decoder' from the above files.
+  These files are available under the MIT License:
+    Node.js is licensed for use as follows:
+
+    """
+    Copyright Node.js contributors. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+    """
+
+    This license applies to parts of Node.js originating from the
+    https://github.com/joyent/node repository:
+
+    """
+    Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+    """
+
 - 'strip-ansi' in extension/dist/ext/extension.js
+- 'strip-ansi' in node_modules/@omega-edit/client
   This product bundles 'strip-ansi' from the above files.
   This package is available under the MIT LICENSE:
 
@@ -1184,6 +1297,7 @@ conditions of the following licenses.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'supports-color' in extension/dist/ext/extension.js
+- 'supports-color' in node_modules/@omega-edit/client
   This product bundles 'supports-color' from the above files.
   This package is available under the MIT LICENSE:
 
@@ -1198,6 +1312,7 @@ conditions of the following licenses.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'thread-stream' in extension/dist/ext/extension.js
+- 'thread-stream' in node_modules/@omega-edit/client
   This product bundles 'thread-stream' from the above files.
   These files are available under the MIT License:
     MIT License
@@ -1278,15 +1393,25 @@ conditions of the following licenses.
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - '@protobufjs/aspromise' in extension/dist/ext/extension.js
+- '@protobufjs/aspromise' in node_modules/@omega-edit/client
 - '@protobufjs/base64' in extension/dist/ext/extension.js
+- '@protobufjs/base64' in node_modules/@omega-edit/client
 - '@protobufjs/codegen' in extension/dist/ext/extension.js
+- '@protobufjs/codegen' in node_modules/@omega-edit/client
 - '@protobufjs/eventemitter' in extension/dist/ext/extension.js
+- '@protobufjs/eventemitter' in node_modules/@omega-edit/client
 - '@protobufjs/fetch' in extension/dist/ext/extension.js
+- '@protobufjs/fetch' in node_modules/@omega-edit/client
 - '@protobufjs/float' in extension/dist/ext/extension.js
+- '@protobufjs/float' in node_modules/@omega-edit/client
 - '@protobufjs/inquire' in extension/dist/ext/extension.js
+- '@protobufjs/inquire' in node_modules/@omega-edit/client
 - '@protobufjs/path' in extension/dist/ext/extension.js
+- '@protobufjs/path' in node_modules/@omega-edit/client
 - '@protobufjs/pool' in extension/dist/ext/extension.js
+- '@protobufjs/pool' in node_modules/@omega-edit/client
 - '@protobufjs/utf8' in extension/dist/ext/extension.js
+- '@protobufjs/utf8' in node_modules/@omega-edit/client
   This product bundles multiple '@protobufjs' packages from the above files.
   This package is available under the BSD-3-Clause LICENSE:
 
@@ -1331,6 +1456,7 @@ conditions of the following licenses.
     support library is itself covered by the above license.
 
 - '@types/long' in extension/dist/ext/extension.js
+- '@types/long' in node_modules/@omega-edit/client
   This product bundles '@types/long' from the above files.
   These packages are available under the MIT License:
     This project is licensed under the MIT license.
@@ -1457,6 +1583,7 @@ conditions of the following licenses.
     OTHER DEALINGS IN THE SOFTWARE.
 
 - 'yargs' in extension/dist/ext/extension.js
+- 'yargs' in node_modules/@omega-edit/client
   This product bundles 'yargs' from the above files.
   This package is available under the MIT License:
     MIT License
@@ -1675,6 +1802,7 @@ conditions of the following licenses.
     suitability for any purpose.
 
 - '@types/node' in extension/dist/ext/extension.js
+- '@types/node' in node_modules/@omega-edit/client
   This product bundles '@types/long' from the above files.
   These packages are available under the MIT License:
     This project is licensed under the MIT license.
@@ -1701,6 +1829,7 @@ conditions of the following licenses.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'wait-port' in extension/dist/ext/extension.js
+- 'wait-port' in node_modules/@omega-edit/client
   This product bundles 'wait-port' from the above files.
   This package is available under the MIT LICENSE:
 
@@ -1727,6 +1856,7 @@ conditions of the following licenses.
     SOFTWARE.
 
 - 'chalk' in extension/dist/ext/extension.js
+- 'chalk' in node_modules/@omega-edit/client
   This product bundles 'chalk' from the above files.
   This package is available under the MIT LICENSE:
 
@@ -1741,6 +1871,7 @@ conditions of the following licenses.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'commander' in extension/dist/ext/extension.js
+- 'commander' in node_modules/@omega-edit/client
   This product bundles 'commander' from the above files.
   This package is available under the MIT LICENSE:
 
@@ -1768,6 +1899,7 @@ conditions of the following licenses.
     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'debug' in extension/dist/ext/extension.js
+- 'debug' in node_modules/@omega-edit/client
   This product bundles 'debug' from the above files.
   This package is available under the MIT LICENSE:
 
@@ -1792,6 +1924,7 @@ conditions of the following licenses.
     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - '@types/google-protobuf' in extension/dist/ext/extension.js
+- '@types/google-protobuf' in node_modules/@omega-edit/client
   This product bundles '@types/google-protobuf' from the above files.
   This package is available under the MIT LICENSE:
 
@@ -1805,6 +1938,7 @@ conditions of the following licenses.
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 - 'google-protobuf' in extension/dist/ext/extension.js
+- 'google-protobuf' in node_modules/@omega-edit/client
   This product bundles 'google-protobuf' from the above files.
   This package is available under the BSD-3-Clause LICENSE:
 

--- a/build/package/NONOTICE
+++ b/build/package/NONOTICE
@@ -10,17 +10,20 @@ Based on source code originally developed by
 
 The following binary components distributed with this project are licensed under the Apache License v2 but do not include NOTICE files in their repositories:
 
+- '@grpc/grpc-js' in node_modules/@omega-edit/client
 - '@grpc/grpc-js' in extension/dist/ext/extension.js
   This product bundles '@grpc/grpc-js' from the above files.
   This package is available under the Apache License v2 without a NOTICE:
         Repository at: https://github.com/grpc/grpc-node/tree/master
 
+- '@grpc/proto-loader' in node_modules/@omega-edit/client
 - '@grpc/proto-loader' in extension/dist/ext/extension.js
   This product bundles '@grpc/proto-loader' from the above files.
     This package is available under the Apache License v2 without a NOTICE:
         Repository at: https://github.com/grpc/grpc-node
 
 - 'long' in extension/dist/ext/extension.js
+- 'long' in node_modules/@omega-edit/client
   This product bundles 'long' from the above files.
   This package is available under the Apache License v2 without a NOTICE:
         Repository at: https://github.com/dcodeIO/long.js

--- a/build/package/NOTICE
+++ b/build/package/NOTICE
@@ -437,3 +437,8 @@ The following NOTICE information applies to binary components distributed with t
     * LOCATION_IN_GRPC:
       * xds/third_party/udpa
 
+- @omega-edit/client
+- @omega-edit/server
+- @omega-edit/server/bin
+  Ωedit
+  Copyright 2021-2022 Concurrent Technologies Corporation

--- a/package.json
+++ b/package.json
@@ -46,11 +46,10 @@
     "svelte:check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@vscode/debugadapter": "1.59.0",
     "@omega-edit/client": "0.9.70",
+    "@vscode/debugadapter": "1.59.0",
     "await-notify": "1.0.1",
     "hexy": "0.3.4",
-    "nodemon": "^3.0.1",
     "unzip-stream": "0.3.1",
     "uuid": "9.0.0",
     "wait-port": "1.0.4",
@@ -74,6 +73,7 @@
     "glob": "8.0.3",
     "mini-css-extract-plugin": "^2.7.6",
     "mocha": "10.2.0",
+    "nodemon": "^3.0.1",
     "prettier": "2.8.8",
     "prettier-plugin-svelte": "^2.9.0",
     "run-func": "^3.0.0",


### PR DESCRIPTION
Add missing dependencies to LICENSE, NOTICE and NONOTICE.

- Add missing depenencies to LICENSE, NOTICE and NONOTICE files, deps included:
  - @omega-edit/client -> and its transitivie dependencies that it bundles
  - quick-format-unescaped -> This was already there just named wrong as quick-format-unescape.
  - string_decoder
  - safe-buffer
- Removed nodemon as a production dependency and moved it to a devDependency as it does not need bundled with the extension.

Closes #688