### PR TITLE
More helpful error messages

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/ErrorEvent.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/ErrorEvent.scala
@@ -19,11 +19,15 @@ package org.apache.daffodil.debugger.dap
 
 import com.microsoft.java.debug.core.protocol.Events.DebugEvent
 
+sealed abstract class ErrorEvent(event: String) extends DebugEvent(event) {
+  def message: String
+}
+
 /** Case classes for errors that we want to relay back to the extension */
-object ErrorEvents {
-  case object UnexpectedError extends DebugEvent("daffodil.error.unexpected")
-  case object UnhandledRequest extends DebugEvent("daffodil.error.requestunhandled")
-  case object LaunchArgsParseError extends DebugEvent("daffodil.error.launchargparse")
-  case object RequestError extends DebugEvent("daffodil.error.request")
-  case object SourceError extends DebugEvent("daffodil.error.source")
+object ErrorEvent {
+  case class UnexpectedError(message: String) extends ErrorEvent("daffodil.error.unexpected")
+  case class UnhandledRequest(message: String) extends ErrorEvent("daffodil.error.requestunhandled")
+  case class LaunchArgsParseError(message: String) extends ErrorEvent("daffodil.error.launchargsparse")
+  case class RequestError(message: String) extends ErrorEvent("daffodil.error.request")
+  case class SourceError(message: String) extends ErrorEvent("daffodil.error.source")
 }

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -26,6 +26,9 @@ import { handleDebugEvent } from './daffodilEvent'
 import { InlineDebugAdapterFactory } from './extension'
 import * as dfdlExt from '../language/semantics/dfdlExt'
 
+export const outputChannel: vscode.OutputChannel =
+  vscode.window.createOutputChannel('Daffodil')
+
 /** Method to file path for schema and data
  * Details:
  *   Required so that the vscode api commands:
@@ -214,7 +217,10 @@ export function activateDaffodilDebug(
           'Select input data file to debug'
         )
       }
-    )
+    ),
+    vscode.commands.registerCommand('extension.dfdl-debug.showLogs', () => {
+      outputChannel.show(true)
+    })
   )
 
   context.subscriptions.push(

--- a/src/adapter/daffodilEvent.ts
+++ b/src/adapter/daffodilEvent.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs'
 
 import * as daf from '../daffodilDebugger'
 import { ensureFile, tmpFile } from '../utils'
+import { outputChannel } from './activateDaffodilDebug'
 
 export function handleDebugEvent(e: vscode.DebugSessionCustomEvent) {
   switch (e.event) {
@@ -31,7 +32,10 @@ export function handleDebugEvent(e: vscode.DebugSessionCustomEvent) {
       break
     // this allows for any error event to be caught in this case
     case e.event.startsWith('daffodil.error') ? e.event : '':
-      vscode.window.showErrorMessage(`debugger ${e.event}`)
+      vscode.window.showErrorMessage(
+        `An error was received from the Daffodil debugger. ([show logs](command:extension.dfdl-debug.showLogs "show logs"))`
+      )
+      outputChannel.appendLine(e.body.message)
       break
   }
 }


### PR DESCRIPTION
Rather than the user having to scroll through the mess of the backend debugger log in the Terminal, we can send the exception message along with the event type back to the extension, which then logs it in a distinct "Daffodil" Output tab.

The user then clicks the "show logs" to switch to that tab.

The current errors are:
* `ErrorEvent.UnhandledRequest`: if the backend receives a type of request it doesn't understand
* `ErrorEvent.LaunchArgsParseError`: if the backend can't parse the launch args when starting a DAP session
* `ErrorEvent.RequestError`: the backend had a problem executing a request; this includes runtime exceptions from Daffodil like schema compilation
* `ErrorEvent.SourceError`: used during an experiment for having backend-provided source files, not used currently
* `ErrorEvent.UnexpectedError`: used when a watch expression can't be evaluated; this error seems to be redundant and could perhaps be merged with `RequestError`

The PR doesn't display the particular the error type, only the underlying message. The user can look at the regular logs for the details.

Fixes #931.