### PR TITLE
#988 - Fix profiler with Ωedit update to v0.9.82

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "svelte:check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@omega-edit/client": "0.9.78",
+    "@omega-edit/client": "0.9.82",
     "@viperproject/locate-java-home": "1.1.13",
     "@vscode/debugadapter": "1.63.0",
     "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -52,10 +52,9 @@ import {
   saveSession,
   SaveStatus,
   searchSession,
-  setAutoFixViewportDataLength,
   setLogger,
   startServer,
-  stopServerUsingPID,
+  stopProcessUsingPID,
   undo,
   ViewportDataResponse,
   ViewportEvent,
@@ -838,7 +837,6 @@ async function createDataEditorWebviewPanel(
   // only start up the server if one is not already running
   if (!(await checkServerListening(omegaEditPort, OMEGA_EDIT_HOST))) {
     await setupLogging(launchConfigVars)
-    setAutoFixViewportDataLength(true)
     await serverStart()
     client = await getClient(omegaEditPort, OMEGA_EDIT_HOST)
     assert(
@@ -1136,7 +1134,7 @@ async function serverStop() {
   const serverPidFile = getPidFile(omegaEditPort)
   if (fs.existsSync(serverPidFile)) {
     const pid = parseInt(fs.readFileSync(serverPidFile).toString())
-    if (await stopServerUsingPID(pid)) {
+    if (await stopProcessUsingPID(pid)) {
       vscode.window.setStatusBarMessage(
         `Ωedit server stopped on port ${omegaEditPort} with PID ${pid}`,
         new Promise((resolve) => {

--- a/src/tests/suite/dataEditor.test.ts
+++ b/src/tests/suite/dataEditor.test.ts
@@ -27,7 +27,7 @@ import {
   getServerInfo,
   setLogger,
   startServer,
-  stopServerUsingPID,
+  stopProcessUsingPID,
 } from '@omega-edit/client'
 import {
   APP_DATA_PATH,
@@ -113,7 +113,7 @@ suite('Data Editor Test Suite', () => {
       assert.strictEqual(fs.existsSync(pidFile), true)
       const pid = parseInt(fs.readFileSync(pidFile).toString())
       console.log(pid)
-      assert.strictEqual(await stopServerUsingPID(pid), true)
+      assert.strictEqual(await stopProcessUsingPID(pid), true)
     })
 
     test('is running', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,18 +131,18 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.19.9.tgz#b2da6219b603e3fa371a78f53f5361260d0c5585"
   integrity sha512-oxoQgglOP7RH6iasDrhY+R/3cHrfwIDvRlT4CGChflq6twk8iENeVvMJjmvBb94Ik1Z+93iGO27err7w6l54GQ==
 
-"@grpc/grpc-js@1.9.14":
-  version "1.9.14"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.14.tgz#236378822876cbf7903f9d61a0330410e8dcc5a1"
-  integrity sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==
+"@grpc/grpc-js@1.10.4":
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.10.4.tgz#a33f743f69ed531e917c9eafb4fd8bc3e5f2e617"
+  integrity sha512-MqBisuxTkYvPFnEiu+dag3xG/NBUDzSbAFAWlzfkGnQkjVZ6by3h4atbBc+Ikqup1z5BfB4BN18gKWR1YyppNw==
   dependencies:
-    "@grpc/proto-loader" "^0.7.8"
-    "@types/node" ">=12.12.47"
+    "@grpc/proto-loader" "^0.7.10"
+    "@js-sdsl/ordered-map" "^4.4.2"
 
-"@grpc/proto-loader@^0.7.8":
-  version "0.7.10"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.10.tgz#6bf26742b1b54d0a473067743da5d3189d06d720"
-  integrity sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==
+"@grpc/proto-loader@^0.7.10":
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.12.tgz#787b58e3e3771df30b1567c057b6ab89e3a42911"
+  integrity sha512-DCVwMxqYzpUCiDMl7hQ384FqP4T3DbNpXU8pt681l3UWCip1WUiD5JrkImUwCB9a7f2cq4CUTmi5r/xIMRPY1Q==
   dependencies:
     lodash.camelcase "^4.3.0"
     long "^5.0.0"
@@ -216,6 +216,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
+
 "@microsoft/fast-element@^1.12.0":
   version "1.12.0"
   resolved "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz"
@@ -267,22 +272,23 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@omega-edit/client@0.9.78":
-  version "0.9.78"
-  resolved "https://registry.yarnpkg.com/@omega-edit/client/-/client-0.9.78.tgz#0cb44ddeb55d75fdc6aa5166bb971101074c8702"
-  integrity sha512-bErQQCZtRNxKKSz2+G48cotw3ek9+3Xra0RsXwDWClBnxlcvjJyCaI6/8At6DqjkdDvukc4a0UFvXdVxkcRwBw==
+"@omega-edit/client@0.9.82":
+  version "0.9.82"
+  resolved "https://registry.yarnpkg.com/@omega-edit/client/-/client-0.9.82.tgz#3099d9d4d6a60efe0a19d6058562510393a9cb7d"
+  integrity sha512-1WmYo3T7C/dEr7FkpSVKsaUPyvQ0eHuStK0iaCmlU/4irOutKofJyPrZ4eV/DsgNCvplN31Hy7ZoSjUoczltow==
   dependencies:
-    "@grpc/grpc-js" "1.9.14"
-    "@omega-edit/server" "0.9.78"
+    "@grpc/grpc-js" "1.10.4"
+    "@omega-edit/server" "0.9.82"
     "@types/google-protobuf" "3.15.12"
     google-protobuf "3.21.2"
-    pino "8.16.2"
+    pid-port "0.2.0"
+    pino "8.19.0"
     wait-port "1.1.0"
 
-"@omega-edit/server@0.9.78":
-  version "0.9.78"
-  resolved "https://registry.yarnpkg.com/@omega-edit/server/-/server-0.9.78.tgz#16725792f08134fb6c28a463874f4891fb63f08f"
-  integrity sha512-idSZQHjv28zF47kiKcMKGrVAqhQHtsxBvSNlP3Ergtn9cEXgsymh4fV6WzBi6VtRG8OrUMAhzd9JrN6j0eHR4g==
+"@omega-edit/server@0.9.82":
+  version "0.9.82"
+  resolved "https://registry.yarnpkg.com/@omega-edit/server/-/server-0.9.82.tgz#2b6e70acdb1e82059235be478029ae08a6307112"
+  integrity sha512-cTohvHGHd8sZeeonW0JBNDoFfzLteei9v+sI/BBGvvWXNbCW74zZeYPQt9qHAqfvopxK+yRPUrvJpaKhZwbyZA==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -462,7 +468,14 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20.11.30":
+"@types/node@*":
+  version "20.10.4"
+  resolved "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz"
+  integrity sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==
+  dependencies:
+    undici-types "~5.26.4"
+
+"@types/node@>=13.7.0", "@types/node@^20.11.30":
   version "20.11.30"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.30.tgz#9c33467fc23167a347e73834f788f4b9f399d66f"
   integrity sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==
@@ -2860,6 +2873,13 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pid-port@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/pid-port/-/pid-port-0.2.0.tgz#db45378e4dcdb8425f911b7c09d7b0187a399873"
+  integrity sha512-xVU9H1FCRSeGrD9Oim5bLg2U7B2BgW0qzK2oahpV5BIf9hwzqQaWyOkOVC0Kgbsc90A9x6525beawx+QK+JduQ==
+  dependencies:
+    execa "^5.1.1"
+
 pino-abstract-transport@v1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz"
@@ -2873,17 +2893,17 @@ pino-std-serializers@^6.0.0:
   resolved "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz"
   integrity sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==
 
-pino@8.16.2:
-  version "8.16.2"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-8.16.2.tgz#7a906f2d9a8c5b4c57412c9ca95d6820bd2090cd"
-  integrity sha512-2advCDGVEvkKu9TTVSa/kWW7Z3htI/sBKEZpqiHk6ive0i/7f5b1rsU8jn0aimxqfnSz5bj/nOYkwhBUn5xxvg==
+pino@8.19.0:
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-8.19.0.tgz#ccc15ef736f103ec02cfbead0912bc436dc92ce4"
+  integrity sha512-oswmokxkav9bADfJ2ifrvfHUwad6MLp73Uat0IkQWY3iAw5xTRoznXbXksZs8oaOUMpmhVWD+PZogNzllWpJaA==
   dependencies:
     atomic-sleep "^1.0.0"
     fast-redact "^3.1.1"
     on-exit-leak-free "^2.1.0"
     pino-abstract-transport v1.1.0
     pino-std-serializers "^6.0.0"
-    process-warning "^2.0.0"
+    process-warning "^3.0.0"
     quick-format-unescaped "^4.0.3"
     real-require "^0.2.0"
     safe-stable-stringify "^2.3.1"
@@ -3176,10 +3196,10 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process-warning@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz"
-  integrity sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==
+process-warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-3.0.0.tgz#96e5b88884187a1dce6f5c3166d611132058710b"
+  integrity sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==
 
 process@^0.11.10:
   version "0.11.10"


### PR DESCRIPTION
In Windows running the profiler would kill the Ωedit server.  That behavior was repaired in a recent update to Ωedit.  With this change, the profiler will work when running in Windows.

Fixes #988.