### PR TITLE
Multiple CI updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,56 +42,12 @@ jobs:
 
   code-format:
     name: TypeScript/Scala/Svelte Formatting
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash
-    env:
-      SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++2.12.15
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Setup Node 16
-        uses: actions/setup-node@v4.0.0
-        with:
-          node-version: '16'
-      - name: Setup Java 8
-        uses: actions/setup-java@v3.13.0
-        with:
-          distribution: temurin
-          java-version: 8
-      - run: $SBT scalafmtCheck
-      - run: $SBT scalafmtSbtCheck
-      - run: yarn install
-      - run: yarn lint
-
-  rat-check:
-    name: Rat Check
-    runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash
-    env:
-      SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++2.12.15
-    steps:
-      - name: Setup Java 8
-        uses: actions/setup-java@v3.13.0
-        with:
-          distribution: temurin
-          java-version: 8
-      - name: Check out Repository
-        uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0
-      - name: Run Rat Check
-        run: $SBT ratCheck || (cat target/rat.txt; exit 1)
-
-  build-test-package:
-    name: 'Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }})'
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
-        node: [ '16', '18' ]
-      fail-fast: false  # don't immediately fail all other jobs if a single job fails
+        java_distribution: [ temurin ]
+        java_version: [ 8 ]
+        os: [ ubuntu-20.04 ]
+        node: [ '16' ]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -99,25 +55,126 @@ jobs:
     env:
       SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++2.12.15
     steps:
-      - name: Setup Java 8
+      ############################################################
+      # Setup
+      ############################################################
+      
+      - name: Check out Repository
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Java
         uses: actions/setup-java@v3.13.0
         with:
-          distribution: temurin
-          java-version: 8
-      - uses: actions/checkout@v4.1.1
+          distribution: ${{ matrix.java_distribution }}
+          java-version: ${{ matrix.java_version }}
+
       - name: Install Node.js
         uses: actions/setup-node@v4.0.0
         with:
