### PR TITLE
Fix broken TDML append, copy and execute functionality

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.tdml/TDML.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.tdml/TDML.scala
@@ -123,6 +123,7 @@ object TDML {
       .relativize(new File(path.toString()).toURI())
       .getPath()
       .toString()
+      .trim()
   }
 
   // Generate a new TDML file.
@@ -253,7 +254,13 @@ object TDML {
   // Returns a tuple containing the following (Path to DFDL Schema, Path to Data File)
   // All paths returned could be either relative or absolute - it depends on what exists in the TDML file
   def execute(tdmlName: String, tdmlDescription: String, tdmlPath: String): Option[(Path, Path)] = {
-    val basePath = Paths.get(tdmlPath).toAbsolutePath().getParent()
+
+    // Correct basepath for Windows OS
+    var basePath = ""
+    if (System.getProperty("os.name").toLowerCase.startsWith("win") == true)
+      (
+        basePath = Paths.get(tdmlPath).toAbsolutePath().getParent().toString()
+      )
 
     val testCaseList = JAXBContext
       .newInstance(classOf[TestSuite])
@@ -278,6 +285,7 @@ object TDML {
                 .asInstanceOf[JAXBElement[DocumentPartType]]
                 .getValue()
                 .getValue()
+                .trim()
             )
             .normalize()
           (schemaPath, dataPath)

--- a/debugger/src/test/scala/org.apache.daffodil.tdml/TDMLSuite.scala
+++ b/debugger/src/test/scala/org.apache.daffodil.tdml/TDMLSuite.scala
@@ -126,10 +126,18 @@ class TDMLSuite extends munit.FunSuite {
   }
 
   test("Test Execute") {
-    TDML.generate(infosetPath, schemaPath, dataPath, tdmlName, tdmlDescription, tdmlPath.toString())
-    val executePaths = TDML.execute(tdmlName, tdmlDescription, tdmlPath.toString())
 
-    assertEquals(executePaths, Option[(Path, Path)]((schemaPath.normalize(), dataPath.normalize())))
+    var schemaPathExecute = Paths.get("/debugger/src/test/data/emptySchema.xml")
+    var dataPathExecute = Paths.get("/debugger/src/test/data/emptyData.xml")
+
+    if (System.getProperty("os.name").toLowerCase.startsWith("win") == true) {
+      schemaPathExecute = schemaPath
+      dataPathExecute = dataPath
+    }
+    TDML.generate(infosetPath, schemaPath, dataPath, tdmlName, tdmlDescription, tdmlPath.toString())
+    val executePaths = TDML.execute(tdmlName, tdmlDescription, tdmlPath.toAbsolutePath().toString())
+
+    assertEquals(executePaths, Option[(Path, Path)]((schemaPathExecute.normalize(), dataPathExecute.normalize())))
   }
 
   test("Test convertToRelativePath") {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "onCommand:extension.dfdl-debug.getTDMLDescription",
     "onCommand:extension.dfdl-debug.getTDMLPath",
     "onCommand:extension.dfdl-debug.getValidatedTDMLPath",
+    "onCommand:extension.dfdl-debug.getValidatedTDMLCopyPath",
     "onCommand:launch.config",
     "onCommand:extension.data.edit",
     "onCommand:extension.dfdl-debug.debugLastEditorContents"
@@ -749,7 +750,11 @@
         "variables": {
           "AskForSchemaName": "extension.dfdl-debug.getSchemaName",
           "AskForDataName": "extension.dfdl-debug.getDataName",
-          "AskForValidatedTDMLPath": "extension.dfdl-debug.getValidatedTDMLPath"
+          "AskForTDMLName": "extension.dfdl-debug.getTDMLName",
+          "AskForTDMLDescription": "extension.dfdl-debug.getTDMLDescription",
+          "AskForTDMLPath": "extension.dfdl-debug.getTDMLPath",
+          "AskForValidatedTDMLPath": "extension.dfdl-debug.getValidatedTDMLPath",
+          "AskForValidatedTDMLCopyPath": "extension.dfdl-debug.getValidatedTDMLCopyPath"
         }
       }
     ],

--- a/src/tests/suite/tdmlXmlUtils.test.ts
+++ b/src/tests/suite/tdmlXmlUtils.test.ts
@@ -152,14 +152,10 @@ suite('TDML Utils Test Suite', () => {
   })
 
   test('Append TDML Test Case', async () => {
-    var xmlBuffer = await readTDMLFileContents(
-      join(data_directory, 'test-second.tdml')
-    )
-    var destinationBuffer = await readTDMLFileContents(
+    var appendedBuffer = await appendTestCase(
+      join(data_directory, 'test-second.tdml'),
       join(data_directory, 'test.tdml')
     )
-
-    var appendedBuffer = await appendTestCase(xmlBuffer, destinationBuffer)
 
     return readTDMLFileContents(join(data_directory, 'test-appended.tdml'))
       .then((buf) => {
@@ -171,17 +167,16 @@ suite('TDML Utils Test Suite', () => {
   })
 
   test('Invalid Append TDML - duplicate', async () => {
-    return readTDMLFileContents(join(data_directory, 'test.tdml')).then(
-      (buf) => {
-        return appendTestCase(buf, buf)
-          .then((_) => {
-            // This is not checked because we threw
-          })
-          .catch((reason) => {
-            // This is checked because we threw
-            strictEqual(reason, 'Duplicate Test Case Name Found')
-          })
-      }
+    return appendTestCase(
+      join(data_directory, 'test.tdml'),
+      join(data_directory, 'test.tdml')
     )
+      .then((_) => {
+        // This is not checked because we threw
+      })
+      .catch((reason) => {
+        // This is checked because we threw
+        strictEqual(reason, 'Duplicate Test Case Name Found')
+      })
   })
 })


### PR DESCRIPTION
closes #1013 

Fixed TDML functionality. Now copyTDML, Append and Execute TDML works as expected.  

Following functionality still need re-visit and further enhancement issues needs to be created. 

- in copy, it is currently being hardcoded to getTmpTDMLFile location. If a user is specifying a custom value in the launch config, we won't be able to pick that up right now (append is probably working the same way) (#1027 )
- in copy, there's no error message when it doesn't work (#1027)
- in append, if you are trying to add a duplicate, there is no error message letting the user know that's why nothing happened (#1028 )
- in execute, if the user takes longer than the timeout to enter name/description, the server will disconnect. #596 should fix this issue. (#1029 )
- in generate, TDML name, description and infoset path is defaults to string "undefined" (#1024 )
- Execute functionality should only require TDML test case name only to execute, currently it requires name and description. #596 should fix this issue. (#1030 )
- append is listed as a valid action in the launch wizard - Append is not a server action and should not be available as an option in launch config. (#1031 )
- TDML Copy function creates the wrong path in some Windows 10 environments (#1034)
- Fix TDML Copy, Execute and Append functionality in MacOS Platform (#1035)

Steps to test TDML copy, execute, append

Configure launch.json to generate a TDML file.
![image](https://github.com/apache/daffodil-vscode/assets/72815523/b755a9bc-fe6b-40ee-b52d-8f498085af49)

Run the debug extension, choose a dfdl schema and data file.  After the schema opens make sure the language mode is DFDL. 
![image](https://github.com/apache/daffodil-vscode/assets/72815523/52c87a75-14d8-4e21-b83e-cffadf426435)

Press the continue button to produce the infoset.
![image](https://github.com/apache/daffodil-vscode/assets/72815523/d65c1736-c37d-4c6f-8732-a1473278be07)

When the infoset generates, a temporary TDML schema will generate.
![image](https://github.com/apache/daffodil-vscode/assets/72815523/bfd4955f-1d11-401e-9b40-e22997c5810a)

Close any open window except the dfdl schema window.  Click “Copy TDML File” in the dropdown at the top tight of the editor window. 
![image](https://github.com/apache/daffodil-vscode/assets/72815523/c506795a-896e-4c0a-80fb-d409a70156a7)

Enter a name for the TDML file, click “Save TDML File in the lower right corner of the popup. 
![image](https://github.com/apache/daffodil-vscode/assets/72815523/7ed26c52-3ea4-44dc-a859-c01183f77de7)

Close the dfdl schema in the editor window.  Click on the explore tab in the top left corner to display the file view. Click on the save TDML file. 
![image](https://github.com/apache/daffodil-vscode/assets/72815523/97eb2220-f308-4ae0-a573-460674b315a8)

After the TDML file opens click the menu in the top right corner and select “Execute TDML” 
![image](https://github.com/apache/daffodil-vscode/assets/72815523/28295679-76ab-49bc-83fa-5c9f1d9f48c7)

Quickly select a test case a press enter.  Then quickly accept the description and press enter.
![image](https://github.com/apache/daffodil-vscode/assets/72815523/ae80039c-0ab9-4118-b283-b64cd5fe17f4)

The previously selected dfdl schema will open and the previously selected data file will be used and empty infoset will also open. 
![image](https://github.com/apache/daffodil-vscode/assets/72815523/dfc4bd4e-d51b-4c61-ac9c-f2b493399c8a)

To append to the existing TDML file, open the test file and click the button in the upper right corner to open in a text editor. 
![image](https://github.com/apache/daffodil-vscode/assets/72815523/7264e8f0-194e-4b99-a60a-9441ff56cdc4)

Change the test case name and save the file.
![image](https://github.com/apache/daffodil-vscode/assets/72815523/4d4e7710-fe95-4d10-836a-bc9f4ef6c52c)

Select append from the TDML dropdown menu at the upper right. 
![image](https://github.com/apache/daffodil-vscode/assets/72815523/41e23fa2-8e5e-4465-b670-cf9ec6a2e065)

The original default test case will be appended to saved TDML file with the new test case.
![image](https://github.com/apache/daffodil-vscode/assets/72815523/7f9b7fdb-c453-4202-841b-ad4663b70a1d)






