### PR TITLE
Update nightly tests to not run newer versions of VSCode on Windows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,13 +28,23 @@ jobs:
       matrix:
         os: [ macos-12, ubuntu-20.04, windows-2019, macos-latest, ubuntu-latest, windows-latest ]
         node: [ '16', '18.20.1' ] # version 18.20.2 (current latest of 18) is broken on windows
-        vscode: [ 'stable', 'insiders' ]
+        vscode: [ '1.91.1', 'stable', 'insiders' ]
         java_distribution: [ temurin ]
         java_version: [ 8, 11, 17 ]
         exclude:
           # java 8 not available on latest macos
           - os: macos-latest
             java_version: 8
+          # Currently newer versions of VSCode don't work the same on Windows, this will need looked into.
+          # TODO: Remove the below windows excludes once the extension tests are working with newer versions of VSCode
+          - os: windows-2019
+            vscode: 'stable'
+          - os: windows-2019
+            vscode: 'insiders'
+          - os: windows-latest
+            vscode: 'stable'
+          - os: windows-latest
+            vscode: 'insiders'
       fail-fast: false  # don't immediately fail all other jobs if a single job fails
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
Once https://github.com/apache/daffodil-vscode/issues/1101 is resolved the excludes for windows and the newer versions of VSCode can be removed.