### PR TITLE
Make CI more similar to (failing) nightly builds.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -133,11 +133,14 @@ jobs:
         java_version: [ 8, 11, 17 ]
         os: [ macos-11, ubuntu-20.04, windows-2019 ]
         node: [ '16', '18' ]
+        vscode: [ 'stable' ]
       fail-fast: false  # don't immediately fail all other jobs if a single job fails
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash
+    env:
+      DAFFODIL_TEST_VSCODE_VERSION: ${{ matrix.vscode }}
     steps:
       ############################################################
       # Setup

--- a/src/daffodilDebugger/utils.ts
+++ b/src/daffodilDebugger/utils.ts
@@ -124,9 +124,12 @@ function latestJdk(jdkHomes: IJavaHomeInfo[]): IJavaHomeInfo | undefined {
 
 // Function for stopping debugging
 export async function stopDebugging() {
-  vscode.debug.stopDebugging()
-  deactivate()
-  vscode.window.activeTerminal?.processId.then(async (id) => {
-    await stopDebugger(id)
+  vscode.debug.stopDebugging().then(async () => {
+    deactivate()
+    for (const t of vscode.window.terminals) {
+      await t.processId?.then(async (id) => {
+        await stopDebugger(id)
+      })
+    }
   })
 }

--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -21,23 +21,13 @@ import * as path from 'path'
 import * as fs from 'fs'
 import { PROJECT_ROOT, PACKAGE_PATH, TEST_SCHEMA } from './common'
 import { getConfig, killProcess } from '../../utils'
-import {
-  daffodilArtifact,
-  daffodilVersion,
-  runDebugger,
-  stopDebugging,
-} from '../../daffodilDebugger'
+import { runDebugger, stopDebugging } from '../../daffodilDebugger'
 import { before, after } from 'mocha'
 import { DFDLDebugger } from '../../classes/dfdlDebugger'
 import { DataEditorConfig } from '../../classes/dataEditor'
 
 // Not using the debug adapter like adapter.test.ts as it will not fully connect the debugger
 suite('Daffodil Debugger', () => {
-  const dfdlVersion = daffodilVersion(PACKAGE_PATH)
-  const artifact = daffodilArtifact(dfdlVersion)
-
-  const EXTRACTED_FOLDER = path.join(PROJECT_ROOT, artifact.name)
-
   // debugger options
   const DATA = path.join(PROJECT_ROOT, 'src/tests/data/test.txt')
   const XML_INFOSET_PATH = path.join(PROJECT_ROOT, 'testinfoset.xml')
@@ -101,9 +91,10 @@ suite('Daffodil Debugger', () => {
   after(async () => {
     await stopDebugging()
     for (const d of debuggers) {
-      await d.processId?.then(killProcess)
+      const pid = await d.processId
+      await killProcess(pid)
     }
-    fs.rmSync(EXTRACTED_FOLDER, { recursive: true })
+    // No need to deleted the debugging server because upon re-run, webpack cleans and re-extracts it.
     if (fs.existsSync(XML_INFOSET_PATH)) fs.rmSync(XML_INFOSET_PATH)
     if (fs.existsSync(JSON_INFOSET_PATH)) fs.rmSync(JSON_INFOSET_PATH)
     dfdlDebuggers.forEach((dfdlDebugger) => {


### PR DESCRIPTION
Nightly uses `vscode: [ 'stable', 'insiders' ]`, whereas CI doesn't specify the vscode version, which defaults to the `package.json` vscode engine version, currently set to `^1.67.2`, which gets resolved to `1.67.2`.

However, let's make the builds as similar as possible to provoke the same failures in CI as nightly.

This provokes the same failures as nightly, and the fix is to not attempt to delete the extracted backend debugger directory. This was added to make local development safer, but re-running the tests locally will always delete the extracted backend debugger before re-extracting it, which happens during the webpack step (using webpack/ext-dev.webpack.config.js).