### PR TITLE
Fixes intellisense problems discovered in RC1

### DIFF
--- a/src/language/providers/attributeCompletion.ts
+++ b/src/language/providers/attributeCompletion.ts
@@ -326,6 +326,26 @@ function checkNearestOpenItem(
         spacingChar,
         afterChar
       )
+    case 'include':
+      return getCompletionItems(
+        ['schemaLocation'],
+        '',
+        '',
+        nsPrefix,
+        '',
+        spacingChar,
+        afterChar
+      )
+    case 'import':
+      return getCompletionItems(
+        ['schemaLocation', 'namespace'],
+        '',
+        '',
+        nsPrefix,
+        '',
+        spacingChar,
+        afterChar
+      )
     case 'assert':
       return getCompletionItems(
         ['testKind', 'test', 'testPattern', 'message', 'failureType'],

--- a/src/language/providers/attributeValueCompletion.ts
+++ b/src/language/providers/attributeValueCompletion.ts
@@ -45,25 +45,19 @@ export function getAttributeValueCompletionProvider() {
           position
         )
 
-        if (attributeName !== 'none') {
+        if (attributeName !== 'none' && !attributeName.includes('xmlns:')) {
           let replaceValue = ''
           if (startPos === endPos) {
             replaceValue = ' '
           }
 
-          if (
-            attributeName.includes(':') &&
-            !attributeName.includes('xmlns:')
-          ) {
+          if (attributeName.includes(':')) {
             attributeName = attributeName.substring(
               attributeName.indexOf(':') + 1
             )
           }
 
-          if (
-            noChoiceAttributes.includes(attributeName) ||
-            attributeName.includes('xmlns:')
-          ) {
+          if (noChoiceAttributes.includes(attributeName)) {
             return undefined
           }
 

--- a/src/language/providers/closeElement.ts
+++ b/src/language/providers/closeElement.ts
@@ -27,6 +27,7 @@ import {
   getXsdNsPrefix,
   insertSnippet,
   isInXPath,
+  isNotTriggerChar,
   getItemsOnLineCount,
   getItemPrefix,
 } from './utils'
@@ -39,12 +40,14 @@ export function getCloseElementProvider() {
         document: vscode.TextDocument,
         position: vscode.Position
       ) {
+        let triggerChar = '>'
         if (
           checkBraceOpen(document, position) ||
           cursorWithinBraces(document, position) ||
           cursorWithinQuotes(document, position) ||
           cursorAfterEquals(document, position) ||
-          isInXPath(document, position)
+          isInXPath(document, position) ||
+          isNotTriggerChar(document, position, triggerChar)
         ) {
           return undefined
         }
@@ -184,7 +187,7 @@ export function getTDMLCloseElementProvider() {
             backpos3
           )
         }
-        return undefined
+        //return undefined
       },
     },
     '>' // triggered whenever a '>' is typed
@@ -202,7 +205,11 @@ function checkItemsOnLine(
   backpos: vscode.Position,
   backpos3: vscode.Position
 ) {
-  if (itemsOnLine == 0 && !triggerText.includes('</')) {
+  if (
+    itemsOnLine == 0 &&
+    !triggerText.includes('</') &&
+    !triggerText.includes('/>')
+  ) {
     if (triggerText.trim() === '>') {
       insertSnippet('</' + nsPrefix + nearestTagNotClosed + '>', backpos)
     } else {
@@ -237,7 +244,11 @@ function checkItemsOnLine(
     }
   }
 
-  if (itemsOnLine === 1 && !triggerText.includes('</')) {
+  if (
+    itemsOnLine === 1 &&
+    !triggerText.includes('</') &&
+    !triggerText.includes('/>')
+  ) {
     checkNearestTagNotClosed(
       document,
       position,

--- a/src/language/providers/closeUtils.ts
+++ b/src/language/providers/closeUtils.ts
@@ -336,6 +336,7 @@ export function getItemsForLineLT2(
             testLine = lineBefore
             while (!testText.includes('>')) {
               testText = document.lineAt(++testLine).text
+              if (testText.indexOf('<') > -1) [openTagArray.push(testLine)]
             }
           }
 

--- a/src/language/providers/intellisense/attributeHoverItems.ts
+++ b/src/language/providers/intellisense/attributeHoverItems.ts
@@ -225,6 +225,10 @@ export function attributeHoverValues(attributeName: string): string {
       return 'Defines text for use in an error message'
     case 'failureType':
       return 'Specifies the type of failure that occurs when the dfdl:assert is unsuccessful'
+    case 'schemaLocation':
+      return 'Specifies the location of the schema'
+    case 'namespace':
+      return 'User defined identifier for the namespace defined by schemaLocation value'
     default:
       return 'No definition available'
   }

--- a/src/language/providers/intellisense/attributeItems.ts
+++ b/src/language/providers/intellisense/attributeItems.ts
@@ -545,6 +545,16 @@ export const attributeCompletion = (
         snippetString: spacingChar + 'failureType="${1|processingError,recoverableError|}"$0' + afterChar,
         markdownString: 'Specifies the type of failure that occurs when the dfdl:assert is unsuccessful',
       },
+      {
+        item: 'schemaLocation',
+        snippetString: spacingChar + 'schemaLocation="$1"$0' + afterChar,
+        markdownString: 'Specifies the location of the schema'
+      },
+      {
+        item: 'namespace',
+        snippetString: spacingChar + 'namespace="$1"$0' + afterChar,
+        markdownString: 'User defined identifier for the imported schemaLocation'
+      }
     ],
   }
 }

--- a/src/language/providers/intellisense/attributeValueItems.ts
+++ b/src/language/providers/intellisense/attributeValueItems.ts
@@ -65,6 +65,7 @@ export const noChoiceAttributes = [
   'source',
   'schemaLocation',
   'targetNamespace',
+  'namespace',
 ]
 
 export function attributeValues(

--- a/src/language/providers/intellisense/elementItems.ts
+++ b/src/language/providers/intellisense/elementItems.ts
@@ -207,7 +207,7 @@ export const elementCompletion = (definedVariables, nsPrefix) => {
         markdownString: 'Used to restrict a datatype to a finite set of values'
       },
       {
-        item: 'include',
+        item: nsPrefix + 'include',
         snippetString: '<' + nsPrefix + 'include "$1"/>$0',
         markdownString: 'Used to add all the components of an included schema'
       },
@@ -216,7 +216,7 @@ export const elementCompletion = (definedVariables, nsPrefix) => {
         snippetString: '<' + nsPrefix + 'documentation>\n\t$1\n</documentation>$0'
       },
       {
-        item: 'import',
+        item: nsPrefix + 'import',
         snippetString: '<' + nsPrefix + 'import "$1"/>$0',
         markdownString: 'Used to add all the components of an included schema'
       },

--- a/src/tests/suite/language/items.test.ts
+++ b/src/tests/suite/language/items.test.ts
@@ -172,6 +172,8 @@ suite('Items Test Suite', () => {
     'testPattern',
     'message',
     'failureType',
+    'schemaLocation',
+    'namespace',
   ]
 
   test('all commonItems available', async () => {


### PR DESCRIPTION
without default values when typng a space or slash in the quoted text
Fixes a problem where typing a slash almost anywhere inserts '/>' a self closing tag
Prevents hover popups for non-attribute items
Fixes intellisense suggesting incorrect attributes for elements that spread across multiple lines

closes #1065