### PR TITLE
Upgrade test-electron dependency to fix nightly tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/vscode": "^1.67.2",
     "@types/vscode-webview": "^1.57.3",
     "@vscode/debugadapter-testsupport": "1.63.0",
-    "@vscode/test-electron": "2.3.5",
+    "@vscode/test-electron": "2.3.8",
     "@vscode/vsce": "2.22.0",
     "chai": "^4.3.10",
     "concurrently": "^8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,10 +402,10 @@
   resolved "https://registry.yarnpkg.com/@vscode/debugprotocol/-/debugprotocol-1.63.0.tgz#f6d16c382765d2533e515939ac2857aa1ed7ba35"
   integrity sha512-7gewwv69pA7gcJUhtJsru5YN7E1AwwnlBrF5mJY4R/NGInOUqOYOWHlqQwG+4AXn0nXWbcn26MHgaGI9Q26SqA==
 
-"@vscode/test-electron@2.3.5":
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-2.3.5.tgz#c472c5bdce1329aeb4762b8aa7a2cbe7aa783aac"
-  integrity sha512-lAW7nQ0HuPqJnGJrtCzEKZCICtRizeP6qNanyCrjmdCOAAWjX3ixiG8RVPwqsYPQBWLPgYuE12qQlwXsOR/2fQ==
+"@vscode/test-electron@2.3.8":
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/@vscode/test-electron/-/test-electron-2.3.8.tgz#06a7c50b38cfac0ede833905e088d55c61cd12d3"
+  integrity sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==
   dependencies:
     http-proxy-agent "^4.0.1"
     https-proxy-agent "^5.0.0"


### PR DESCRIPTION
Fixes #855... perhaps.

Nightly errors look like the archive format changed (this is from a local run):
```
Downloaded VS Code into /Users/arosien/nteligen/daffodil-vscode/.vscode-test/vscode-darwin-1.67.2
Test error: Error: spawn /Users/arosien/nteligen/daffodil-vscode/.vscode-test/vscode-darwin-1.67.2/Visual Studio Code.app/Contents/MacOS/Electron ENOENT
Exit code:   -2
Failed to run tests: Failed
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
➜  daffodil-vscode git:(Shanedell/add-root-element-settings) ls /Users/arosien/nteligen/daffodil-vscode/.vscode-test/vscode-darwin-1.67.2
Contents
➜  daffodil-vscode git:(Shanedell/add-root-element-settings) ls /Users/arosien/nteligen/daffodil-vscode/.vscode-test/vscode-darwin-1.67.2/Contents/
CodeResources    Frameworks/      Info.plist       MacOS/           PkgInfo          Resources/       _CodeSignature/
```

The [changelog](https://github.com/microsoft/vscode-test/blob/main/CHANGELOG.md) of `test-electron` shows a couple of recent releases that handle permission and path differences from downloaded archives, and updating makes `yarn test` pass.

I'm not sure how to trigger the nightly tests other than waiting, but the PR tests should be a good proxy(?)