### PR TITLE
Nightly tests updates:

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,10 @@ jobs:
         vscode: [ 'stable', 'insiders' ]
         java_distribution: [ temurin ]
         java_version: [ 8, 11, 17 ]
+        exclude:
+          # java 8 not available on latest macos
+          - os: macos-latest
+            java_version: 8
       fail-fast: false  # don't immediately fail all other jobs if a single job fails
     runs-on: ${{ matrix.os }}
     defaults:
@@ -56,6 +60,11 @@ jobs:
         uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ matrix.node }}
+
+      # macos-latest doesn't seem to have sbt installed by default
+      - name: Install sbt - macos-latest
+        run: brew install sbt
+        if: matrix.os == 'macos-latest'
 
       ############################################################
       # Build & Package


### PR DESCRIPTION
Nightly tests updates:

- Exclude java_version 8 with macos-latest as it is not supported.
- Add command to install sbt on macos-latest as it doesn't seem to installed by default.

Fixes items 1 and 3 of #1032