### PR TITLE
#1084 add ds-nteligen as a contributor

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,6 +25,7 @@ github:
     merge:    false
     rebase:   true
   collaborators:
+    - ds-nteligen
     - hdalsania
     - lrbarber
     - michael-hoke


### PR DESCRIPTION
This adds ds-nteligen as a contributor.

Closes #1084.