### PR TITLE
Fix code completion trigger for slash in dfdl schema files

### DIFF
--- a/src/language/providers/closeElementSlash.ts
+++ b/src/language/providers/closeElementSlash.ts
@@ -62,7 +62,7 @@ export function getCloseElementSlashProvider() {
           return undefined
         }
 
-        if (triggerText.endsWith('/')) {
+        if (triggerText.endsWith(' ')) {
           let range = new vscode.Range(backpos, position)
 
           await vscode.window.activeTextEditor?.edit((editBuilder) => {
@@ -84,7 +84,7 @@ export function getCloseElementSlashProvider() {
       },
     },
     '/'
-    // triggered whenever a '/' is typed
+    // triggered whenever a ' ' is typed
   )
 }
 
@@ -118,7 +118,7 @@ export function getTDMLCloseElementSlashProvider() {
           return undefined
         }
 
-        if (triggerText.endsWith('/')) {
+        if (triggerText.endsWith(' ')) {
           let range = new vscode.Range(backpos, position)
 
           await vscode.window.activeTextEditor?.edit((editBuilder) => {
@@ -140,7 +140,7 @@ export function getTDMLCloseElementSlashProvider() {
       },
     },
     '/'
-    // triggered whenever a '/' is typed
+    // triggered whenever a ' ' is typed
   )
 }
 
@@ -173,7 +173,7 @@ function checkItemsOnLine(
 
   if (itemsOnLine > 1) {
     if (
-      triggerText.endsWith('/') &&
+      triggerText.endsWith(' ') &&
       triggerText.includes('<' + nsPrefix + nearestTagNotClosed)
     ) {
       let tagPos = triggerText.lastIndexOf('<' + nsPrefix + nearestTagNotClosed)


### PR DESCRIPTION
The code completion trigger in dfdl schema files was incorrectly set to a space only, but it was also being triggered by a slash '/'. This pull request fixes the issue by updating the trigger to only happen for a space '  '.