### PR TITLE
Fix check for using default values

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,9 +125,10 @@ export function getConfig(jsonArgs: object): vscode.DebugConfiguration {
 
   Object.entries(defaultValues).map(
     ([key, defaultValue]) =>
-      (launchConfigArgs[key] = launchConfigArgs[key]
-        ? launchConfigArgs[key]
-        : defaultValue)
+      (launchConfigArgs[key] =
+        launchConfigArgs[key] !== undefined
+          ? launchConfigArgs[key]
+          : defaultValue)
   )
 
   return JSON.parse(JSON.stringify(launchConfigArgs))


### PR DESCRIPTION
Fix check for using default values

- The check used for seeing if default values or not was working improperly as it was checking the boolean-ness of a variable.
  - So, if the value provided was false it would still use a default value.
  - To fix the issue we need to check if accessing the varaible returns undefined meaning it wasn't provided so use the default then.

Closes #852