### PR TITLE
Fixed Multiple Data Editor Editing / Display Items

### DIFF
--- a/src/svelte/src/components/DataDisplays/CustomByteDisplay/BinaryData.ts
+++ b/src/svelte/src/components/DataDisplays/CustomByteDisplay/BinaryData.ts
@@ -16,8 +16,16 @@
  */
 
 import { SimpleWritable } from '../../../stores/localStore'
-import type { RadixValues } from '../../../stores/configuration'
-import { radixBytePad } from '../../../utilities/display'
+import {
+  NUM_LINES_DISPLAYED,
+  type BytesPerRow,
+  type RadixValues,
+  VIEWPORT_CAPACITY_MAX,
+} from '../../../stores/configuration'
+import {
+  radixBytePad,
+  viewport_offset_to_line_num,
+} from '../../../utilities/display'
 
 export const BYTE_ACTION_DIV_OFFSET: number = 24
 
@@ -95,6 +103,32 @@ export class ViewportDataStore_t extends SimpleWritable<ViewportData_t> {
   public set(value: ViewportData_t): void {
     this.store.set(value)
     this._offsetMax = value.fileOffset + value.bytesLeft + value.length
+  }
+
+  public lowerFetchBoundary(): number {
+    return this.storeData().fileOffset
+  }
+
+  public upperFetchBoundary(bytesPerRow: BytesPerRow): number {
+    const store = this.storeData()
+    const boundary =
+      store.fileOffset + store.length - NUM_LINES_DISPLAYED * bytesPerRow
+
+    return boundary
+  }
+
+  public lineTopMax(bytesPerRow: BytesPerRow): number {
+    const vpMaxOffset = Math.max(
+      0,
+      this.storeData().length - NUM_LINES_DISPLAYED * bytesPerRow
+    )
+    const vpLineTopMax = viewport_offset_to_line_num(
+      vpMaxOffset + this.storeData().fileOffset,
+      this.storeData().fileOffset,
+      bytesPerRow
+    )
+
+    return vpLineTopMax + 1
   }
 
   public physical_byte_values(

--- a/src/svelte/src/components/DataDisplays/CustomByteDisplay/DataValue.svelte
+++ b/src/svelte/src/components/DataDisplays/CustomByteDisplay/DataValue.svelte
@@ -39,7 +39,6 @@ limitations under the License.
 
   const eventDispatcher = createEventDispatcher()
 
-  let consideredForSelection = false
   let makingSelection = false
 
   $: {
@@ -50,6 +49,11 @@ limitations under the License.
 
   function mouse_enter_handle(event: MouseEvent) {
     if (!makingSelection) return
+    if (disabled) {
+      selectionData.endOffset = -1
+      makingSelection = false
+      return
+    }
     selectionData.endOffset = byte.offset
   }
   function mouse_leave_handle(event: MouseEvent) {
@@ -78,7 +82,6 @@ limitations under the License.
     class:isSelected
     class:isSearchResult
     class:possibleSelection
-    class:selecting={consideredForSelection}
     id={id + '-' + byte.offset.toString()}
     style:width
     on:mouseup={mouse_event_handle}
@@ -95,12 +98,13 @@ limitations under the License.
     class:isSelected
     class:isSearchResult
     class:possibleSelection
-    class:selecting={consideredForSelection}
     id={id + '-' + byte.offset.toString()}
     style:width={'20px'}
     class:latin1Undefined={latin1Undefined(byte.value)}
     on:mouseup={mouse_event_handle}
     on:mousedown={mouse_event_handle}
+    on:mouseenter={mouse_enter_handle}
+    on:mouseleave={mouse_leave_handle}
   >
     {latin1Undefined(byte.value) ? '' : String.fromCharCode(byte.value)}
   </div>

--- a/src/svelte/src/components/DataDisplays/CustomByteDisplay/FileTraversalIndicator.svelte
+++ b/src/svelte/src/components/DataDisplays/CustomByteDisplay/FileTraversalIndicator.svelte
@@ -16,13 +16,12 @@ limitations under the License.
 -->
 <script lang="ts">
   import { createEventDispatcher } from 'svelte'
-
+  import { bytesPerRow } from '../../../stores'
   const eventDispatcher = createEventDispatcher()
 
   export let totalLines = 0
   export let currentLine = 0
   export let fileOffset = 0
-  export let bytesPerRow = 16
   export let percentageTraversed
   export let maxDisplayLines = 20
   export let selectionActive: boolean
@@ -42,7 +41,7 @@ limitations under the License.
     } else {
       indicatorClickDisabled = false
       percentageTraversed =
-        ((currentLine + (fileOffset / bytesPerRow + 20)) / totalLines) * 100.0
+        ((currentLine + (fileOffset / $bytesPerRow + 20)) / totalLines) * 100.0
       if (indicatorContainer)
         indicatorContainer.addEventListener('click', updatePercentageTraversed)
     }

--- a/src/svelte/src/components/DataDisplays/DataViewports.svelte
+++ b/src/svelte/src/components/DataDisplays/DataViewports.svelte
@@ -17,9 +17,7 @@ limitations under the License.
 <script lang="ts">
   import {
     addressRadix,
-    bytesPerRow,
     displayRadix,
-    dataFeedLineTop,
     dataFeedAwaitRefresh,
     viewport,
   } from '../../stores'
@@ -32,7 +30,6 @@ limitations under the License.
   on:applyChanges
   on:handleEditorEvent
   viewportData={$viewport}
-  bytesPerRow={$bytesPerRow}
   dataRadix={$displayRadix}
   addressRadix={$addressRadix}
   bind:awaitViewportSeek={$dataFeedAwaitRefresh}

--- a/src/svelte/src/components/Editors/DataEditor.svelte
+++ b/src/svelte/src/components/Editors/DataEditor.svelte
@@ -15,7 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <script lang="ts">
-  import { editorSelection, editMode, selectionDataStore } from '../../stores'
+  import {
+    editorSelection,
+    editMode,
+    selectionDataStore,
+    regularSizedFile,
+  } from '../../stores'
   import { EditByteModes } from '../../stores/configuration'
   import { UIThemeCSSClass } from '../../utilities/colorScheme'
   import { createEventDispatcher } from 'svelte'
@@ -30,7 +35,9 @@ limitations under the License.
         {
           const eventDetails = event as InputEvent
           const editorElement = eventDetails.target as HTMLTextAreaElement
-          $editorSelection = editorElement.value
+          editorSelection.update(() => {
+            return editorElement.value
+          })
         }
 
         break
@@ -45,7 +52,7 @@ limitations under the License.
 </script>
 
 <div class="editView" id="edit_view">
-  {#if $editMode === EditByteModes.Multiple && $selectionDataStore.active}
+  {#if $editMode === EditByteModes.Multiple && ($selectionDataStore.active || !$regularSizedFile)}
     <textarea
       class={$UIThemeCSSClass}
       id="selectedContent"

--- a/src/svelte/src/components/Header/fieldsets/SearchReplace.svelte
+++ b/src/svelte/src/components/Header/fieldsets/SearchReplace.svelte
@@ -29,6 +29,7 @@ limitations under the License.
     searchErr,
     searchQuery,
     seekErr,
+    dataFeedAwaitRefresh,
   } from '../../../stores'
   import { vscode } from '../../../utilities/vscode'
   import { MessageCommand } from '../../../utilities/message'
@@ -255,6 +256,7 @@ limitations under the License.
         searchStarted = replaceStarted = false
         if (msg.data.data.replacementsCount > 0) {
           // subtract 1 from the next offset because search next will add 1
+          clearSearchResultsHighlights()
           matchOffset = msg.data.data.nextOffset - 1
           preReplaceHasPrev = hasPrev
           justReplaced = true

--- a/src/svelte/src/components/Header/fieldsets/Settings.svelte
+++ b/src/svelte/src/components/Header/fieldsets/Settings.svelte
@@ -24,9 +24,12 @@ limitations under the License.
     displayRadix,
     editorEncoding,
     editorActionsAllowed,
+    bytesPerRow,
   } from '../../../stores'
   import FlexContainer from '../../layouts/FlexContainer.svelte'
   import { UIThemeCSSClass } from '../../../utilities/colorScheme'
+
+  $: $bytesPerRow = $displayRadix === RADIX_OPTIONS.Binary ? 8 : 16
 </script>
 
 <fieldset>

--- a/src/svelte/src/utilities/display.ts
+++ b/src/svelte/src/utilities/display.ts
@@ -37,10 +37,6 @@ const ByteDivWidths = {
   2: '64px' as ByteDivWidth,
 }
 
-export type BinaryBytePrefix = 'B' | 'KB' | 'MB' | 'GB' | 'TB' | 'PB'
-
-export type BinaryBitPrefix = 'b' | 'Kb' | 'Mb' | 'Gb' | 'Tb' | 'Pb'
-
 export function radixBytePad(radix: RadixValues): number {
   switch (radix) {
     case 2:
@@ -181,7 +177,17 @@ export function viewport_offset_to_line_num(
   vpStartOffset: number,
   bytesPerRow: BytesPerRow
 ): number {
-  return Math.floor((offset - vpStartOffset) / bytesPerRow)
+  return Math.max(0, Math.floor((offset - vpStartOffset) / bytesPerRow))
+}
+
+export function line_num_to_file_offset(
+  lineNum: number,
+  viewportStartOffset: number,
+  bytesPerRow: BytesPerRow
+): number {
+  const offsetInViewport = lineNum * bytesPerRow
+  const offsetInFile = viewportStartOffset + offsetInViewport
+  return Math.max(0, offsetInFile)
 }
 
 export enum BinaryBytePrefixes {

--- a/src/svelte/src/utilities/elementKeypressEvents.ts
+++ b/src/svelte/src/utilities/elementKeypressEvents.ts
@@ -26,7 +26,6 @@ type ElementKeypressEvent = {
 }
 
 class ElementKeypressEventMap {
-  // private events: Array<ElementKeypressEvent> = []
   private events: {
     [key in ElementKeypressEventKey]: Array<ElementKeypressEvent>
   } = {

--- a/src/svelte/src/utilities/highlights.ts
+++ b/src/svelte/src/utilities/highlights.ts
@@ -50,6 +50,7 @@ export const selectionHighlights = derived(
 )
 
 export const searchResultsHighlights = readable(searchResultsHighlightLUT)
+export const searchResultsUpdated = writable(false)
 export function updateSearchResultsHighlights(
   data: number[],
   viewportFileOffset: number,
@@ -68,6 +69,7 @@ export function updateSearchResultsHighlights(
     for (let i = 0; i < byteWidth; i++)
       searchResultsHighlightLUT[offset - viewportFileOffset + i] = 1
   })
+  searchResultsUpdated.set(true)
 }
 export function clearSearchResultsHighlights() {
   searchResultsHighlightLUT.fill(0)


### PR DESCRIPTION
- Fixed issue where binary display radix would still display 16 bytes per row, instead of 8.
- Fixed inability to edit a "non-regular" sized file ( file size < 2 )
- Rerouted all file / viewport UI offset traversal to use toplevel `seek()` function.

Closes #821
Closes #783