### PR TITLE
Fix java command line arguments for Java 17+

### DIFF
--- a/src/daffodilDebugger/utils.ts
+++ b/src/daffodilDebugger/utils.ts
@@ -43,7 +43,10 @@ export const shellArgs = (port: number, isAtLeastJdk17: boolean) => {
   // Workaround: certain reflection (used by JAXB) isn't allowed by default in JDK 17:
   //   https://docs.oracle.com/en/java/javase/17/migrate/migrating-jdk-8-later-jdk-releases.html#GUID-7BB28E4D-99B3-4078-BDC4-FC24180CE82B
   const extraArgs = isAtLeastJdk17
-    ? ['-J--add-opens', '-Jjava.base/java.lang=ALL-UNNAMED']
+    ? osCheck(
+        ['-J"--add-opens java.base/java.lang=ALL-UNNAMED"'],
+        ['-J--add-opens', '-Jjava.base/java.lang=ALL-UNNAMED']
+      )
     : []
   return ['--listenPort', `${port}`].concat(extraArgs)
 }

--- a/webpack/ext-package.webpack.config.js
+++ b/webpack/ext-package.webpack.config.js
@@ -101,6 +101,7 @@ module.exports = /** @type WebpackConfig */ {
         { from: 'images', to: `${pkg_dir}/images` },
         { from: 'language', to: `${pkg_dir}/language` },
         { from: 'package.json', to: `${pkg_dir}` },
+        { from: 'yarn.lock', to: `${pkg_dir}` },
         {
           from: 'node_modules/@omega-edit/server/bin',
           to: `${pkg_dir}/node_modules/@omega-edit/server/bin`,


### PR DESCRIPTION

Close #895 
Changed assignment of extraArgs in utils.ts to be **os** specific and fix Java 17+ on Windows