### PR TITLE
Fix error thrown when using ${command:AskForSchemaName}

### DIFF
--- a/src/daffodilDebugger/debugger.ts
+++ b/src/daffodilDebugger/debugger.ts
@@ -152,7 +152,7 @@ export async function getDebugger(
 
     // Get schema file before debugger starts to avoid timeout
     if (config.schema.path.includes('${command:AskForSchemaName}')) {
-      config.schema = await vscode.commands.executeCommand(
+      config.schema.path = await vscode.commands.executeCommand(
         'extension.dfdl-debug.getSchemaName'
       )
     }


### PR DESCRIPTION
Fix error thrown when using ${command:AskForSchemaName}

- The issue dealt with setting `schema` to the result of the command instead of using `schema.path`.

Closes #962