### PR TITLE
Change daffodilDebugClasspath to array of string instead of string

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
@@ -399,8 +399,10 @@ object Parse {
     // arguments: Launch config
     def parseRootName(arguments: JsonObject) =
       Right(
-        Option(arguments.getAsJsonObject("schema").getAsJsonPrimitive("rootName"))
-          .map(_.getAsString())
+        arguments.getAsJsonObject("schema").get("rootName") match {
+          case null => None
+          case rn   => if (rn.isJsonNull()) None else Some(rn.getAsString())
+        }
       ).toEitherNel
 
     // Parse the root namespae field from the launch config
@@ -409,8 +411,10 @@ object Parse {
     // arguments: Launch config
     def parseRootNamespace(arguments: JsonObject) =
       Right(
-        Option(arguments.getAsJsonObject("schema").getAsJsonPrimitive("rootNamespace"))
-          .map(_.getAsString())
+        arguments.getAsJsonObject("schema").get("rootNamespace") match {
+          case null => None
+          case rn   => if (rn.isJsonNull()) None else Some(rn.getAsString())
+        }
       ).toEitherNel
 
     // Parse the data field from the launch config

--- a/package.json
+++ b/package.json
@@ -333,10 +333,28 @@
               "schema": {
                 "type": "object",
                 "description": "Contains the absolute path to the DFDL schema file, root element name and namespace.",
+                "required": ["path"],
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "Absolute path to the DFDL schema file",
+                    "default": "${command:AskForSchemaName}"
+                  },
+                  "rootName": {
+                    "type": ["string", "null"],
+                    "description": "Name of the root element",
+                    "default": null
+                  },
+                  "rootNamespace": {
+                    "type": ["string", "null"],
+                    "description": "Name of the root element namespace",
+                    "default": null
+                  }
+                },
                 "default": {
                   "path": "${command:AskForSchemaName}",
-                  "rootName": "",
-                  "rootNamespace": ""
+                  "rootName": null,
+                  "rootNamespace": null
                 }
               },
               "data": {
@@ -407,9 +425,9 @@
                 "default": false
               },
               "daffodilDebugClasspath": {
-                "type": "string",
+                "type": "array",
                 "description": "Additional classpaths to be exported to the debugger",
-                "default": ""
+                "default": []
               },
               "variables": {
                 "type": "object",
@@ -456,8 +474,8 @@
             "name": "Ask for file name",
             "schema": {
               "path": "${command:AskForSchemaName}",
-              "rootName": "",
-              "rootNamespace": ""
+              "rootName": null,
+              "rootNamespace": null
             },
             "data": "${command:AskForDataName}",
             "stopOnEntry": true,
@@ -476,7 +494,7 @@
             "openDataEditor": false,
             "openInfosetView": false,
             "openInfosetDiffView": false,
-            "daffodilDebugClasspath": "",
+            "daffodilDebugClasspath": [],
             "variables": {},
             "tunables": {},
             "dataEditor": {
@@ -504,8 +522,8 @@
               "name": "Ask for file name",
               "schema": {
                 "path": "^\"\\${command:AskForSchemaName}\"",
-                "rootName": "",
-                "rootNamespace": ""
+                "rootName": null,
+                "rootNamespace": null
               },
               "data": "^\"\\${command:AskForDataName}\"",
               "stopOnEntry": true,
@@ -524,7 +542,7 @@
               "openDataEditor": false,
               "openInfosetView": false,
               "openInfosetDiffView": false,
-              "daffodilDebugClasspath": "",
+              "daffodilDebugClasspath": [],
               "variables": {},
               "tunables": {},
               "dataEditor": {
@@ -566,8 +584,8 @@
             "description": "Contains the absolute path to the DFDL schema file, root element name and namespace.",
             "default": {
               "path": "${command:AskForSchemaName}",
-              "rootName": "",
-              "rootNamespace": ""
+              "rootName": null,
+              "rootNamespace": null
             }
           },
           "data": {
@@ -629,9 +647,9 @@
             "default": false
           },
           "daffodilDebugClasspath": {
-            "type": "string",
+            "type": "array",
             "description": "Additional classpaths to be exported to the debugger",
-            "default": ""
+            "default": []
           },
           "variables": {
             "type": "object",

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -115,8 +115,8 @@ function createDebugRunFileConfigs(
           type: 'dfdl',
           schema: {
             path: targetResource.fsPath,
-            rootName: '',
-            rootNamespace: '',
+            rootName: null,
+            rootNamespace: null,
           },
           data: false,
           debugServer: false,
@@ -303,8 +303,8 @@ export function activateDaffodilDebug(
                 type: 'dfdl',
                 schema: {
                   path: '${file}',
-                  rootName: '',
-                  rootNamespace: '',
+                  rootName: null,
+                  rootNamespace: null,
                 },
                 data: false,
                 debugServer: false,
@@ -331,8 +331,8 @@ export function activateDaffodilDebug(
               type: 'dfdl',
               schema: {
                 path: '${file}',
-                rootName: '',
-                rootNamespace: '',
+                rootName: null,
+                rootNamespace: null,
               },
               data: false,
               debugServer: false,

--- a/src/classes/schemaData.ts
+++ b/src/classes/schemaData.ts
@@ -17,6 +17,6 @@
 
 export interface SchemaData {
   path: string
-  rootName: string
-  rootNamespace: string
+  rootName: string | null
+  rootNamespace: string | null
 }

--- a/src/classes/vscode-launch.ts
+++ b/src/classes/vscode-launch.ts
@@ -38,6 +38,6 @@ export interface VSCodeLaunchConfigArgs {
   openDataEditor: boolean
   openInfosetView: boolean
   openInfosetDiffView: boolean
-  daffodilDebugClasspath: string
+  daffodilDebugClasspath: Array<string>
   dfdlDebugger: DFDLDebugger
 }

--- a/src/daffodilDebugger/debugger.ts
+++ b/src/daffodilDebugger/debugger.ts
@@ -18,7 +18,7 @@
 import * as vscode from 'vscode'
 import * as fs from 'fs'
 import * as path from 'path'
-import { regexp, getConfig, osCheck } from '../utils'
+import { getConfig } from '../utils'
 import { runDebugger, stopDebugger, stopDebugging } from './utils'
 
 // Function to get data file given a folder
@@ -102,34 +102,25 @@ async function getTDMLConfig(
 async function getDaffodilDebugClasspath(
   config: vscode.DebugConfiguration,
   workspaceFolder: string
-): Promise<string> {
-  let daffodilDebugClasspath = ''
+): Promise<Array<string>> {
+  let daffodilDebugClasspath: Array<string> = []
 
   //check if each classpath still exists
   if (config.daffodilDebugClasspath) {
-    config.daffodilDebugClasspath
-      .split(osCheck(';', ':'))
-      .forEach((entry: string) => {
-        if (entry !== '') {
-          let fullpathEntry = entry.replaceAll(
-            '${workspaceFolder}',
-            workspaceFolder
-          )
-
-          if (!fs.existsSync(fullpathEntry)) {
-            throw new Error(`File or directory: ${fullpathEntry} doesn't exist`)
-          }
-        }
-      })
-
-    daffodilDebugClasspath = config.daffodilDebugClasspath.includes(
-      '${workspaceFolder}'
-    )
-      ? config.daffodilDebugClasspath.replace(
-          regexp['workspace'],
+    config.daffodilDebugClasspath.forEach((entry: string) => {
+      if (entry !== '') {
+        let fullpathEntry = entry.replaceAll(
+          '${workspaceFolder}',
           workspaceFolder
         )
-      : config.daffodilDebugClasspath
+
+        if (!fs.existsSync(fullpathEntry)) {
+          throw new Error(`File or directory: ${fullpathEntry} doesn't exist`)
+        } else {
+          daffodilDebugClasspath.push(fullpathEntry)
+        }
+      }
+    })
   }
 
   // make sure infoset output directory is present

--- a/src/daffodilDebugger/utils.ts
+++ b/src/daffodilDebugger/utils.ts
@@ -53,7 +53,7 @@ export const shellArgs = (port: number, isAtLeastJdk17: boolean) => {
 
 export async function runDebugger(
   rootPath: string,
-  daffodilDebugClasspath: string,
+  daffodilDebugClasspath: Array<string>,
   filePath: string,
   serverPort: number,
   dfdlDebugger: DFDLDebugger,
@@ -89,13 +89,17 @@ export async function runDebugger(
   // The backend's launch script honors $JAVA_HOME, but if not set it assumes java is available on the path.
   const env = javaHome
     ? {
-        DAFFODIL_DEBUG_CLASSPATH: daffodilDebugClasspath,
+        DAFFODIL_DEBUG_CLASSPATH: daffodilDebugClasspath.join(
+          osCheck(';', ':')
+        ),
         DAFFODIL_DEBUG_LOG_LEVEL: dfdlDebugger.logging.level,
         DAFFODIL_DEBUG_LOG_FILE: dfdlDebugger.logging.file,
         JAVA_HOME: javaHome?.path,
       }
     : {
-        DAFFODIL_DEBUG_CLASSPATH: daffodilDebugClasspath,
+        DAFFODIL_DEBUG_CLASSPATH: daffodilDebugClasspath.join(
+          osCheck(';', ':')
+        ),
         DAFFODIL_DEBUG_LOG_LEVEL: dfdlDebugger.logging.level,
         DAFFODIL_DEBUG_LOG_FILE: dfdlDebugger.logging.file,
       }

--- a/src/launchWizard/launchWizard.js
+++ b/src/launchWizard/launchWizard.js
@@ -79,10 +79,16 @@ function getConfigValues() {
   const dfdlDebuggerLogLevel = document.getElementById(
     'dfdlDebuggerLogLevel'
   ).value
-  const rootName = document.getElementById('rootName').value
-  const rootNamespace = document.getElementById('rootNamespace').value
+  const rootName =
+    document.getElementById('rootName').value == 'null'
+      ? null
+      : document.getElementById('rootName').value
+  const rootNamespace =
+    document.getElementById('rootNamespace').value == 'null'
+      ? null
+      : document.getElementById('rootNamespace').value
 
-  const daffodilDebugClasspath = getDaffodilDebugClasspathString()
+  const daffodilDebugClasspath = getDaffodilDebugClasspathArray()
 
   return {
     name,
@@ -113,8 +119,8 @@ function getConfigValues() {
   }
 }
 
-// Function get daffodil debug classpath string
-function getDaffodilDebugClasspathString() {
+// Function get daffodil debug classpath
+function getDaffodilDebugClasspathArray() {
   let childNodes = document.getElementById(
     'daffodilDebugClasspathTable'
   ).childNodes
@@ -127,14 +133,13 @@ function getDaffodilDebugClasspathString() {
           .replace('-', '') // remove initial - in front of every item
     )
     .filter((cp) => cp != '')
-    .join(':')
 }
 
 // Function to call extension to open file picker
 function filePicker(id, description) {
   let extraData = {}
   if (id === 'daffodilDebugClasspath') {
-    extraData['daffodilDebugClasspath'] = getDaffodilDebugClasspathString()
+    extraData['daffodilDebugClasspath'] = getDaffodilDebugClasspathArray()
   }
 
   vscode.postMessage({
@@ -156,7 +161,7 @@ async function removeDebugClasspathItem(child) {
 // Function to update classpath list
 async function updateDaffodilDebugClasspathList(data, delimeter) {
   let list = document.getElementById('daffodilDebugClasspathTable')
-  let itemArray = data.split(delimeter)
+  let itemArray = delimeter !== undefined ? data.split(delimeter) : data
 
   for (var i = 0; i < itemArray.length; i++) {
     let item = itemArray[i]
@@ -452,7 +457,7 @@ async function updateConfigValues(config) {
    */
   await clearDaffodilDebugClasspathList()
   if (config.daffodilDebugClasspath !== '') {
-    await updateDaffodilDebugClasspathList(config.daffodilDebugClasspath, ':')
+    await updateDaffodilDebugClasspathList(config.daffodilDebugClasspath)
   }
 
   updateInfosetOutputType()

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -51,6 +51,15 @@ function getConfigValues(data, configIndex) {
       if (!currentConfig.hasOwnProperty(key)) {
         currentConfig[key] = defaultConf[key]
       }
+
+      // If key is an object itself, make sure nested keys are in current config
+      if (defaultConf[key] instanceof Object) {
+        for (var nestedKey of Object.keys(defaultConf[key])) {
+          if (!currentConfig[key].hasOwnProperty(nestedKey)) {
+            currentConfig[key][nestedKey] = defaultConf[key][nestedKey]
+          }
+        }
+      }
     }
 
     return currentConfig
@@ -289,9 +298,9 @@ async function createWizard(ctx: vscode.ExtensionContext) {
             let duplicateCount = 0
 
             if (message.id === 'daffodilDebugClasspath') {
-              duplicateCount = message.extraData['daffodilDebugClasspath']
-                .split(':')
-                .some((cp) => cp === result)
+              duplicateCount = message.extraData['daffodilDebugClasspath'].some(
+                (cp) => cp === result
+              )
             }
 
             var command =
@@ -425,7 +434,7 @@ class LaunchWizard {
     let daffodilDebugClasspathList =
       '<ul id="daffodilDebugClasspathTable" style="list-style: none; padding-left: 20px;">'
     if (defaultValues.daffodilDebugClasspath) {
-      let itemArray = defaultValues.daffodilDebugClasspath.split(':')
+      let itemArray = defaultValues.daffodilDebugClasspath
       for (let i = 0; i < itemArray.length; i++) {
         daffodilDebugClasspathList += `
           <li style="margin-left: -5px;" onclick="removeDebugClasspathItem(this)">
@@ -558,7 +567,7 @@ class LaunchWizard {
       <div id="schemaDiv" class="setting-div">
         <p>Main Schema File:</p>
         <p class="setting-description">Absolute path to the DFDL schema file.</p>
-        <input class="file-input" value="${defaultValues.schema}" id="schema"/>
+        <input class="file-input" value="${defaultValues.schema.path}" id="schema"/>
         <button id="schemaBrowse" class="browse-button" type="button" onclick="filePicker('schema', 'Select DFDL schema to debug')">Browse</button>
       </div>
 

--- a/src/tests/suite/daffodil.test.ts
+++ b/src/tests/suite/daffodil.test.ts
@@ -100,8 +100,8 @@ suite('Daffodfil', () => {
       let launchArgs: daffodil.LaunchArgs = {
         schema: {
           path: '/path/to/schema.xsd.xml',
-          rootName: '',
-          rootNamespace: '',
+          rootName: null,
+          rootNamespace: null,
         },
         dataPath: '/path/to/data.jpg',
         stopOnEntry: true,
@@ -114,8 +114,8 @@ suite('Daffodfil', () => {
       assert.strictEqual(true, launchArgs.stopOnEntry)
       assert.strictEqual('json', launchArgs.infosetFormat)
       assert.strictEqual(infosetOutput, launchArgs.infosetOutput)
-      assert.strictEqual('', launchArgs.schema.rootName)
-      assert.strictEqual('', launchArgs.schema.rootNamespace)
+      assert.strictEqual(null, launchArgs.schema.rootName)
+      assert.strictEqual(null, launchArgs.schema.rootNamespace)
     })
 
     test('ConfigEvent functions properly', () => {
@@ -132,8 +132,8 @@ suite('Daffodfil', () => {
       let launchArgs: daffodil.LaunchArgs = {
         schema: {
           path: '/path/to/schema.xsd.xml',
-          rootName: '',
-          rootNamespace: '',
+          rootName: null,
+          rootNamespace: null,
         },
         dataPath: '/path/to/data.jpg',
         stopOnEntry: true,

--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -69,7 +69,7 @@ suite('Daffodil Debugger', () => {
     debuggers.push(
       await runDebugger(
         PROJECT_ROOT,
-        '',
+        [],
         PACKAGE_PATH,
         4711,
         dfdlDebuggers[0],
@@ -79,7 +79,7 @@ suite('Daffodil Debugger', () => {
     debuggers.push(
       await runDebugger(
         PROJECT_ROOT,
-        '',
+        [],
         PACKAGE_PATH,
         4712,
         dfdlDebuggers[1],

--- a/src/tests/suite/utils.test.ts
+++ b/src/tests/suite/utils.test.ts
@@ -30,8 +30,8 @@ suite('Utils Test Suite', () => {
     type: 'dfdl',
     schema: {
       path: '${command:AskForSchemaName}',
-      rootName: '',
-      rootNamespace: '',
+      rootName: null,
+      rootNamespace: null,
     },
     data: '${command:AskForDataName}',
     debugServer: 4711,
@@ -52,7 +52,7 @@ suite('Utils Test Suite', () => {
     openDataEditor: false,
     openInfosetView: false,
     openInfosetDiffView: false,
-    daffodilDebugClasspath: '',
+    daffodilDebugClasspath: [],
     dataEditor: {
       port: 9000,
       logging: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,8 +123,8 @@ export function getConfig(jsonArgs: object): vscode.DebugConfiguration {
   const defaultValues = {
     schema: defaultConf.get('schema', {
       path: '${command:AskForSchemaName}',
-      rootName: '',
-      rootNamespace: '',
+      rootName: null,
+      rootNamespace: null,
     }),
     data: defaultConf.get('data', '${command:AskForDataName}'),
     debugServer: defaultConf.get('debugServer', 4711),
@@ -145,7 +145,7 @@ export function getConfig(jsonArgs: object): vscode.DebugConfiguration {
     openDataEditor: defaultConf.get('openDataEditor', false),
     openInfosetView: defaultConf.get('openInfosetView', false),
     openInfosetDiffView: defaultConf.get('openInfosetDiffView', false),
-    daffodilDebugClasspath: defaultConf.get('daffodilDebugClasspath', ''),
+    daffodilDebugClasspath: defaultConf.get('daffodilDebugClasspath', []),
     dataEditor: defaultConf.get('dataEditor', {
       port: 9000,
       logging: {


### PR DESCRIPTION
Change daffodilDebugClasspath to array of string instead of string

- This helps prevent issues where users might not be aware to use : for mac/linx and ; for windows.
- Update launch wizard to work properly with an array of strings instead of string.
- Update some other code to not try to split the daffodilDebugClasspath.
- When the classpath is passed to the debugger we join the array of string by either : or ; based on the OS.
- Allow rootName and rootNamespace to be null and allow null to be passed between TS and Scala.
  - Both also default to null.
  - Update properties of schema to require the path and define path, rootName and rootNamespace as properties.

Closes #934