### PR TITLE
Ignore requests for stale state.

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/ErrorEvents.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/ErrorEvents.scala
@@ -26,5 +26,4 @@ object ErrorEvents {
   case object LaunchArgsParseError extends DebugEvent("daffodil.error.launchargparse")
   case object RequestError extends DebugEvent("daffodil.error.request")
   case object SourceError extends DebugEvent("daffodil.error.source")
-  case object ScopeNotFoundError extends DebugEvent("daffodil.error.scopenotfound")
 }

--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/logging.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/logging.scala
@@ -31,14 +31,14 @@ object logging {
     case response if response.command == "source" =>
       s"#${response.request_seq} ${response.command} ${if (response.success) "success"
         else "failure"} <response body elided>"
-    case response =>
-      s"#${response.request_seq} ${response.command} ${if (response.success) "success"
-        else "failure"} ${JsonUtils
-          .toJson(response.body)}"
+    case response if response.success =>
+      s"#${response.request_seq} ${response.command} success ${JsonUtils.toJson(response.body)}"
+    case failed =>
+      s"#${failed.request_seq} ${failed.command} failure ${failed.message}"
   }
 
   implicit val eventShow: Show[DebugEvent] = {
-    case event: Events.StoppedEvent => s"${event.`type`} ${event.reason}"
+    case event: Events.StoppedEvent => s"${event.`type`} ${event.reason} ${event.description}"
     case event: Events.ThreadEvent  => s"${event.`type`} ${event.reason}"
     case event: DAPodil.LoadedSourceEvent =>
       s"${event.`type`} ${event.reason} ${JsonUtils.toJson(event.source)}"


### PR DESCRIPTION
During 'continue' or 'next' events the frontend makes a sequence of requests to get the current state: asking for threads, the stack frames of each thread, the scopes listing the variables, and the values of the variables. If a rapid sequence of 'continue' or 'next' requests come in during this sequence, the debugger state is advanced and late-arriving requests from previous stepping will fail.

Rather than abort, we ignore the stale requests and log them. The later requests will still request the current state and the frontend will have the correct data.

Fixes #844.