### PR TITLE
Properly Dispose of Data Editor Session / Server

### DIFF
--- a/src/dataEditor/include/server/ServerInfo.ts
+++ b/src/dataEditor/include/server/ServerInfo.ts
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-import { IServerInfo } from '@omega-edit/client'
 import * as editor_config from '../../config'
 import * as fs from 'fs'
 import assert from 'assert'
+import { IServerInfo, getSessionCount } from '@omega-edit/client'
+
 export class ServerInfo implements IServerInfo {
   serverHostname: string = 'unknown'
   serverProcessId: number = 0
@@ -51,4 +52,11 @@ export function configureOmegaEditPort(configVars: editor_config.Config): void {
     )
     assert(omegaEditPort !== 0, 'omegaEditPort is not set')
   }
+}
+export type ServerStopPredicate = (context?: any) => Promise<boolean>
+export const NoSessionsExist: ServerStopPredicate = (): Promise<boolean> => {
+  return new Promise(async (resolve) => {
+    const count = await getSessionCount()
+    resolve(count === 0)
+  })
 }

--- a/src/dataEditor/include/utils.ts
+++ b/src/dataEditor/include/utils.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { debug } from 'vscode'
+
+export function isDFDLDebugSessionActive(): boolean {
+  return (
+    debug.activeDebugSession !== undefined &&
+    debug.activeDebugSession.type === 'dfdl'
+  )
+}


### PR DESCRIPTION
If the data editor panel was closed, or a DFDL debug session terminated, the omega edit server would not be properly shut down from the data editor side.

- Implemented proper `dataEditorClient` & `WebviewPanel` disposal.

Closes #898