### PR TITLE
Resolved Selection Highlighting Rescend

### DIFF
--- a/src/svelte/src/utilities/highlights.ts
+++ b/src/svelte/src/utilities/highlights.ts
@@ -106,7 +106,7 @@ class ViewportByteIndications extends SimpleWritable<Uint8Array> {
         }),
         generateSelectionCategoryParition(
           Math.max(originalEnd, editedEnd),
-          VIEWPORT_CAPACITY_MAX - start,
+          VIEWPORT_CAPACITY_MAX,
           (byte) => {
             byte[0] &= ~category1.indexOf('selected')
           }


### PR DESCRIPTION
- Updated selection partition calculations to calculate against the `VIEWPORT_CAPACITY_MAX`.

Closes #1019