### PR TITLE
fixes a bug where quoted text is replaced by a space when a slash is typed

### DIFF
--- a/src/language/providers/attributeHover.ts
+++ b/src/language/providers/attributeHover.ts
@@ -17,6 +17,7 @@
 
 import * as vscode from 'vscode'
 import { attributeHoverValues } from './intellisense/attributeHoverItems'
+import { attributeCompletion } from './intellisense/attributeItems'
 
 export function getAttributeHoverProvider() {
   return vscode.languages.registerHoverProvider('dfdl', {
@@ -28,11 +29,17 @@ export function getAttributeHoverProvider() {
       const range = document.getWordRangeAtPosition(position)
       const word = document.getText(range)
 
+      let itemNames: string[] = []
+      attributeCompletion('', '', 'dfdl:', '', '').items.forEach((r) =>
+        itemNames.push(r.item)
+      )
       if (word.length > 0) {
-        return new vscode.Hover({
-          language: 'dfdl',
-          value: attributeHoverValues(word),
-        })
+        if (itemNames.includes(word)) {
+          return new vscode.Hover({
+            language: 'dfdl',
+            value: attributeHoverValues(word),
+          })
+        }
       }
     },
   })

--- a/src/language/providers/attributeValueCompletion.ts
+++ b/src/language/providers/attributeValueCompletion.ts
@@ -51,13 +51,19 @@ export function getAttributeValueCompletionProvider() {
             replaceValue = ' '
           }
 
-          if (attributeName.includes(':')) {
+          if (
+            attributeName.includes(':') &&
+            !attributeName.includes('xmlns:')
+          ) {
             attributeName = attributeName.substring(
               attributeName.indexOf(':') + 1
             )
           }
 
-          if (noChoiceAttributes.includes(attributeName)) {
+          if (
+            noChoiceAttributes.includes(attributeName) ||
+            attributeName.includes('xmlns:')
+          ) {
             return undefined
           }
 
@@ -75,7 +81,7 @@ export function getAttributeValueCompletionProvider() {
         return undefined
       },
     },
-    ' ' // triggered whenever a newline is typed
+    ' ' // triggered whenever a space is typed
   )
 }
 
@@ -130,7 +136,7 @@ export function getTDMLAttributeValueCompletionProvider() {
         return undefined
       },
     },
-    ' ' // triggered whenever a newline is typed
+    ' ' // triggered whenever a space is typed
   )
 }
 
@@ -182,6 +188,10 @@ function getAttributeDetails(
           currentPos < triggerPos &&
           textBeforeTrigger.lastIndexOf('=') === currentPos - 1
         ) {
+          textBeforeTrigger = textBeforeTrigger.substring(
+            0,
+            textBeforeTrigger.lastIndexOf('=')
+          )
           endPos = currentText.indexOf(quoteChar[i], currentPos + 1)
           attributeStartPos = textBeforeTrigger.lastIndexOf(' ')
           attributeName = textBeforeTrigger.substring(

--- a/src/language/providers/closeElementSlash.ts
+++ b/src/language/providers/closeElementSlash.ts
@@ -47,6 +47,9 @@ export function getCloseElementSlashProvider() {
           position,
           nsPrefix
         )
+        if (nearestTagNotClosed === 'none') {
+          return undefined
+        }
         const itemsOnLine = getItemsOnLineCount(triggerText)
 
         if (

--- a/src/language/providers/intellisense/attributeValueItems.ts
+++ b/src/language/providers/intellisense/attributeValueItems.ts
@@ -62,6 +62,9 @@ export const noChoiceAttributes = [
   'test',
   'testPattern',
   'message',
+  'source',
+  'schemaLocation',
+  'targetNamespace',
 ]
 
 export function attributeValues(

--- a/src/language/providers/utils.ts
+++ b/src/language/providers/utils.ts
@@ -207,8 +207,17 @@ export function checkTagOpen(
   const triggerPos = position.character
   const textBeforeTrigger = triggerText.substring(0, triggerPos)
 
-  while (itemsOnLine < 2 && !triggerText.trim().startsWith('<')) {
+  while (
+    itemsOnLine < 2 &&
+    !triggerText.trim().startsWith('<') &&
+    !triggerText.includes('/>') &&
+    !triggerText.includes('<')
+  ) {
     triggerText = document.lineAt(--triggerLine).text
+  }
+
+  if (triggerText.includes('/>') || triggerText.includes('</')) {
+    return false
   }
 
   if (!(triggerText.endsWith('>') && triggerText.includes('<'))) {


### PR DESCRIPTION
fixes a bug where quoted text is replaced by a space when a slash is typed

To test:
Either create and install the extension or run the extension in the vscode debugger.
In the vscode window running the extension, open the folder containing the dfdl schema you are going to test with.
Open the dfdl schema in that folder, but don't use debug to open the schema with the launch.json configuration.
Place the cursor on one of the quoted values of the schema namespace defines.
(if the schema you select contains <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
or ' <xs:appinfo source="http://www.ogf.org/dfdl/"> you could also try placing the cursor in those quoted values)
Press the '/' slash key.
The quoted text should not be replaced.
Try the typing a space in the same quoted value. (A space is the only defined trigger for this function, I'm not sure why slash is triggering it).
The quoted text should not be replaced .
You can also try this test using the launch.json config that asks for a schema file and a data file, but I could not reproduce the failure when opening the file that way.

closes #1064