### PR TITLE
Launch configuration wizard mismatched label/text

### DIFF
--- a/src/infoset.ts
+++ b/src/infoset.ts
@@ -147,8 +147,8 @@ export async function activate(ctx: vscode.ExtensionContext) {
         let prev = ensureFile(`${path}.prev`)
         vscode.commands.executeCommand(
           'vscode.diff',
-          Uri.parse(prev),
-          Uri.parse(path),
+          Uri.file(prev),
+          Uri.file(path),
           'Previous ↔ Current',
           { preview: false, viewColumn: vscode.ViewColumn.Two }
         )

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -669,7 +669,7 @@ class LaunchWizard {
 
       <div id="openInfosetDiffViewDiv" class="setting-div" onclick="check('openInfosetDiffView')">
         <p>Open Infoset Diff View:</p>
-        <label class="container">Open infoset view on debug start.
+        <label class="container">Open infoset diff on debug start.
           <input type="checkbox" id="openInfosetDiffView" ${openInfosetDiffView}>
           <span class="checkmark"></span>
         </label>
@@ -677,7 +677,7 @@ class LaunchWizard {
 
       <div id="openInfosetViewDiv" class="setting-div" onclick="check('openInfosetView')">
         <p>Open Infoset View:</p>
-        <label class="container">Open infoset diff on debug start.
+        <label class="container">Open infoset view on debug start.
           <input type="checkbox" id="openInfosetView" ${openInfosetView}>
           <span class="checkmark"></span>
         </label>


### PR DESCRIPTION
fixing text description of checkbox to open infoset viewer and infoset diff viewer and
correcting url parse/file problem that prevented diff viewer from finding files on Windows.
Closes #985 
Closes #986 