### PR TITLE
Add left over data message to debugger and extension

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Utils.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Utils.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.daffodil.debugger.dap
+
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.file.Path
+import org.apache.daffodil.io.DataDumper
+
+/** Data Left Over Utils */
+object DataLeftOverUtils {
+
+  /** Get message based on dataFilePath, bitPos1bm bytePos1b and leftOverBits */
+  def getMessage(dataFilePath: Path, bitPos1b: Long, bytePos1b: Long, leftOverBits: Long): String = {
+    val leftOverBitsText =
+      s"Left over data. Consumed ${bitPos1b - 1} bit(s), with at least ${leftOverBits} bit(s) remaining.\n"
+
+    val Dump = new DataDumper
+
+    val numBytes = math.min(8, (leftOverBits / 8)).toInt
+
+    // read to byte array starting where the parse ended
+    val f = new RandomAccessFile(dataFilePath.toFile, "r")
+    val bytes = new Array[Byte](numBytes)
+    f.seek(bytePos1b - 1)
+    f.readFully(bytes)
+    f.close
+
+    // convert those bytes to hex/binary
+    val dumpString =
+      if (bytes.length > 0)
+        Dump
+          .dump(
+            Dump.TextOnly(Some("utf-8")),
+            0,
+            bytes.length * 8,
+            ByteBuffer.wrap(bytes),
+            includeHeadingLine = false
+          )
+          .mkString("\n")
+      else ""
+
+    val dataHex =
+      if (bytes.length > 0)
+        s"Left over data (Hex) starting at byte ${bytePos1b} is: (0x${bytes.map { a =>
+            f"$a%02x"
+          }.mkString}...)\n"
+      else ""
+
+    val dataText =
+      if (bytes.length > 0)
+        s"Left over data (UTF-8) starting at byte ${bytePos1b} is: (${dumpString}...)"
+      else ""
+
+    leftOverBitsText + dataHex + dataText
+  }
+}

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -35,6 +35,11 @@ import {
 } from 'tdmlEditor/utilities/tdmlXmlUtils'
 import xmlFormat from 'xml-formatter'
 import { CommandsProvider } from '../views/commands'
+import {
+  DaffodilDataLeftOver,
+  extractDaffodilData,
+  extractDaffodilEvent,
+} from '../daffodilDebugger/daffodil'
 
 export const outputChannel: vscode.OutputChannel =
   vscode.window.createOutputChannel('Daffodil')
@@ -556,6 +561,20 @@ export function activateDaffodilDebug(
   launchWizard.activate(context)
   tdmlEditor.activate(context)
   rootCompletion.activate(context)
+
+  vscode.debug.onDidReceiveDebugSessionCustomEvent(async (e) => {
+    const debugEvent = extractDaffodilEvent(e)
+    if (debugEvent === undefined) return
+    const debugEventObject = debugEvent.asObject()
+
+    if (debugEventObject.command == 'daffodil.dataLeftOver') {
+      const dataLeftOver = extractDaffodilData(
+        debugEventObject
+      ) as DaffodilDataLeftOver
+
+      vscode.window.showErrorMessage(dataLeftOver.message)
+    }
+  })
 }
 
 class DaffodilConfigurationProvider

--- a/src/daffodilDebugger/daffodil.ts
+++ b/src/daffodilDebugger/daffodil.ts
@@ -25,6 +25,14 @@ export interface DaffodilData {
   bytePos1b: number
 }
 
+export const dataLeftOverEvent = 'daffodil.dataLeftOver'
+export interface DaffodilDataLeftOver {
+  bitPos1b: number
+  bytePos1b: number
+  leftOverBits: number
+  message: string
+}
+
 export const infosetEvent = 'daffodil.infoset'
 export interface InfosetEvent {
   content: string
@@ -71,25 +79,34 @@ export type DaffodilEventType =
   | 'daffodil.data'
   | 'daffodil.infoset'
   | 'daffodil.config'
-export type DaffodilDataType = DaffodilData | InfosetEvent | ConfigEvent
+export type DaffodilEventData = { command: string; data: any }
+export type DaffodilDataType =
+  | DaffodilData
+  | DaffodilDataLeftOver
+  | InfosetEvent
+  | ConfigEvent
 export type DaffodilDataTypeMap = {
   'daffodil.data': DaffodilData
+  'daffodil.dataLeftOver': DaffodilDataLeftOver
   'daffodil.infoset': InfosetEvent
   'daffodil.config': ConfigEvent
 }
+
 export class DaffodilDebugEvent<
   E extends DaffodilEventType,
   B extends DaffodilDataTypeMap[E],
 > implements DebugSessionCustomEvent
 {
   readonly session: DebugSession
+
   constructor(
     readonly event: E,
     readonly body: B
   ) {
     this.session = debug.activeDebugSession!
   }
-  asEditorMessage(): { command: string; data: any } {
+
+  asObject(): DaffodilEventData {
     return {
       command: this.event,
       data: this.body,
@@ -107,8 +124,9 @@ export function extractDaffodilEvent<
   return new DaffodilDebugEvent(eventType, body)
 }
 
-export function extractDaffodilData<
-  E extends DaffodilEventType,
->(editorMessage: { command: string; data: any }): DaffodilDataTypeMap[E] {
-  return editorMessage.data as DaffodilDataTypeMap[E]
+export function extractDaffodilData<E extends DaffodilEventType>(message: {
+  command: string
+  data: any
+}): DaffodilDataTypeMap[E] {
+  return message.data as DaffodilDataTypeMap[E]
 }

--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -162,7 +162,7 @@ export class DataEditorClient implements vscode.Disposable {
         const eventAsEditorMessage = extractDaffodilEvent(debugEvent)
         if (eventAsEditorMessage === undefined) return
 
-        const forwardAs = eventAsEditorMessage.asEditorMessage()
+        const forwardAs = eventAsEditorMessage.asObject()
 
         await this.panel.webview.postMessage(forwardAs)
       })


### PR DESCRIPTION
Add left over data message to debugger and extension

- After a parse completes, the debugger will check if there is data left over.
- When data is left over the debugger will log an error message to the console.
- The debugger also sends data, bitPos1b, bytePos1b, leftOverBits and message to the extension.
- Currently the extension parses the sent over data and shows an error message with the message the debugger sent.

Closes #974