### PR TITLE
Implemented Configurable Data Viewport Geometry

### DIFF
--- a/src/svelte/src/components/DataDisplays/CustomByteDisplay/BinaryData.ts
+++ b/src/svelte/src/components/DataDisplays/CustomByteDisplay/BinaryData.ts
@@ -17,15 +17,15 @@
 
 import { SimpleWritable } from '../../../stores/localStore'
 import {
-  NUM_LINES_DISPLAYED,
   type BytesPerRow,
   type RadixValues,
-  VIEWPORT_CAPACITY_MAX,
 } from '../../../stores/configuration'
 import {
   radixBytePad,
   viewport_offset_to_line_num,
 } from '../../../utilities/display'
+import { dataDislayLineAmount } from '../../../stores'
+import { get } from 'svelte/store'
 
 export const BYTE_ACTION_DIV_OFFSET: number = 24
 
@@ -112,7 +112,7 @@ export class ViewportDataStore_t extends SimpleWritable<ViewportData_t> {
   public upperFetchBoundary(bytesPerRow: BytesPerRow): number {
     const store = this.storeData()
     const boundary =
-      store.fileOffset + store.length - NUM_LINES_DISPLAYED * bytesPerRow
+      store.fileOffset + store.length - get(dataDislayLineAmount) * bytesPerRow
 
     return boundary
   }
@@ -120,7 +120,7 @@ export class ViewportDataStore_t extends SimpleWritable<ViewportData_t> {
   public lineTopMax(bytesPerRow: BytesPerRow): number {
     const vpMaxOffset = Math.max(
       0,
-      this.storeData().length - NUM_LINES_DISPLAYED * bytesPerRow
+      this.storeData().length - get(dataDislayLineAmount) * bytesPerRow
     )
     const vpLineTopMax = viewport_offset_to_line_num(
       vpMaxOffset + this.storeData().fileOffset,

--- a/src/svelte/src/components/Header/fieldsets/Settings.svelte
+++ b/src/svelte/src/components/Header/fieldsets/Settings.svelte
@@ -24,12 +24,11 @@ limitations under the License.
     displayRadix,
     editorEncoding,
     editorActionsAllowed,
-    bytesPerRow,
   } from '../../../stores'
   import FlexContainer from '../../layouts/FlexContainer.svelte'
   import { UIThemeCSSClass } from '../../../utilities/colorScheme'
+  import ViewportVisibilityIcon from '../../Icons/ViewportVisibilityIcon.svelte'
 
-  $: $bytesPerRow = $displayRadix === RADIX_OPTIONS.Binary ? 8 : 16
 </script>
 
 <fieldset>
@@ -76,6 +75,7 @@ limitations under the License.
     </FlexContainer>
 
     <hr />
+    <ViewportVisibilityIcon dimension={20}/>
   </FlexContainer>
 </fieldset>
 

--- a/src/svelte/src/components/Icons/ViewportVisibilityIcon.svelte
+++ b/src/svelte/src/components/Icons/ViewportVisibilityIcon.svelte
@@ -1,0 +1,214 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script lang='ts'>
+  import Tooltip from "../layouts/Tooltip.svelte"
+  import { bytesPerRow, dataDislayLineAmount, visableViewports } from "../../stores"
+  import { BYTES_PER_ROW_MAX_LINE_NUM, type BytesPerRow } from "../../stores/configuration"
+
+    export let dimension: number = 20
+    const defaultDimension = 20
+    const minDimension = 15
+    const maxDimension = 30
+
+    let width  = valid_dimensions()
+    let height = valid_dimensions()
+    let minWidth = pixel_string(minDimension)
+    let minHeight = pixel_string(minDimension)
+    let maxWidth = pixel_string(maxDimension)
+    let maxHeight = pixel_string(maxDimension)
+
+    let selectionsDisplay = {
+        viewports: false,
+        bytesPerRow: false
+    }
+
+    function valid_dimensions(): string {
+        return (dimension > maxDimension || dimension < minDimension) 
+            ? pixel_string(defaultDimension)
+            : pixel_string(dimension)
+    }
+    function pixel_string(value: number): string {
+        return value.toString() + 'px'
+    }
+    function set_bytes_per_row(bytesPerRowSelection: BytesPerRow) {
+        if($dataDislayLineAmount > BYTES_PER_ROW_MAX_LINE_NUM[bytesPerRowSelection])
+            $dataDislayLineAmount = BYTES_PER_ROW_MAX_LINE_NUM[bytesPerRowSelection]
+        
+        $bytesPerRow = bytesPerRowSelection
+    }
+</script>
+
+<span class="icon-container">
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <Tooltip alwaysEnabled={true} description="Viewports visible: {$visableViewports}">
+        <span class="setting-icon" 
+            style:width 
+            style:height
+            style:min-width={ minWidth }
+            style:min-height={ minHeight }
+            style:max-width={ maxWidth }
+            style:max-height={ maxHeight }
+            on:click={() => { selectionsDisplay.viewports = selectionsDisplay.viewports ? false : true }}
+        >
+            <span
+                style:background-color={ $visableViewports === 'all' || $visableViewports === 'physical' ? 'white' : ''}
+                class="viewport physical" 
+            />
+            <span
+                style:background-color={ $visableViewports === 'all' || $visableViewports === 'logical' ? 'white' : ''} 
+                class="viewport logical" 
+            />
+        </span>
+    </Tooltip>
+    {#if selectionsDisplay.viewports}
+    <span 
+        class='material-symbols-outlined'
+        style:width=15px
+        style:font-size=20px
+    >chevron_right
+    </span>
+    <span class="selections-container">
+        <Tooltip alwaysEnabled={true} description="physical">
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <span 
+                class="setting-icon selection physical"
+                on:click={ () => { $visableViewports = 'physical' }}    
+            >
+                <span class="viewport" style:background-color={'white'}></span>
+                <span class="viewport"></span>
+            </span>            
+        </Tooltip>
+
+        <Tooltip alwaysEnabled={true} description="logical">
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <span 
+            class="setting-icon selection logical"
+            on:click={ () => { $visableViewports = 'logical' }}   
+        >
+            <span class="viewport"></span>
+            <span class="viewport" style:background-color={'white'}></span>
+        </span>
+        </Tooltip>
+        <Tooltip alwaysEnabled={true} description="all">
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <span 
+            class="setting-icon selection all"
+            on:click={ () => { $visableViewports = 'all' }}   
+        >
+            <span class="viewport" style:background-color={'white'}></span>
+            <span class="viewport" style:background-color={'white'}></span>
+        </span>
+        </Tooltip>
+    </span>
+    {/if}
+</span>
+
+<!-- BPR Setting Icon -->
+<span class="icon-container">
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <Tooltip alwaysEnabled={true} description="Bytes per row: {$bytesPerRow}">
+        <span class="setting-icon" 
+            style:width 
+            style:height
+            style:min-width={ minWidth }
+            style:min-height={ minHeight }
+            style:max-width={ maxWidth }
+            style:max-height={ maxHeight }
+            on:click={() => { selectionsDisplay.bytesPerRow = selectionsDisplay.bytesPerRow ? false : true }}
+        >
+            <span 
+                class="material-symbols-outlined"
+                style:display=flex
+                style:align-content=center
+                style:justify-content=center
+                style:font-size=20px    
+            >power_input</span>
+        </span>
+    </Tooltip>
+    {#if selectionsDisplay.bytesPerRow}
+    <span 
+        class='material-symbols-outlined'
+        style:width=15px
+        style:font-size=20px
+    >chevron_right
+    </span>
+    <span class="selections-container">
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <span 
+            class="setting-icon selection "
+            on:click={ () => { set_bytes_per_row(8) }}    
+        >8
+        </span>
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <span 
+            class="setting-icon selection "
+            on:click={ () => { set_bytes_per_row(16) }}   
+        >16
+        </span>
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <span 
+            class="setting-icon selection "
+            on:click={ () => { set_bytes_per_row(24) }}   
+        >24
+        </span>
+    </span>
+    {/if}
+</span>
+
+<style lang="scss">
+    .icon-container {
+        margin: 2px 0;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        cursor: pointer;
+    }
+    .setting-icon {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        overflow: hidden;
+        border: 1px solid white;
+        border-radius: 4px;
+        padding: 2px;
+    }
+    .selection {
+        width: 15px;
+        height: 15px;
+        cursor: pointer;
+    }
+    .viewport {
+        border: 1px solid white;
+        border-radius: 2px;
+        margin: 1px;
+        width: 50%;
+    }
+    .selections-container{
+        display: flex;
+        flex-direction: row;
+        justify-content: space-evenly;
+        min-width: 85px;
+    }
+    .icon {
+        display: flex;
+        height: 100%;
+        font-size: x-large;
+        align-items: center;
+        justify-content: center;
+    }
+</style>

--- a/src/svelte/src/components/Inputs/Buttons/Button.svelte
+++ b/src/svelte/src/components/Inputs/Buttons/Button.svelte
@@ -24,6 +24,7 @@ limitations under the License.
   export let fn: (event?: Event) => void
   export let disabledBy = false
   export let width = ''
+  export let fixedWidth = ''
 
   onMount(() => {
     collapseContent = shouldCollapseContent()
@@ -51,6 +52,7 @@ limitations under the License.
       class={$UIThemeCSSClass + ' collapsed'}
       disabled={disabledBy}
       on:click={!disabledBy ? fn : () => {}}
+      style:width={fixedWidth}
     >
       <FlexContainer
         --dir="row"
@@ -68,7 +70,7 @@ limitations under the License.
       class={$UIThemeCSSClass}
       disabled={disabledBy}
       on:click={!disabledBy ? fn : () => {}}
-      style:width
+      style:width = { fixedWidth.length > 0 ? fixedWidth : width }
     >
       <FlexContainer
         --dir="row"

--- a/src/svelte/src/components/Main.svelte
+++ b/src/svelte/src/components/Main.svelte
@@ -21,16 +21,32 @@ limitations under the License.
 </script>
 
 <main class="dataEditor">
-  <DisplayHeader on:clearDataDisplays />
-  <DataViewports
-    on:clearDataDisplays
-    on:scrolledToTop
-    on:scrolledToEnd
-    on:applyChanges
-    on:handleEditorEvent
-    on:scrollBoundary
-    on:traverse-file
-    on:seek
-  />
-  <DataEditor on:applyChanges on:handleEditorEvent />
+  <div class="data-viewports">
+    <DisplayHeader on:clearDataDisplays/>
+    <DataViewports
+      on:clearDataDisplays
+      on:scrolledToTop
+      on:scrolledToEnd
+      on:applyChanges
+      on:handleEditorEvent
+      on:scrollBoundary
+      on:traverse-file
+      on:seek
+    />    
+  </div>
+  <div class="data-editor">
+    <DataEditor on:applyChanges on:handleEditorEvent on:clearDataDisplays/>
+  </div>
 </main>
+
+<style lang="scss">
+  .data-viewports {
+    display: flex;
+    flex-direction: column;
+  }
+  .data-editor {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+</style>

--- a/src/svelte/src/components/dataEditor.svelte
+++ b/src/svelte/src/components/dataEditor.svelte
@@ -29,13 +29,13 @@ limitations under the License.
     requestable,
     selectionDataStore,
     selectionSize,
-    viewportNumLinesDisplayed,
     dataFeedLineTop,
     SelectionData_t,
     dataFeedAwaitRefresh,
     viewport,
     searchQuery,
     regularSizedFile,
+    dataDislayLineAmount,
   } from '../stores'
   import {
     CSSThemeClass,
@@ -48,8 +48,8 @@ limitations under the License.
   import Main from './Main.svelte'
   import {
     EditByteModes,
-    VIEWPORT_SCROLL_INCREMENT,
     type BytesPerRow,
+    VIEWPORT_SCROLL_INCREMENT,
   } from '../stores/configuration'
   import ServerMetrics from './ServerMetrics/ServerMetrics.svelte'
   import {
@@ -87,12 +87,15 @@ limitations under the License.
     bytesPerRow: BytesPerRow,
     viewportStartOffset: number = $viewport.fileOffset
   ): number {
-    const nearestBPRdivisibleOffset = byte_count_divisible_offset(
-      offset - viewportStartOffset,
+    const nearestBPRdivisibleTargetFileOffset = byte_count_divisible_offset(
+      offset,
       bytesPerRow
     )
-    const offsetLineNumInViewport = nearestBPRdivisibleOffset / bytesPerRow
-    return offsetLineNumInViewport
+    const nearestBPRdivisibleViewportFileOffset = byte_count_divisible_offset(
+      viewportStartOffset,
+      bytesPerRow
+    ) 
+    return (nearestBPRdivisibleTargetFileOffset - nearestBPRdivisibleViewportFileOffset) / bytesPerRow
   }
 
   function fetchable_content(offset: number): boolean {
@@ -127,8 +130,7 @@ limitations under the License.
 
     $dataFeedAwaitRefresh = true
 
-    offsetArg = byte_count_divisible_offset(offsetArg, $bytesPerRow)
-    const fetchOffset = Math.max(0, offsetArg - VIEWPORT_SCROLL_INCREMENT)
+    const fetchOffset = Math.max(0, byte_count_divisible_offset(offsetArg - (VIEWPORT_SCROLL_INCREMENT-$bytesPerRow), $bytesPerRow))
 
     $dataFeedLineTop = offset_to_viewport_line_number(
       offsetArg,
@@ -141,7 +143,7 @@ limitations under the License.
       data: {
         scrollOffset: fetchOffset,
         bytesPerRow: $bytesPerRow,
-        numLinesDisplayed: $viewportNumLinesDisplayed,
+        numLinesDisplayed: $dataDislayLineAmount,
       },
     })
     clearDataDisplays()
@@ -321,6 +323,7 @@ limitations under the License.
 
 <!-- svelte-ignore css-unused-selector -->
 <style lang="scss">
+
   div.test {
     display: flex;
     flex-wrap: wrap;

--- a/src/svelte/src/components/globalStyles.css
+++ b/src/svelte/src/components/globalStyles.css
@@ -278,15 +278,10 @@ div.hide-scrollbar::-webkit-scrollbar {
 
 /* Global Style Classes */
 .dataEditor {
-  display: grid;
-  grid-template-columns: 110px max-content max-content auto;
-  grid-template-rows: max-content auto;
-  /*noinspection CssUnresolvedCustomProperty*/
+  display: flex;
   font-family: 'Red Hat Mono';
 }
-/* display of binary encoded data takes more space in the physical view */
 .dataEditor.binary {
-  /* I think this should be 16em instead of 10em for 16 characters, but that didn't work */
   grid-template-columns: max-content max-content 10em auto;
 }
 .dataEditor div {
@@ -316,8 +311,6 @@ div.hide-scrollbar::-webkit-scrollbar {
   display: flex;
   font-family: 'Red Hat Mono';
   height: 25pt;
-  border-width: 0 0 2px 0;
-  border-style: solid;
 }
 .dataEditor div.measure.dark {
   display: flex;
@@ -341,7 +334,8 @@ div.hide-scrollbar::-webkit-scrollbar {
 .dataEditor div.measure span {
   align-self: flex-end;
 }
-.dataEditor div.measure div {
+.dataEditor div.measure div,
+.dataEditor div.measure sub {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -405,18 +399,15 @@ div.hide-scrollbar::-webkit-scrollbar {
   color: #02060b;
 }
 .dataEditor div.editView {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: 75%;
-  grid-row-start: 3;
-  grid-row-end: 5;
-  gap: 10pt;
-  overflow-x: hidden;
-  word-break: break-all;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  height: 100%;
   margin-left: 4px;
 }
 .dataEditor div.editView textarea {
   width: auto;
+  height: 100%;
 }
 .dataEditor textarea.selectedContent {
   background: #2c2c2c;
@@ -427,6 +418,9 @@ div.hide-scrollbar::-webkit-scrollbar {
 .dataEditor select.content-select {
   float: right;
   max-width: 110px;
+}
+div.viewport-hdr-content {
+  height: 35px;
 }
 
 .tooltip {

--- a/src/svelte/src/stores/configuration.ts
+++ b/src/svelte/src/stores/configuration.ts
@@ -19,7 +19,7 @@ export type Radixes = 'Hexadecimal' | 'Decimal' | 'Octal' | 'Binary'
 
 export type RadixValues = 16 | 10 | 8 | 2
 
-export type BytesPerRow = 16 | 8
+export type BytesPerRow = 16 | 8 | 24
 
 export enum EditByteModes {
   Single = 'single',
@@ -108,11 +108,13 @@ export const UNPRINTABLE_CHAR_STAND_IN = String.fromCharCode(9617)
 
 // Number of bytes to for the viewport to populate
 export const VIEWPORT_CAPACITY_MAX = 16 * 64 // 1024, Ωedit maximum viewport size is 1048576 (1024 * 1024)
-
-// Offset shift amount on viewport data fetch
 export const VIEWPORT_SCROLL_INCREMENT = VIEWPORT_CAPACITY_MAX / 2
 
-// Number of bytes to display in the viewport
-export const NUM_LINES_DISPLAYED = 20
+export const BYTES_PER_ROW_MAX_LINE_NUM: { [k in BytesPerRow]: number } = {
+  16: Math.floor(VIEWPORT_SCROLL_INCREMENT / 16),
+  8: Math.floor(VIEWPORT_SCROLL_INCREMENT / 8),
+  24: Math.floor(VIEWPORT_SCROLL_INCREMENT / 24),
+}
 
+// Number of bytes to display in the viewport
 export const DATA_PROFILE_MAX_LENGTH = 10_000_000

--- a/src/svelte/src/stores/index.ts
+++ b/src/svelte/src/stores/index.ts
@@ -43,6 +43,7 @@ import {
   type RadixValues,
   type BytesPerRow,
   EditActionRestrictions,
+  VIEWPORT_CAPACITY_MAX,
 } from './configuration'
 
 export class SelectionData_t {
@@ -117,7 +118,6 @@ export const rerenderActionElements = writable(false)
 
 // Viewport properties
 export const viewport = new ViewportDataStore_t()
-export const viewportNumLinesDisplayed = writable(20)
 
 export const bytesPerRow = writable(16 as BytesPerRow)
 export const editingByte = writable(false)
@@ -147,6 +147,10 @@ export const sizeHumanReadable = writable(false)
 // tracks the start and end offsets of the current selection
 export const selectionDataStore = new SelectionData()
 
+export const dataDislayLineAmount = writable(20)
+
+export type VisibleViewports = 'physical' | 'logical' | 'all'
+export const visableViewports = writable('all' as VisibleViewports)
 // Can the user's selection derive both edit modes?
 export const regularSizedFile = derived(fileMetrics, ($fileMetrics) => {
   return $fileMetrics.computedSize >= 2
@@ -288,7 +292,7 @@ export const editedByteIsOriginalByte = derived(
   ([$editorSelection, $selectedByte, $focusedViewportId]) => {
     return $focusedViewportId === 'logical'
       ? $editorSelection === $selectedByte.text
-      : $editorSelection.toLowerCase() === $selectedByte.text.toLowerCase()
+      : $editorSelection.toLowerCase() === $selectedByte.text!.toLowerCase()
   }
 )
 


### PR DESCRIPTION
- Added the ability to hide/show viewports.
- Added the ability to change the amount of bytes per row shown and be independent of the current display radix.
- Added the ability to increment/decrement the amount of viewport lines being displayed.
- Reworked CSS for viewport data tables to move from `display:grid;` to `display:flex;`.
---
### Settings Panel
Two expandable button icons were placed in the _Settings_ fieldset in the main display header. The top icon corresponds to showing / hiding data viewports. The bottom icon corresponds to the amount of bytes in each data line.

<details><summary><h4>Screenshot</h4></summary>

![image](https://github.com/apache/daffodil-vscode/assets/30351915/424a7226-6181-40e0-a5b9-8a1a0f1d8a12)

</details>

###  Display Line Adjustments
Two buttons were appended to the file traversal button row and separated by a divider as a visual indication of different functionality while still remaining relevant to data traversal. The left is for incrementing the amount of data lines and the right is for decrementing. Both adjustments are by 1 line.
<details><summary><h4>Screenshot</h4></summary>

![image](https://github.com/apache/daffodil-vscode/assets/30351915/254067bf-7ff3-4d96-89bc-8e11c94294f6)

</details>


Closes #864
Closes #797
Closes #794