### PR TITLE
Remove excludes for windows and vscode versions.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -155,9 +155,9 @@ jobs:
           distribution: ${{ matrix.java_distribution }}
           java-version: ${{ matrix.java_version }}
       
-      - name: Install sbt - macos-13 only
-        run: brew install sbt
-        if: matrix.os == 'macos-13'
+      # some runner oses don't have sbt by default
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v4.1.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,16 +35,6 @@ jobs:
           # java 8 not available on latest macos
           - os: macos-latest
             java_version: 8
-          # Currently newer versions of VSCode don't work the same on Windows, this will need looked into.
-          # TODO: Remove the below windows excludes once the extension tests are working with newer versions of VSCode
-          - os: windows-2019
-            vscode: 'stable'
-          - os: windows-2019
-            vscode: 'insiders'
-          - os: windows-latest
-            vscode: 'stable'
-          - os: windows-latest
-            vscode: 'insiders'
       fail-fast: false  # don't immediately fail all other jobs if a single job fails
     runs-on: ${{ matrix.os }}
     defaults:
@@ -71,10 +61,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # macos-13 & macos-latest doesn't seem to have sbt installed by default
-      - name: Install sbt - macos-latest
-        run: brew install sbt
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'
+      # some runner oses don't have sbt by default
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       ############################################################
       # Build & Package


### PR DESCRIPTION
Remove excludes for windows and vscode versions.

- Newer versions of VSCode seem to work okay now on regular CI so adding it back into nightly
- Add sbt setup step to CI files to ensure all runners will have sbt installed.

Closes #1101