### PR TITLE
update nightly CI to test under node 16 and 18

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,8 +26,8 @@ jobs:
     name: 'Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, VS Code: ${{ matrix.vscode }} )'
     strategy:
       matrix:
-        os: [ macos-11, ubuntu-20.04, windows-2019 ]
-        node: [ '14', '16' ]
+        os: [ macos-11, ubuntu-20.04, windows-2019, macos-latest, ubuntu-latest, windows-latest ]
+        node: [ '16', '18' ]
         vscode: [ 'stable', 'insiders' ]
       fail-fast: false  # don't immediately fail all other jobs if a single job fails
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Nightly testing to use node 16 and 18 builds for testing against the latest VS Code stable and insider's builds.  It may not work with node 16 since the latest stable and insider's use node 18 internally.