### PR TITLE
Add -no-header flag for consistent JAXB builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,6 +135,7 @@ lazy val xjcSettings =
     xjcCommandLine += "-nv",
     xjcCommandLine += "-p",
     xjcCommandLine += "org.apache.daffodil.tdml",
+    xjcCommandLine += "-no-header",
     xjcBindings += "debugger/src/main/resources/bindings.xjb",
     xjcJvmOpts ++= extraJvmOptions,
     xjcLibs := Seq(


### PR DESCRIPTION
Closes #840 

Creating as draft because this is most likely only going to be temporarily a problem.