### PR TITLE
Augment xpath/dpath validation

### DIFF
--- a/src/language/semantics/functionData.ts
+++ b/src/language/semantics/functionData.ts
@@ -47,6 +47,7 @@ export class FunctionData {
     'collection#1',
     'compare#2',
     'compare#3',
+    'concat#2',
     'concat#3',
     'contains#2',
     'contains#3',


### PR DESCRIPTION
Closes #850 

Adds fn:concat function with 2 arguments

Adds hard-coded/prebuilt variables:
- dfdl:encoding
- dfdl:byteOrder
- dfdl:binaryFloatRep
- dfdl:outputNewLine

Check the prefix of variables, and don't flag them if the prefix is valid. Note that this will also prevent the above variables from being flagged. Do we need to do anything else to differentiate?