### PR TITLE
Added retainContextWhenHidden settings to fix the launch config reset…

### DIFF
--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -29,6 +29,11 @@ const defaultConf = getConfig({
   name: 'Wizard Config',
   request: 'launch',
   type: 'dfdl',
+  schema: {
+    path: '${command:AskForSchemaName}',
+    rootName: 'null',
+    rootNamespace: 'null',
+  },
 })
 
 // Function that will activate/open the launch config wizard
@@ -356,7 +361,13 @@ class LaunchWizard {
         'launchWizard',
         'Launch Config Wizard',
         vscode.ViewColumn.Active,
-        this.getWebViewOptions(this.extensionUri)
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+          localResourceRoots: [
+            vscode.Uri.parse(this.ctx.asAbsolutePath('./src/launchWizard')),
+          ],
+        }
       )
 
       this.panel.onDidDispose(

--- a/src/launchWizard/script.js
+++ b/src/launchWizard/script.js
@@ -392,8 +392,8 @@ function copyConfig() {
 async function updateConfigValues(config) {
   document.getElementById('name').value = config.name
   document.getElementById('data').value = config.data
-  document.getElementById('rootName').value = config.rootName
-  document.getElementById('rootNamespace').value = config.rootNamespace
+  document.getElementById('rootName').value = config.schema.rootName
+  document.getElementById('rootNamespace').value = config.schema.rootNamespace
   document.getElementById('debugServer').value = parseInt(config.debugServer)
   document.getElementById('infosetFormat').value = config.infosetFormat
     ? config.infosetFormat
@@ -428,7 +428,7 @@ async function updateConfigValues(config) {
   document.getElementById('openInfosetDiffView').checked =
     config.openInfosetDiffView
   document.getElementById('openInfosetView').checked = config.openInfosetView
-  document.getElementById('schema').value = config.schema
+  document.getElementById('schema').value = config.schema.path
   document.getElementById('stopOnEntry').checked = config.stopOnEntry
   document.getElementById('trace').checked = config.trace
   document.getElementById('useExistingServer').checked =
@@ -442,9 +442,9 @@ async function updateConfigValues(config) {
     config.dataEditor.logging.level
 
   document.getElementById('dfdlDebuggerLogFile').value =
-    config.dfdlDebugger.file
+    config.dfdlDebugger.logging.file
   document.getElementById('dfdlDebuggerLogLevel').value =
-    config.dfdlDebugger.level
+    config.dfdlDebugger.logging.level
 
   updateInfosetOutputType()
   updateTDMLAction()


### PR DESCRIPTION
closing #1009 
closing #1182 

updated LaunchWizard to fix Switching to another doc and back from Launch Config Wizard resets the form. Now it retains the changes made to the launch config wizard when you switch active tabs.

Updated default values for following fields when creating new config from the config wizard.
- Absolute path to the DFDL schema file
- Name of the root element
- Namespace of the root element
- Daffodil Debugger Settings - Log File
- Daffodil Debugger Settings - Log Level



**Testing Steps to test #1009** 

- Modified some forms on the Launch Config wizard (changed port debug server and check/unchecked check boxes)
- Clicked on jeg.dfdl.xsd
- Clicked back on Launch Config Wizard and the modified values are there.

**Testing Steps to test #1182** 

- Create new configuration by selecting 'New Config' from Launch Config option
- Verify that following values are loaded by default
- Run debug flow normally by selecting new launch config

![image](https://github.com/user-attachments/assets/d1f252ce-b3bf-48f8-b8a7-a26545870428)