-          node-version: ${{ matrix.node}}
-      - run: $SBT compile # used to initialize sbt, if not done sbt universal:packageBin ran by yarn package times out -- windows only
-        if: runner.os == 'Windows'
-      - run: yarn install
-      - run: xvfb-run -a yarn test
+          node-version: ${{ matrix.node }}
+
+      ############################################################
+      # Lint/format checks
+      ############################################################
+
+      - name: Scala format check
+        run: $SBT scalafmtCheck
+
+      - name: Scala sbt format check
+        run: $SBT scalafmtSbtCheck
+
+      - name: Install node dependencies
+        run: yarn install
+      
+      - name: TypeScript lint
+        run: yarn lint
+
+  rat-check:
+    name: Rat Check
+    strategy:
+      matrix:
+        java_distribution: [ temurin ]
+        java_version: [ 8 ]
+        os: [ ubuntu-20.04 ]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++2.12.15
+    steps:
+      ############################################################
+      # Setup
+      ############################################################
+
+      - name: Check out Repository
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java
+        uses: actions/setup-java@v3.13.0
+        with:
+          distribution: ${{ matrix.java_distribution }}
+          java-version: ${{ matrix.java_version }}
+
+      ############################################################
+      # Rat check
+      ############################################################
+
+      - name: Run Rat Check
+        run: $SBT ratCheck || (cat target/rat.txt; exit 1)
+
+  build-test-package:
+    name: 'Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, Java: ${{ matrix.java_version }})'
+    strategy:
+      matrix:
+        java_distribution: [ temurin ]
+        java_version: [ 8, 11, 17 ]
+        os: [ macos-11, ubuntu-20.04, windows-2019 ]
+        node: [ '16', '18' ]
+      fail-fast: false  # don't immediately fail all other jobs if a single job fails
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      ############################################################
+      # Setup
+      ############################################################
+
+      - name: Check out Repository
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Java
+        uses: actions/setup-java@v3.13.0
+        with:
+          distribution: ${{ matrix.java_distribution }}
+          java-version: ${{ matrix.java_version }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: ${{ matrix.node }}
+
+      ############################################################
+      # Build & Package
+      ############################################################
+
+      - name: Install node dependencies
+        run: yarn install
+
+      - name: Runs tests - Linux
+        run: xvfb-run -a yarn test
         if: runner.os == 'Linux'
-      - run: yarn test
+
+      - name: Runs tests - Windows/Mac
+        run: yarn test
         if: runner.os != 'Linux'
+
       - name: Check for Errors in macOS
         run: tail -n 1000 '/Users/runner/Library/Application Support/omega_edit/'* && exit 1
         if: failure() && runner.os == 'macOS'
+
       - name: Package
         run: yarn package

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,12 +23,14 @@ on:
 
 jobs:
   build-test-package:
-    name: 'Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, VS Code: ${{ matrix.vscode }} )'
+    name: 'Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, Java: ${{ matrix_java_version }}, VS Code: ${{ matrix.vscode }} )'
     strategy:
       matrix:
         os: [ macos-11, ubuntu-20.04, windows-2019, macos-latest, ubuntu-latest, windows-latest ]
         node: [ '16', '18' ]
         vscode: [ 'stable', 'insiders' ]
+        java_distribution: [ temurin ]
+        java_version: [ 8, 11, 17 ]
       fail-fast: false  # don't immediately fail all other jobs if a single job fails
     runs-on: ${{ matrix.os }}
     defaults:
@@ -36,23 +38,43 @@ jobs:
         shell: bash
     env:
       DAFFODIL_TEST_VSCODE_VERSION: ${{ matrix.vscode }}
-      SBT: sbt -J-Xms1024m -J-Xmx5120m -J-XX:ReservedCodeCacheSize=512m -J-XX:MaxMetaspaceSize=1024m ++2.12.15
     steps:
-      - name: Setup Java 8
+      ############################################################
+      # Setup
+      ############################################################
+
+      - name: Check out Repository
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Java
         uses: actions/setup-java@v3.13.0
         with:
-          distribution: temurin
-          java-version: 8
-      - uses: actions/checkout@v4.1.1
+          distribution: ${{ matrix.java_distribution }}
+          java-version: ${{ matrix.java_version }}
+
       - name: Install Node.js
         uses: actions/setup-node@v4.0.0
         with:
           node-version: ${{ matrix.node }}
-      - run: $SBT compile # used to initialize sbt, if not done sbt universal:packageBin ran by yarn package times out -- windows only
-        if: runner.os == 'Windows'
-      - run: yarn install
-      - run: yarn package
-      - run: xvfb-run -a yarn test
+
+      ############################################################
+      # Build & Package
+      ############################################################
+
+      - name: Install node dependencies
+        run: yarn install
+
+      - name: Runs tests - Linux
+        run: xvfb-run -a yarn test
         if: runner.os == 'Linux'
-      - run: yarn test
+
+      - name: Runs tests - Windows/Mac
+        run: yarn test
         if: runner.os != 'Linux'
+
+      - name: Check for Errors in macOS
+        run: tail -n 1000 '/Users/runner/Library/Application Support/omega_edit/'* && exit 1
+        if: failure() && runner.os == 'macOS'
+
+      - name: Package
+        run: yarn package


### PR DESCRIPTION
Multiple CI updates:

- Add matrix to test different Java versions to main CI and nightly CI.
- Cleaned up the CI workflow file a bit.
  - The steps were too compacted, believe new layout makes it easier to read and follow.
- Add java_version to job names.
- Remove sbt compile from windows jobs, seemed to cause windows issues with jaxb.
- Believe the nightly CI maybe fixed with this update.
- Possibly fixes https://github.com/apache/daffodil-vscode/issues/855 but will wait to see if a nightly build passes before closing.

Closes https://github.com/apache/daffodil-vscode/issues/772