### PR TITLE
Output TDML errors via vscode pop-up

### DIFF
--- a/src/tdmlEditor/utilities/tdmlXmlUtils.ts
+++ b/src/tdmlEditor/utilities/tdmlXmlUtils.ts
@@ -19,6 +19,7 @@ import { readFileSync, writeFileSync } from 'fs'
 import os from 'os'
 import { join, resolve, sep, relative, dirname } from 'path'
 import { Element, ElementCompact, js2xml, xml2js } from 'xml-js'
+import * as vscode from 'vscode'
 
 /*
  * Note that the functions in this file assumes the structure of a TDML file
@@ -290,10 +291,16 @@ export async function copyTestCase(
   )
 
   if (sourceTestSuite === undefined) {
+    vscode.window.showErrorMessage(
+      'TDML ERROR: No test suite found in source XML buffer'
+    )
     throw `No test suite found in source XML buffer`
   }
 
   if (sourceTestSuite.length !== 1) {
+    vscode.window.showErrorMessage(
+      'TDML ERROR: More than one test suite found in source XML buffer'
+    )
     throw `More than one test suite found in source XML buffer`
   }
 
@@ -302,10 +309,16 @@ export async function copyTestCase(
   )
 
   if (sourceTestCase === undefined) {
+    vscode.window.showErrorMessage(
+      'TDML ERROR: No test case found in source XML buffer'
+    )
     throw `No test case found in source XML buffer`
   }
 
   if (sourceTestCase.length !== 1) {
+    vscode.window.showErrorMessage(
+      'TDML ERROR: More than one test case found in source XML buffer'
+    )
     throw `More than one test case found in source XML buffer`
   }
 
@@ -379,10 +392,16 @@ export async function copyTestCase(
     )
 
     if (destinationTestSuite === undefined) {
+      vscode.window.showErrorMessage(
+        'TDML ERROR: No test suites found in destination XML buffer'
+      )
       throw `No test suites found in destination XML buffer`
     }
 
     if (destinationTestSuite.length !== 1) {
+      vscode.window.showErrorMessage(
+        'TDML ERROR: More than one test suite found in destination XML buffer'
+      )
       throw `More than one test suite found in destination XML buffer`
     }
 
@@ -398,6 +417,9 @@ export async function copyTestCase(
         testCase.attributes[testCaseNameAttribute] ===
           sourceTestCase[0].attributes[testCaseNameAttribute]
       ) {
+        vscode.window.showErrorMessage(
+          'TDML ERROR: Duplicate Test Case Name Found'
+        )
         throw `Duplicate Test Case Name Found`
       }
     })


### PR DESCRIPTION
This fixes "No Error message or user notification for Duplicate append test case to TDML file #1028" by calling vscode.window.showErrorMessage(...) which creates a small pop-up window in the lower right corner of the VSCode window.