### PR TITLE
Fix Windows not hitting breakpoints

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
@@ -748,11 +748,8 @@ object DAPodil extends IOApp {
       copy(value = value + (uri.normalize -> lines))
 
     def contains(location: Location): Boolean =
-      value.exists {
-        // format: off
-        case (uri, lines) =>
-          uri == location.uri && lines.exists(_ == location.line)
-        // format: on
+      value.exists { case (uri, lines) =>
+        Portability.fixWindowsDriveLetter(uri.getPath) == location.uri.getPath && lines.exists(_ == location.line)
       }
   }
 

--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Portability.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Portability.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.debugger.dap
+
+object Portability {
+  def osIsWindows(): Boolean = System.getProperty("os.name").toLowerCase.startsWith("win")
+
+  def fixWindowsDriveLetter(uriPath: String): String =
+    osIsWindows() match {
+      case true =>
+        val uriParts = uriPath.split("/")
+        // item at index 0 is empty string, item at index 1 is drive letter
+        uriParts(1) = uriParts(1).toUpperCase
+        uriParts.mkString("/")
+      case false => uriPath
+    }
+}


### PR DESCRIPTION
Fix Windows not hitting breakpoints.

- Slight differences in the uri and location.uri was causing windows breakpoints not to be hit.
  - Updating the content of the uri to better match made the breakpoints work for Mac, Linux and Windows.

Closes #968