### PR TITLE
Add root element and namespace auto suggestions

### DIFF
--- a/build/package/LICENSE
+++ b/build/package/LICENSE
@@ -569,6 +569,32 @@ conditions of the following licenses.
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 
+- 'fast-xml-parser' in extension/dist/ext/extension.js
+  This product bundles the 'fast-xml-parser' from the above files.
+  This package is available under the MIT License:
+
+    MIT License
+
+    Copyright (c) 2017 Amit Kumar Gupta
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
 - 'fsevents' in extension/dist/ext/extension.js
   This product bundles 'fsevents' from the above files.
   This package is available under the MIT License:
@@ -1407,6 +1433,32 @@ conditions of the following licenses.
     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
     
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+- 'strnum' in extension/dist/ext/extension.js
+  This product bundles 'strnum' from the above files.
+  This package is available under the MIT LICENSE:
+
+    MIT License
+
+    Copyright (c) 2021 Natural Intelligence
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 
 - 'supports-color' in extension/dist/ext/extension.js
 - 'supports-color' in node_modules/@omega-edit/client

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "css-loader": "^6.8.1",
     "css-minimizer-webpack-plugin": "^7.0.0",
     "esbuild": "^0.25.0",
+    "fast-xml-parser": "^4.5.2",
     "glob": "8.1.0",
     "mini-css-extract-plugin": "^2.7.6",
     "mocha": "10.2.0",

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -14,6 +14,8 @@ import * as dfdlLang from 'language/dfdl'
 import * as dfdlExt from 'language/semantics/dfdlExt'
 import * as dataEditClient from 'dataEditor'
 import * as tdmlEditor from 'tdmlEditor'
+import * as rootCompletion from 'rootCompletion'
+
 import {
   CancellationToken,
   DebugConfiguration,
@@ -553,6 +555,7 @@ export function activateDaffodilDebug(
   dataEditClient.activate(context)
   launchWizard.activate(context)
   tdmlEditor.activate(context)
+  rootCompletion.activate(context)
 }
 
 class DaffodilConfigurationProvider

--- a/src/rootCompletion/index.ts
+++ b/src/rootCompletion/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode'
+import { getCompletionProviders } from './utils'
+
+export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    ...getCompletionProviders('rootName'),
+    ...getCompletionProviders('rootNamespace')
+  )
+}

