### PR TITLE
Use jsonc-parser instead of JSON.parse

### DIFF
--- a/build/package/LICENSE
+++ b/build/package/LICENSE
@@ -656,6 +656,31 @@ conditions of the following licenses.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+- 'jsonc-parser' in extension/dist/ext/extension.js
+  This product bundles 'jsonc-parser' from the above files.
+  This package is available under the MIT License:
+    The MIT License (MIT)
+
+    Copyright (c) Microsoft
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
 - 'lodash.camelcase' in extension/dist/ext/extension.js
 - 'lodash.camelcase' in node_modules/@omega-edit/client
   This product bundles 'lodash.camelcase' from the above files.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@vscode/debugadapter": "1.59.0",
     "await-notify": "1.0.1",
     "hexy": "0.3.4",
+    "jsonc-parser": "^3.2.0",
     "unzip-stream": "0.3.1",
     "uuid": "9.0.0",
     "wait-port": "1.0.4",

--- a/src/daffodilDebugger/daffodil.ts
+++ b/src/daffodilDebugger/daffodil.ts
@@ -16,6 +16,7 @@
  */
 
 import * as fs from 'fs'
+import { parse as jsoncParse } from 'jsonc-parser'
 
 export const dataEvent = 'daffodil.data'
 export interface DaffodilData {
@@ -56,5 +57,5 @@ export interface BuildInfo {
 }
 
 export function getDaffodilVersion(filePath: fs.PathLike) {
-  return JSON.parse(fs.readFileSync(filePath).toString())['daffodilVersion']
+  return jsoncParse(fs.readFileSync(filePath).toString())['daffodilVersion']
 }

--- a/src/infoset.ts
+++ b/src/infoset.ts
@@ -29,7 +29,7 @@ import {
 // Function to display an infomation message that the infoset file has been created
 // If the user wishes to open the file then they may click the 'Open' button
 async function openInfosetFilePrompt() {
-  let config = JSON.parse(JSON.stringify(getCurrentConfig()))
+  let config = getCurrentConfig()
 
   if (config.infosetOutput.type === 'file') {
     let rootPath = vscode.workspace.workspaceFolders

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -21,6 +21,7 @@ import { getConfig, osCheck } from '../utils'
 import { DFDLDebugger } from '../classes/dfdlDebugger'
 import { VSCodeLaunchConfigArgs } from '../classes/vscode-launch'
 import { DataEditorConfig } from '../classes/dataEditor'
+import { parse as jsoncParse } from 'jsonc-parser'
 
 const defaultConf = getConfig({
   name: 'Wizard Config',
@@ -84,7 +85,7 @@ async function createUpdateConfigFile(data, updateOrCreate) {
   }
 
   let newConf = JSON.parse(data).configurations[0]
-  let fileData = JSON.parse(
+  let fileData = jsoncParse(
     fs.readFileSync(`${rootPath}/.vscode/launch.json`).toString()
   )
 
@@ -146,7 +147,7 @@ async function updateWebViewConfigValues(configIndex) {
   let fileData =
     configIndex === -1
       ? null
-      : JSON.parse(
+      : jsoncParse(
           fs.readFileSync(`${rootPath}/.vscode/launch.json`).toString()
         )
 
@@ -314,7 +315,7 @@ class LaunchWizard {
     let fileData = JSON.parse('{}')
 
     if (fs.existsSync(`${rootPath}/.vscode/launch.json`)) {
-      fileData = JSON.parse(
+      fileData = jsoncParse(
         fs.readFileSync(`${rootPath}/.vscode/launch.json`).toString()
       )
 

--- a/src/tests/suite/version.test.ts
+++ b/src/tests/suite/version.test.ts
@@ -19,10 +19,11 @@ import * as assert from 'assert'
 import * as fs from 'fs'
 import * as path from 'path'
 import { PROJECT_ROOT } from './common'
+import { parse as jsoncParse } from 'jsonc-parser'
 
 suite('Daffodil Version', () => {
   const versionFile = path.join(PROJECT_ROOT, 'src/version.ts')
-  const packageMapped = JSON.parse(
+  const packageMapped = jsoncParse(
     fs.readFileSync(path.join(PROJECT_ROOT, 'package.json')).toString()
   )
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,7 +57,7 @@ export function runCommand(command: string) {
 // Function for checking if config specifies if either the
 // infoset, infoset diff or hex view needs to be opened
 export async function onDebugStartDisplay(viewsToCheck: string[]) {
-  let config = JSON.parse(JSON.stringify(getCurrentConfig()))
+  let config = getCurrentConfig()
 
   viewsToCheck.forEach(async (viewToCheck) => {
     switch (viewToCheck) {

--- a/webpack/ext-dev.webpack.config.js
+++ b/webpack/ext-dev.webpack.config.js
@@ -12,8 +12,9 @@
 const path = require('path')
 const unzip = require('unzip-stream')
 const fs = require('fs')
+const jsoncParse = require('jsonc-parser').parse
 
-const packageData = JSON.parse(
+const packageData = jsoncParse(
   fs.readFileSync(path.resolve('package.json')).toString()
 )
 const pkg_version = packageData['version']

--- a/webpack/ext-package.webpack.config.js
+++ b/webpack/ext-package.webpack.config.js
@@ -26,10 +26,11 @@ const path = require('path')
 const unzip = require('unzip-stream')
 const fs = require('fs')
 const CopyPlugin = require('copy-webpack-plugin')
+const jsoncParse = require('jsonc-parser').parse
 
 const pkg_dir = path.resolve('dist/package')
 
-const packageData = JSON.parse(
+const packageData = jsoncParse(
   fs.readFileSync(path.resolve('package.json')).toString()
 )
 const pkg_version = packageData['version']


### PR DESCRIPTION
Use jsonc-parser instead of JSON.parse

- Update all files to that use JSON.parse to now use 'jsonc-parser'.parse instead.
  - jsonc-parser allows the json being parsed to not be strict json.

Closes #635