### PR TITLE
Fix to remove dfdl prefix for dfdl attributes if the element containi…

### DIFF
--- a/src/language/providers/attributeCompletion.ts
+++ b/src/language/providers/attributeCompletion.ts
@@ -18,13 +18,14 @@
 import * as vscode from 'vscode'
 
 import {
+  XmlItem,
+  getSchemaNsPrefix,
   nearestOpen,
   checkBraceOpen,
   isInXPath,
   lineCount,
   createCompletionItem,
   getCommonItems,
-  getXsdNsPrefix,
   getItemsOnLineCount,
   cursorWithinQuotes,
   cursorWithinBraces,
@@ -79,10 +80,15 @@ export function getAttributeCompletionProvider() {
           .text.substring(0, position.character)
         const charBeforeTrigger = triggerText.charAt(position.character - 1)
         const charAfterTrigger = triggerText.charAt(position.character)
-        let nearestOpenItem = nearestOpen(document, position)
+        let xmlItem = new XmlItem()
+        xmlItem = nearestOpen(document, position)
+        let nearestOpenItem = xmlItem.itemName
         let itemsOnLine = getItemsOnLineCount(triggerText)
-        const nsPrefix = getXsdNsPrefix(document, position)
-        let additionalItems = getDefinedTypes(document, nsPrefix)
+        const nsPrefix = xmlItem.itemNS
+        let additionalItems = getDefinedTypes(
+          document,
+          getSchemaNsPrefix(document)
+        )
 
         if (isInXPath(document, position)) return undefined
 
@@ -131,9 +137,11 @@ export function getTDMLAttributeCompletionProvider() {
           .text.substring(0, position.character)
         const charBeforeTrigger = triggerText.charAt(position.character - 1)
         const charAfterTrigger = triggerText.charAt(position.character)
-        let nearestOpenItem = nearestOpen(document, position)
+        let xmlItem = new XmlItem()
+        xmlItem = nearestOpen(document, position)
+        let nearestOpenItem = xmlItem.itemName
         let itemsOnLine = getItemsOnLineCount(triggerText)
-        const nsPrefix = getXsdNsPrefix(document, position)
+        const nsPrefix = xmlItem.itemNS
         let additionalItems = getDefinedTypes(document, nsPrefix)
 
         if (isInXPath(document, position)) return undefined
@@ -221,6 +229,10 @@ function checkNearestOpenItem(
     charAfterTrigger !== '\t'
       ? ' '
       : ''
+  let dfdlPrefix = dfdlDefaultPrefix
+  if (nsPrefix === 'dfdl:') {
+    dfdlPrefix = ''
+  }
   switch (nearestOpenItem) {
     case 'element':
       return getCompletionItems(
@@ -256,7 +268,7 @@ function checkNearestOpenItem(
         preVal,
         additionalItems,
         nsPrefix,
-        dfdlDefaultPrefix,
+        dfdlPrefix,
         spacingChar,
         afterChar
       )
@@ -272,7 +284,7 @@ function checkNearestOpenItem(
         preVal,
         '',
         nsPrefix,
-        dfdlDefaultPrefix,
+        dfdlPrefix,
         spacingChar,
         afterChar
       )
@@ -288,7 +300,7 @@ function checkNearestOpenItem(
         '',
         '',
         nsPrefix,
-        dfdlDefaultPrefix,
+        dfdlPrefix,
         spacingChar,
         afterChar
       )
@@ -304,7 +316,7 @@ function checkNearestOpenItem(
         '',
         '',
         nsPrefix,
-        dfdlDefaultPrefix,
+        dfdlPrefix,
         spacingChar,
         afterChar
       )
@@ -322,7 +334,7 @@ function checkNearestOpenItem(
         '',
         '',
         nsPrefix,
-        dfdlDefaultPrefix,
+        dfdlPrefix,
         spacingChar,
         afterChar
       )

--- a/src/language/providers/attributeHover.ts
+++ b/src/language/providers/attributeHover.ts
@@ -30,14 +30,20 @@ export function getAttributeHoverProvider() {
       const word = document.getText(range)
 
       let itemNames: string[] = []
-      attributeCompletion('', '', 'dfdl:', '', '').items.forEach((r) =>
+      attributeCompletion('', '', 'dfdl', '', '').items.forEach((r) =>
         itemNames.push(r.item)
       )
+      let testWord = ''
       if (word.length > 0) {
-        if (itemNames.includes(word)) {
+        if (!word.includes('dfdl:')) {
+          testWord = 'dfdl:' + word
+        } else {
+          testWord = word
+        }
+        if (itemNames.includes(testWord)) {
           return new vscode.Hover({
             language: 'dfdl',
-            value: attributeHoverValues(word),
+            value: attributeHoverValues(testWord),
           })
         }
       }

--- a/src/language/providers/attributeValueCompletion.ts
+++ b/src/language/providers/attributeValueCompletion.ts
@@ -17,7 +17,7 @@
 
 import * as vscode from 'vscode'
 
-import { checkBraceOpen, cursorWithinBraces, getXsdNsPrefix } from './utils'
+import { checkBraceOpen, cursorWithinBraces, getNsPrefix } from './utils'
 import { getDefinedTypes } from './attributeCompletion'
 import {
   attributeValues,
@@ -38,7 +38,8 @@ export function getAttributeValueCompletionProvider() {
         ) {
           return undefined
         }
-        const nsPrefix = getXsdNsPrefix(document, position)
+        const schemaPosition = new vscode.Position(0, 0)
+        const nsPrefix = getNsPrefix(document, schemaPosition)
         let additionalItems = getDefinedTypes(document, nsPrefix)
         let [attributeName, startPos, endPos] = getAttributeDetails(
           document,
@@ -93,7 +94,7 @@ export function getTDMLAttributeValueCompletionProvider() {
         ) {
           return undefined
         }
-        const nsPrefix = getXsdNsPrefix(document, position)
+        const nsPrefix = getNsPrefix(document, position)
         let additionalItems = getDefinedTypes(document, nsPrefix)
         let [attributeName, startPos, endPos] = getAttributeDetails(
           document,

--- a/src/language/providers/closeElement.ts
+++ b/src/language/providers/closeElement.ts
@@ -24,7 +24,7 @@ import {
   cursorWithinQuotes,
 } from './utils'
 import {
-  getXsdNsPrefix,
+  getNsPrefix,
   insertSnippet,
   isInXPath,
   isNotTriggerChar,
@@ -63,7 +63,7 @@ export function getCloseElementProvider() {
           backpos3 = position.with(position.line, position.character - 3)
         }
 
-        let nsPrefix = getXsdNsPrefix(document, position)
+        let nsPrefix = getNsPrefix(document, position)
         const origPrefix = nsPrefix
 
         const nearestTagNotClosed = checkMissingCloseTag(
@@ -143,7 +143,7 @@ export function getTDMLCloseElementProvider() {
           backpos3 = position.with(position.line, position.character - 3)
         }
 
-        let nsPrefix = getXsdNsPrefix(document, position)
+        let nsPrefix = getNsPrefix(document, position)
         const origPrefix = nsPrefix
 
         const nearestTagNotClosed = checkMissingCloseTag(

--- a/src/language/providers/closeElementSlash.ts
+++ b/src/language/providers/closeElementSlash.ts
@@ -22,7 +22,7 @@ import {
   checkBraceOpen,
   isInXPath,
   isNotTriggerChar,
-  getXsdNsPrefix,
+  getNsPrefix,
   getItemPrefix,
   getItemsOnLineCount,
   cursorWithinBraces,
@@ -38,8 +38,8 @@ export function getCloseElementSlashProvider() {
         document: vscode.TextDocument,
         position: vscode.Position
       ) {
-        let backpos = position.with(position.line, position.character - 1)
-        const nsPrefix = getXsdNsPrefix(document, position)
+        let backpos = new vscode.Position(position.line, position.character - 1)
+        const nsPrefix = getNsPrefix(document, position)
         const triggerText = document
           .lineAt(position)
           .text.substring(0, position.character)
@@ -98,7 +98,7 @@ export function getTDMLCloseElementSlashProvider() {
         position: vscode.Position
       ) {
         let backpos = position.with(position.line, position.character - 1)
-        const nsPrefix = getXsdNsPrefix(document, position)
+        const nsPrefix = getNsPrefix(document, position)
         const triggerText = document
           .lineAt(position)
           .text.substring(0, position.character)
@@ -154,11 +154,6 @@ function checkItemsOnLine(
     !(nearestTagNotClosed == 'none') &&
     (itemsOnLine == 1 || itemsOnLine == 0)
   ) {
-    // let range = new vscode.Range(backpos, position)
-
-    // await vscode.window.activeTextEditor?.edit((editBuilder) => {
-    //   editBuilder.replace(range, '')
-    // })
     if (
       nearestTagNotClosed.includes('defineVariable') ||
       nearestTagNotClosed.includes('setVariable')
@@ -176,10 +171,6 @@ function checkItemsOnLine(
     ) {
       let tagPos = triggerText.lastIndexOf('<' + nsPrefix + nearestTagNotClosed)
       let tagEndPos = triggerText.indexOf('>', tagPos)
-      // let range = new vscode.Range(backpos, position)
-      // await vscode.window.activeTextEditor?.edit((editBuilder) => {
-      //   editBuilder.replace(range, '')
-      // })
 
       if (
         tagPos != -1 &&

--- a/src/language/providers/closeUtils.ts
+++ b/src/language/providers/closeUtils.ts
@@ -45,7 +45,7 @@ export function checkMissingCloseTag(
           i
         )
 
-        if (gt1res != undefined) {
+        if (gt1res != 'none') {
           return gt1res
         }
       }
@@ -248,7 +248,7 @@ export function getItemsForLineGT1(
 ) {
   let openTagArray: number[] = []
   let closeTagArray: number[] = []
-  let [nextCloseCharPos, nextOpenTagPos] = [0, 0, 0]
+  let [nextCloseCharPos, nextOpenTagPos] = [0, 0]
 
   while (
     (nextOpenTagPos = triggerText.indexOf(
@@ -336,7 +336,8 @@ export function getItemsForLineLT2(
             testLine = lineBefore
             while (!testText.includes('>')) {
               testText = document.lineAt(++testLine).text
-              if (testText.indexOf('<') > -1) [openTagArray.push(testLine)]
+              if (testText.indexOf('<' + nsPrefix + items[i]) > -1)
+                openTagArray.push(testLine)
             }
           }
 

--- a/src/language/providers/elementCompletion.ts
+++ b/src/language/providers/elementCompletion.ts
@@ -18,8 +18,9 @@
 import * as vscode from 'vscode'
 import { checkMissingCloseTag, getCloseTag } from './closeUtils'
 import {
+  XmlItem,
   checkBraceOpen,
-  getXsdNsPrefix,
+  getNsPrefix,
   isInXPath,
   isTagEndTrigger,
   nearestOpen,
@@ -43,19 +44,23 @@ export function getElementCompletionProvider(dfdlFormatString: string) {
         token: vscode.CancellationToken,
         context: vscode.CompletionContext
       ) {
+        const triggerChar = context.triggerCharacter
         if (
           !checkBraceOpen(document, position) &&
           !cursorWithinBraces(document, position) &&
           !cursorWithinQuotes(document, position) &&
           !cursorAfterEquals(document, position) &&
           !isInXPath(document, position) &&
-          !isTagEndTrigger(document, position)
+          !isTagEndTrigger(triggerChar)
         ) {
-          let nsPrefix = getXsdNsPrefix(document, position)
+          let nsPrefix = getNsPrefix(document, position)
           let [triggerLine, triggerPos] = [position.line, position.character]
           let triggerText = document.lineAt(triggerLine).text
           let itemsOnLine = getItemsOnLineCount(triggerText)
           let nearestOpenItem = nearestOpen(document, position)
+          if (nearestOpenItem.itemNS != 'none') {
+            nsPrefix = nearestOpenItem.itemNS
+          }
           let lastCloseSymbol = triggerText.lastIndexOf('>')
           let firstOpenSymbol = triggerText.indexOf('<')
 
@@ -65,7 +70,10 @@ export function getElementCompletionProvider(dfdlFormatString: string) {
             nsPrefix
           )
 
-          if (!nearestOpenItem.includes('none') && missingCloseTag == 'none') {
+          if (
+            !nearestOpenItem.itemName.includes('none') &&
+            missingCloseTag == 'none'
+          ) {
             return undefined
           }
           if (
@@ -122,11 +130,13 @@ export function getTDMLElementCompletionProvider(tdmlFormatString: string) {
         return undefined
       }
 
-      let nsPrefix = getXsdNsPrefix(document, position)
+      let nsPrefix = getNsPrefix(document, position)
       let [triggerLine, triggerPos] = [position.line, position.character]
       let triggerText = document.lineAt(triggerLine).text
       let itemsOnLine = getItemsOnLineCount(triggerText)
-      let nearestOpenItem = nearestOpen(document, position)
+      let xmlItem = new XmlItem()
+      xmlItem = nearestOpen(document, position)
+      let nearestOpenItem = xmlItem.itemName
       let lastCloseSymbol = triggerText.lastIndexOf('>')
       let firstOpenSymbol = triggerText.indexOf('<')
 

--- a/src/language/providers/intellisense/elementItems.ts
+++ b/src/language/providers/intellisense/elementItems.ts
@@ -49,17 +49,17 @@ export const elementCompletion = (definedVariables, nsPrefix) => {
       },
       {
         item: 'dfdl:assert',
-        snippetString: '<dfdl:assert $0',
+        snippetString: '<' + nsPrefix + 'assert $0',
         markdownString: 'Used to assert truths about a DFDL model',
       },
       {
         item: 'dfdl:discriminator',
-        snippetString: '<dfdl:discriminator $0',
+        snippetString: '<' + nsPrefix + 'discriminator $0',
         markdownString: 'Used during parsing to resolve points or uncertainity, remove ambiguity during speculative parsing, improve diagnostic behavior',
       },
       {
         item: 'dfdl:format',
-        snippetString: '<dfdl:format $0',
+        snippetString: '<' + nsPrefix + 'format $0',
         markdownString: 'Defines the physical data format properties for multiple DFDL schema constructs',
       },
       {
@@ -102,62 +102,62 @@ export const elementCompletion = (definedVariables, nsPrefix) => {
       },
       {
         item: 'dfdl:newVariableInstance',
-        snippetString: '<dfdl:newVariableInstance ref="$1"$0',
+        snippetString: '<' + nsPrefix + 'newVariableInstance ref="$1"$0',
         markdownString: 'Defines the name, type, and optional default value for the variable'
       },
       {
         item: 'dfdl:defineVariable',
-        snippetString: '<dfdl:defineVariable name="$1"$0',
+        snippetString: '<' + nsPrefix + 'defineVariable name="$1"$0',
         markdownString: 'Defines the name, type, and optionally default value for the variable.',
       },
       {
         item: 'dfdl:setVariable',
-        snippetString: '<dfdl:setVariable ref="${1|' + definedVariables + '"|}, value="$2"$0',
+        snippetString: '<' + nsPrefix + 'setVariable ref="${1|' + definedVariables + '"|}, value="$2"$0',
         markdownString: 'Sets the value of a variable whose declaration is in scope',
       },
       {
         item: 'dfdl:defineFormat',
-        snippetString: '<dfdl:defineFormat name="$1">\n\t$2\n</dfdl:defineFormat>$0',
+        snippetString: '<' + nsPrefix + 'defineFormat name="$1">\n\t$2\n</dfdl:defineFormat>$0',
         markdownString: 'Defines a named reusable format definition',
       },
       {
         item: 'dfdl:defineEscapeScheme',
-        snippetString: '<dfdl:defineEscapeScheme name=$1 >\n\t$0,/dfdl:defineEscapeScheme>',
+        snippetString: '<' + nsPrefix + 'defineEscapeScheme name=$1 >\n\t$0,/dfdl:defineEscapeScheme>',
         markdownString: 'Defines a named, reusable escapeScheme',
       },
       {
         item: 'dfdl:escapeScheme',
-        snippetString: '<dfdl:escapeScheme $0',
+        snippetString: '<' + nsPrefix + 'escapeScheme $0',
         markdownString: 'Allows a common set of properties to be defined that can be reused',
       },
       {
         item: 'dfdl:simpleType',
-        snippetString: '<dfdl:simpleType $1/>$0',
+        snippetString: '<' + nsPrefix + 'simpleType $1/>$0',
         markdownString: 'Defines the physical data format properties of an xs:simpleType',
       },
       {
         item: 'dfdl:element',
-        snippetString: '<dfdl:element $1/>$0',
+        snippetString: '<' + nsPrefix + 'element $1/>$0',
         markdownString: 'Defines the physical data format properties of an xs:element',
       },
       {
         item: 'dfdl:sequence',
-        snippetString: '<dfdl:sequence $1/>$0',
+        snippetString: '<' + nsPrefix + 'sequence $1/>$0',
         markdownString: 'Defines the physical data format properties of an xs:sequence group',
       },
       {
         item: 'dfdl:group',
-        snippetString: '<dfdl:group $1/>$0',
+        snippetString: '<' + nsPrefix + 'group $1/>$0',
         markdownString: 'Defines the physical data format properties of an xs:group reference',
       },
       {
         item: 'dfdl:choice',
-        snippetString: '<dfdl:choice $1/>$0',
+        snippetString: '<' + nsPrefix + 'choice $1/>$0',
         markdownString: 'Defines the physical data format properties of an xs:choice group',
       },
       {
         item: 'dfdl:property',
-        snippetString: '<dfdl:property name="$1">\n\t$2\n</dfdl:property>$0',
+        snippetString: '<' + nsPrefix + 'property name="$1">\n\t$2\n</dfdl:property>$0',
         markdownString: 'Used in the syntax of format annotations',
       },
       {

--- a/src/tests/DfdlIntellisenseTestingChecklist.md
+++ b/src/tests/DfdlIntellisenseTestingChecklist.md
@@ -1,0 +1,176 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# The following tests use the file: src/tests/data/testDfdlMixedLineFormats.dfdl.xsd
+
+Place the cursor at line 29 column 44, after alignmentUnits="bytes" press the backspace key until alignmentUnits="bytes" is erased. Type CTRL+space. Select dfdl:alignmentUnits from the dropdown and bytes from the value dropdown.
+
+- [ ] Verify that alignmentUnits="bytes" is inserted.
+- [ ] Verify that alignmentUnits does not have the dfdl: prefix.
+
+Place the cursor on line 46, column 28 at the end of the line <xs:group
+name = "test" >. Type a space.
+
+- [ ] Verify drop down contains xs:annotation and xs:sequence.
+
+Place the cursor at the same position as above. Type CTRL+space
+
+- [ ] Verify drop down contains xs:annotation and xs:sequence.
+
+Place the cursor at line 48, column 18 at the end of the line
+<xs:sequence>. Type a space or CTRL+space.
+
+- [ ] Verify dropdown contains xs:annotation, xs:choice, xs:element
+      name, xs:element ref, and xs:sequence.
+
+Place cursor at line 56, column 39 at the end of the line xs:element
+name="Keyword". Type a space.
+
+- [ ] Verify dropdown contains dfdl:alignment, dfdl:alignmentUnits,
+      dfdl:binaryBooleanFalseRep, dfdl:binaryBooleanTrueRep,
+      dfdl:binaryNumberRep, dfdl:bitOrder, dfdl:byteOrder,
+      dfdl:choiceBranchKey, dfdl:encoding, dfdl:inputValueCalc, dfdl:length,
+      dfdl:lengthKind, dfdl:lengthPattern, dfdl:lengthUnits, dfdl:occursCount,
+      dfdl:occursCountKind, dfdl:outputNewLine dfdl:outputValueCalc,
+      dfdl:prefxIncludesPrefixLength, dfdl:prefixLengthType,
+      dfdl:representation, dfdl:terminator, maxOccurs, minOccurs, name, ref,
+      and type.
+      Note: This isn't a comprehensive list of attributes, just the most commonly used attributes.
+
+- [ ] Verify dropdown appears with above listed elements, and the first
+      line in dropdown is highlighted with a description of the highlighted
+      item beside it.
+
+- [ ] Verify a dropdown appears with the above listed elements and
+      pressing the down arrow key displays the description of each highlighted
+      element.
+
+Place the cursor at line 57 and hover over the attribute dfdl:alignment.
+
+- [ ] Verify a text box appears with a definition for dfdl:alignment.
+
+Place the cursor at line 57 column 47, within the double quotes with the value 1 for dfdl:alignment.
+Type CTRL+space.
+
+- [ ] Verify the dropdown contains 1, 2, and implicit.
+
+Place the cursor at line 57 column 65, after dfdl:length="10". Type CTRL+space. Select dfdl:byteOrder from the dropdown and bigEndian for the value.
+
+- [ ] Verify that dfdl:byteOrder="bigEndian" is inserted and appropriately spaced.
+- [ ] Verify that the dfdl: prefix was inserted with byteOrder.
+
+Place cursor at line 67, column 26, after </xs:element>. Type a space.
+
+- [ ] Verify the dropdown contains xs:annotation, xs:choice, xs:element
+      name, xs:element ref, and xs:sequence.
+
+Place the cursor at line 68, column 42 after <xs:element
+name="Datastream". Type a space.
+
+- [ ] Verify the dropdown contains dfdl:alignment, dfdl:alignmentUnits,
+      dfdl:binaryBooleanFalseRep, dfdl:binaryBooleanTrueRep,
+      dfdl:binaryNumberRep, dfdl:bitOrder, dfdl:byteOrder,
+      dfdl:choiceBranchKey, dfdl:encoding, dfdl:inputValueCalc, dfdl:length,
+      dfdl:lengthKind, dfdl:lengthPattern, dfdl:lengthUnits, dfdl:occursCount,
+      dfdl:occursCountKind, dfdl:outputNewLine dfdl:outputValueCalc,
+      dfdl:prefxIncludesPrefixLength, dfdl:prefixLengthType,
+      dfdl:representation, dfdl:terminator, maxOccurs, minOccurs, name, ref,
+      and type.
+      Note: This isn't a comprehensive list of attributes, just the most commonly used attributes.
+
+Place the cursor at line 68 column 98, within the double quotes containing the value binary for dfdl:representation. Type CTRL+space.
+
+- [ ] Verify the dropdown contains binary an text. Select "text" as the value.
+- [ ] verify that "binary" is replaced with "text".
+
+Place the cursor at line 68 column 252 at the end of the line. Backspace over the last 2 characters "/>". The cursor shoul;d be directly after dfdl:length="{../../Length - fn:string-length(../Keyword) - 2}". Type a / (slash '/').
+
+- [ ] Verify that the self closing tag "/> was added to the end of the line.
+
+Place cursor at line 69, column 25, before </xs:sequence>. Type CTRL+space.
+
+- [ ] Verify the dropdown contains xs:choice, xs:group name, dfdl:group ref, and xs:sequence.
+
+Place a cursor at line 71 column 20, after </xs:element>. Backspace until the closing element tag is erased. Type > (the greater than symbol).
+
+- [ ] Verify the </xs:element> tag is replaced.
+
+Place the cursor at line 73 column 129, before <xs:annotation>. Type CTRL+space.
+
+- [ ] Verify the dropdown contains xs:annotation, xs:complexType, xs:complexType name=,xs:simpleType, and xs:simpleType name=.
+
+Place the cursor at line 73 column 263, after </xs:annotation>. Backspace to remove the annoation closing tag. With your cursor just after the </xs:appinfo> tag, type > (the greater than symbol).
+
+- [ ] Verify the closing tag for annotation is re-created in the proper place.
+
+DO NOT save any changes to the test file.
+
+# The following test use the file: src/test/data/helloWorldPlusLongForm.dfdl.xsd
+
+Place the cursor at line 29 column 32, backspace over the two slashes ('/'). Type 2 slashes.
+See issue # 1083 "Intellisense issue when the "/" character is typed" for context.
+
+- [ ] Verify that typing the slashes does not erase any of the data in quotes
+
+Place the cursor at line 31 column 39, after ref="GeneralFormat". Type a space.
+
+- [ ] Verify the dropdown contains a long list of dfdl attributes including:
+      dfdl:alignment, dfdl:alignmentUnits,
+      dfdl:binaryBooleanFalseRep, dfdl:binaryBooleanTrueRep,
+      dfdl:binaryNumberRep, dfdl:bitOrder, dfdl:byteOrder,
+      dfdl:choiceBranchKey, dfdl:encoding, dfdl:inputValueCalc, dfdl:length,
+      dfdl:lengthKind, dfdl:lengthPattern, dfdl:lengthUnits, dfdl:occursCount,
+      dfdl:occursCountKind, dfdl:outputNewLine dfdl:outputValueCalc,
+      dfdl:prefxIncludesPrefixLength, dfdl:prefixLengthType,
+      dfdl:representation, dfdl:terminator, maxOccurs, minOccurs, name, ref,
+      and type.
+      Note: This isn't a comprehensive list of attributes, just the most commonly used attributes.
+
+Select alignment from the dropdown. select 1 as the value for alignment.
+
+- [ ] Verify that alignment="1" is inserted.
+- [ ] Verfiy that alignment does not have the dfdl: prefix.
+
+Place the cursor at line 33 column 1. Type CTRL+space.
+
+- [ ] Verify the dropdown contains dfdl:defineEscapeScheme, dfdl:defineFormat, dfdl:defineVariable,and dfdl:format.
+
+Place the cursor at line 52 column 56 at the end of the line. Backspace over the last two characters "/>". The cursor should be directly after encoding="ascii". Type a / (slash '/').
+
+- [ ] Verify the self closing tag characters "/>" appear at the end of the line.
+
+Place the cursor at line 59, column 46, after representation="text". Type a space.
+
+- [ ] Verify the dropdown contains dfdl:alignment, dfdl:alignmentUnits,
+      dfdl:binaryBooleanFalseRep, dfdl:binaryBooleanTrueRep,
+      dfdl:binaryNumberRep, dfdl:bitOrder, dfdl:byteOrder,
+      dfdl:choiceBranchKey, dfdl:encoding, dfdl:inputValueCalc, dfdl:length,
+      dfdl:lengthKind, dfdl:lengthPattern, dfdl:lengthUnits, dfdl:occursCount,
+      dfdl:occursCountKind, dfdl:outputNewLine dfdl:outputValueCalc,
+      dfdl:prefxIncludesPrefixLength, dfdl:prefixLengthType,
+      dfdl:representation, dfdl:terminator, maxOccurs, minOccurs, name, ref,
+      and type.
+      Note: This isn't a comprehensive list of attributes, just the most commonly used attributes.
+
+Select dfdl:alignment from the dropdown. select 1 as the value.
+
+- [ ] Verify that alignment="1" was inserted.
+- [ ] Verify that alignment does not contian the dfdl: prefix.
+
+Place the cursor at line 68 column 59, after >. Type CTRL+space. -[ ] Verify the dropdown contains dfdl:assert, dfdl:discriminator, dfdl:element, dfdl:property, and dfdl:setVariable.
+
+DO NOT save any changes to the test file.

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -50,6 +50,10 @@
   - [ ] XML
   - [ ] JSON
 
+## DFDL Intellisense
+
+Instructions for testing dfdl intellisense are in the file DfdlIntellisenseTestingChecklist.md in the same directory as this file
+
 ## TDML
 
 - [ ] open a TDML file

--- a/src/tests/data/helloWorldPlusLongForm.dfdl.xsd
+++ b/src/tests/data/helloWorldPlusLongForm.dfdl.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	   xmlns:tns="http://example.com/dfdl/helloworld/"
+	   targetNamespace="http://example.com/dfdl/helloworld/"
+           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+           xmlns:fn="http://www.w3.org/2005/xpath-functions"
+           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext">
+
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
+   
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+     
+      <dfdl:format ref="GeneralFormat" alignment="1" 
+		   representation="text" encoding="UTF-8" lengthKind="delimited"/> 
+                    
+    </xs:appinfo>
+  </xs:annotation>
+  
+  <xs:element name="helloWorld">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element name="word" type="xs:string" maxOccurs="unbounded" dfdl:alignment="implicit"  
+		    dfdl:lengthKind="delimited" dfdl:terminator="%WSP+;"
+		    dfdl:occursCountKind="parsed"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+   
+  <xs:complexType name="myNumbers">
+  <xs:sequence>
+
+    <xs:annotation>
+      <xs:appinfo source="http://www.ogf.org/dfdl/v1.0">
+        <dfdl:sequence separator=";" encoding="ascii"/>
+      </xs:appinfo>
+    </xs:annotation>
+
+    <xs:element name="myInt" type="xs:int">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/v1.0">
+          <dfdl:element representation="text" alignment="1" 
+                textNumberRep="standard" encoding="ascii"
+                lengthKind="delimited" initiator="int="/>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:element>
+
+    <xs:element name="myFloat" type="xs:float">
+      <xs:annotation>
+        <xs:appinfo source="http://www.ogf.org/dfdl/v1.0">
+          <dfdl:element representation="text" 
+                textNumberRep="standard" encoding="ascii"
+                lengthKind="delimited" initiator="float="/>
+        </xs:appinfo>
+      </xs:annotation>
+    </xs:element>
+
+  </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/src/tests/data/testDfdlMixedLineFormats.dfdl.xsd
+++ b/src/tests/data/testDfdlMixedLineFormats.dfdl.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/xmlSchema"
+    xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+    xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+    xmlns:fn="http:/www.w3.org/2005/xpath-functions"
+  elementFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <dfdl:defineFormat name="testFormat">
+        <dfdl:format alignmentUnits="bytes" lengthUnits="bits" representation="binary" binaryNumberRep="binary" 
+                      byteOrder="bigEndian" bitOrder="mostSignificantBitFirst" lengthKind="implicit" alignment="1" encodingErrorPolicy="replace" 
+                      binaryFloatRep="ieee" calendarPatternKind="implicit" documentFinalTerminatorCanBeMissing="yes" 
+                      emptyValueDelimiterPolicy="none" escapeSchemeRef="" fillByte="f" floating="no" ignoreCase="no" 
+                      initiatedContent="no" initiator="" leadingSkip="0" separator="" separatorSuppressionPolicy="anyEmpty" 
+                      textStandardZeroRep="0" textStandardInfinityRep="Inf" textStandardExponentRep="E" 
+                      textStandardNaNRep="NaN" textNumberPattern="#,##0.###;-#,##0.###" textNumberRounding="explicit" 
+                      textNumberRoundingMode="roundUnnecessary" textNumberRoundingIncrement="0" textStandardGroupingSeparator="," 
+                      separatorPosition="infix" sequenceKind="ordered" terminator="" textBidi="no" textNumberCheckPolicy="strict" 
+                      textNumberRep="standard" textPadKind="none" textStandardBase="10" textTrimKind="none" trailingSkip="0" truncateSpecifiedLengthString="no" 
+                      utf16Width="fixed" encoding="US-ASCII" nilKind="literalValue" nilValueDelimiterPolicy="none" occursCountKind="parsed"
+                      textOutputMinLength="0" />
+        </dfdl:defineFormat>
+        <dfdl:format ref="testFormat"/>
+    </xs:appinfo>
+  </xs:annotation>
+  
+  <xs:group name = "test" >
+   <xs:sequence dfdl:hiddenGroupRef="hiddenTestGrp"/>
+    <xs:sequence>
+      <xs:element name="foo1">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:annotation>
+              <xs:appinfo source="http://www.ogf.org/dfdl/">
+              </xs:appinfo>
+            </xs:annotation>
+            <xs:element name="Keyword"
+            type="xs:string" dfdl:alignment="1" dfdl:length="10" 
+            dfdl:alignmentUnits="bits" dfdl:representation="binary"
+            dfdl:lengthKind="delimited" dfdl:terminator="%NUL;" 
+            dfdl:outputNewLine="%CR;"></xs:element>
+            <xs:element name="Compression_Method" type="xs:unsignedInt">
+              <xs:annotation>
+                <xs:appinfo source="http://www.ogf.org/dfdl/">
+                  <dfdl:assert><![CDATA[{ . eq 0 }]]></dfdl:assert>
+                </xs:appinfo>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="Datastream" type="xs:string" minOccurs="0" dfdl:representation="binary" dfdl:occursCountKind="implicit" dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes" dfdl:length="{../../Length - fn:string-length(../Keyword) - 2}"/>
+          </xs:sequence>      
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>  
+   <xs:sequence><xs:element name="foo2" type="xs:string" dfdl:length="10"  dfdl:lengthKind="delimited" dfdl:lengthUnits="bytes"><xs:annotation><xs:appinfo source="http://www.ogf.org/dfdl/"><dfdl:discriminator test="{./length eq 4}"/></xs:appinfo></xs:annotation></xs:element></xs:sequence>
+  </xs:group>
+</xs:schema>


### PR DESCRIPTION
…ng the

attributes is a dfdl element
Add dfdl intellisense checklist
Add intellisense test dfdl schema files to src/tests/data
The testing checklist src/tests/DfdlIntellisenseTestingChecklist.md can be used to verify that intellisense continues to work as expected.

Closes #1080
Closes #1081
Closes #1170
Closes #1196