--- a/src/rootCompletion/utils.ts
+++ b/src/rootCompletion/utils.ts
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from 'fs'
+import * as vscode from 'vscode'
+import { XMLParser } from 'fast-xml-parser'
+
+// Method to create simple completion item given provided value and position
+export function getSimpleCompletionItem(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  value: string
+): vscode.CompletionItem {
+  let item = new vscode.CompletionItem(
+    `${value}`,
+    vscode.CompletionItemKind.Value
+  )
+  const text = item.label.toString()
+
+  const before =
+    position.character > 0
+      ? document.getText(new vscode.Range(position.translate(0, -1), position))
+      : ''
+  const after = document.getText(
+    new vscode.Range(position, position.translate(0, 1))
+  )
+
+  // Check if already wrapped in quotes
+  const alreadyWrapped = before === '"' && after === '"'
+
+  // If not wrapped in quotes add double quotes to before and after text
+  item.insertText = !alreadyWrapped ? `"${text}"` : text
+
+  item.range = new vscode.Range(position, position)
+  return item
+}
+
+/* Method to get previous lines based on i.
+ *
+ * The reason for going 4 lines back is because the schema object only has
+ * 3 sub properties. So, this mean the schema object should technically
+ * not be anymore than 3 or 4 lines back from where the path attribute is set.
+ */
+function getPrevLines(
+  document: vscode.TextDocument,
+  i: number
+): vscode.TextLine[] {
+  let prevLines: vscode.TextLine[] = []
+
+  for (var j = 0; j < 4; j++) {
+    if (i > j) {
+      prevLines.push(document.lineAt(i - (j + 1)))
+    }
+  }
+
+  return prevLines
+}
+
+/* Method to get the schema path from the configuration file being edited.
+ *
+ * The reason for going 4 lines back is because the schema object only has
+ * 3 sub properties. So, this mean the schema object should technically
+ * not be anymore than 3 or 4 lines back from where the path attribute is set.
+ */
+export function getSchemaPathFromLaunchJSON(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): string {
+  let schemaPath = ''
+
+  for (var i = position.line - 4; i < position.line; i++) {
+    if (i <= 0) continue
+
+    let currLine = document.lineAt(i)
+    if (!currLine.text.includes('path')) continue
+
+    const prevLines = getPrevLines(document, i)
+
+    let isUnderSchema =
+      prevLines
+        .map((prevLines) => prevLines.text.includes('schema'))
+        .filter((b) => b == true).length > 0
+
+    if (isUnderSchema) {
+      const regex = /(["'])path\1\s*:\s*(["'])(.*?)\2/
+      const match = currLine.text.match(regex)
+
+      schemaPath = match ? JSON.parse(`{${match[0]}}`).path : ''
+    }
+  }
+
+  return schemaPath.includes('${workspaceFolder}') &&
+    vscode.workspace.workspaceFolders
+    ? schemaPath.replace(
+        '${workspaceFolder}',
+        vscode.workspace.workspaceFolders[0].uri.fsPath
+      )
+    : schemaPath
+}
+
+// Method to get the possible items
+export function getPossibleItems(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  findRootNamespace: boolean
+): string[] {
+  const schemaPath = getSchemaPathFromLaunchJSON(document, position)
+
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    removeNSPrefix: true,
+    isArray: (name) => name == 'element',
+  })
+
+  const fileData = schemaPath === '' ? '' : fs.readFileSync(schemaPath)
+  if (fileData === '') return []
+
+  const obj = parser.parse(fileData)
+
+  if (obj && typeof obj === 'object') {
+    return findRootNamespace
+      ? [obj['schema']['@_targetNamespace']]
+      : obj['schema']['element'].map((e) => e['@_name'])
+  }
+
+  return []
+}
+
+export function checkForItems(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+  includeText: string
+): vscode.CompletionItem[] {
+  if (
+    !document.fileName.includes('launch.json') ||
+    !document.lineAt(position).text.includes(`"${includeText}"`)
+  )
+    return []
+
+  const possibleItems: string[] = getPossibleItems(
+    document,
+    position,
+    includeText.includes('rootNamespace')
+  )
+
+  return possibleItems.map((prn) =>
+    getSimpleCompletionItem(document, position, prn)
+  )
+}
+
+export function getCompletionProviders(includeText: string) {
+  return [
+    vscode.languages.registerCompletionItemProvider(
+      { language: 'jsonc' },
+      {
+        provideCompletionItems(
+          document: vscode.TextDocument,
+          position: vscode.Position
+        ) {
+          return checkForItems(document, position, includeText)
+        },
+      },
+      '"' // trigger
+    ),
+    vscode.languages.registerCompletionItemProvider(
+      { language: 'json' },
+      {
+        provideCompletionItems(
+          document: vscode.TextDocument,
+          position: vscode.Position
+        ) {
+          return checkForItems(document, position, includeText)
+        },
+      },
+      '"' // trigger
+    ),
+  ]
+}

--- a/webpack/ext-dev.webpack.config.js
+++ b/webpack/ext-dev.webpack.config.js
@@ -23,6 +23,7 @@ const localModuleAliases = {
   language: localModulePath('language'),
   launchWizard: localModulePath('launchWizard/launchWizard'),
   infoset: localModulePath('infoset'),
+  rootCompletion: localModulePath('rootCompletion'),
 }
 
 const packageData = jsoncParse(

--- a/webpack/ext-package.webpack.config.js
+++ b/webpack/ext-package.webpack.config.js
@@ -38,6 +38,7 @@ const localModuleAliases = {
   language: localModulePath('language'),
   launchWizard: localModulePath('launchWizard/launchWizard'),
   infoset: localModulePath('infoset'),
+  rootCompletion: localModulePath('rootCompletion'),
 }
 
 const packageData = jsoncParse(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,6 +2087,13 @@ fast-redact@^3.1.1:
   resolved "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz"
   integrity sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==
 
+fast-xml-parser@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.2.tgz#f535f77b1396b859498203a2fd1994c4230a0ff9"
+  integrity sha512-xmnYV9o0StIz/0ArdzmWTxn9oDy0lH8Z80/8X/TD2EUQKXY4DHxoT9mYBqgGIG17DgddCJtH1M6DriMbalNsAA==
+  dependencies:
+    strnum "^1.0.5"
+
 fastest-levenshtein@^1.0.12:
   version "1.0.16"
   resolved "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz"
@@ -4279,6 +4286,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 stylehacks@^7.0.4:
   version "7.0.4"


### PR DESCRIPTION
Add root element and namespace auto suggestions

- Create completion providers needed to show root element and namespace suggestions when inside a launch.json file.
- Create methods to parse the schema path from the launch.json and read in the XML.
- Parse the schema XML to get the possible root elements and namespace.
  - Root elements were limited to element's that were direct children of the schema.
- Add fast-xml-parser and strnum to LICENSE file

Closes https://github.com/apache/daffodil-vscode/issues/984