### PR TITLE
Refactor to fix event delivery guarantees.

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/logging.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/logging.scala
@@ -42,6 +42,8 @@ object logging {
     case event: Events.ThreadEvent  => s"${event.`type`} ${event.reason}"
     case event: DAPodil.LoadedSourceEvent =>
       s"${event.`type`} ${event.reason} ${JsonUtils.toJson(event.source)}"
+    case event: Parse.DataEvent =>
+      s"${event.`type`} ${event.bytePos1b}"
     case event => s"${event.`type`}"
   }
 }


### PR DESCRIPTION
Events were emitted, or sometimes not emitted at all, before state changes were committed.

Some refactorings to both directly fix this and also improve the code:
- New `Parse.Deliver` class encapsulates translation of `Parse.Event`s into DAP state and events, delivered via the `Debugee` interface. It also ensures state is delivered before events so that consumers can react to events and read the correct state values. `Parse.Deliver` also fixes the bug of not delivering certain events, like the data position upon the "continue" action, by delivering events at every kind of stopping action, which includes "step", "continue", and a hit breakpoint.
- Remove `Debugee.state` and have the `Debugee` implementation emit the DAP events directly via `Debugee.events`.
- Instead of using `None`-terminated `Queue`, which enqueues with `Some` and terminates with `None`, use the `Channel` data type which only uses the actual message type.
- To lift an `IO` into a `Resource`, replace `Resource.eval(io)` with `io.toResource`.

Fixes #995.