### PR TITLE
Upgrade Ωedit to solve DE startup problem under Windows (#1117)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ on:
   push:
     branches-ignore: [ 'dependabot/**' ]
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   single-commit:
@@ -47,7 +47,7 @@ jobs:
         java_distribution: [ temurin ]
         java_version: [ 8 ]
         os: [ ubuntu-20.04 ]
-        node: [ '16' ]
+        node: [ '18' ]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -126,14 +126,14 @@ jobs:
         run: $SBT ratCheck || (cat target/rat.txt; exit 1)
 
   build-test-package:
-    name: 'Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, Java: ${{ matrix.java_version }})'
+    name: 'Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, Java: ${{ matrix.java_version }}, VS Code: ${{ matrix.vscode }})'
     strategy:
       matrix:
         java_distribution: [ temurin ]
         java_version: [ 8, 11, 17 ]
         os: [ macos-12, ubuntu-20.04, windows-2019 ]
-        node: [ '16', '18.20.1' ] # version 18.20.2 (current latest of 18) is broken on windows
-        vscode: [ '1.91.1' ]
+        node: [ '18.20.1' ]
+        vscode: [ '1.82.0', 'stable' ] # v1.82.0 is the first version of VSCode to use Node 18
       fail-fast: false  # don't immediately fail all other jobs if a single job fails
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,12 +23,12 @@ on:
 
 jobs:
   build-test-package:
-    name: 'Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, Java: ${{ matrix.java_version }}, VS Code: ${{ matrix.vscode }} )'
+    name: 'Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, Java: ${{ matrix.java_version }}, VS Code: ${{ matrix.vscode }})'
     strategy:
       matrix:
         os: [ macos-12, ubuntu-20.04, windows-2019, macos-latest, ubuntu-latest, windows-latest ]
-        node: [ '16', '18.20.1' ] # version 18.20.2 (current latest of 18) is broken on windows
-        vscode: [ '1.91.1', 'stable', 'insiders' ]
+        node: [ '18.20.1' ]
+        vscode: [ '1.82.0', 'stable', 'insiders' ] # v1.82.0 is the first version of VSCode to use Node 18
         java_distribution: [ temurin ]
         java_version: [ 8, 11, 17 ]
         exclude:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "svelte:check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@omega-edit/client": "0.9.82",
+    "@omega-edit/client": "0.9.83",
     "@viperproject/locate-java-home": "1.1.15",
     "@vscode/debugadapter": "1.63.0",
     "@vscode/webview-ui-toolkit": "^1.2.2",


### PR DESCRIPTION
Also replace node 16 with node 20 in CI.

Fixes #1117.

Need to upgrade from Node 16 to 18 to work in Electron 30.  The spawn call in Node requires that the shell be used for Windows scripts like we're using to start the Ωedit service.  That was fixed in Ωedit v0.9.83, which now needs node 18+.

References:
https://github.com/ctc-oss/omega-edit/commit/70e71dd48bb88b528b22c9ca209856a2561892b0 
https://code.visualstudio.com/updates/v1_92#_electron-30-update
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high
https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
