### PR TITLE
Added .xml extension after .prev to be recognized as an xml file

### DIFF
--- a/src/adapter/daffodilEvent.ts
+++ b/src/adapter/daffodilEvent.ts
@@ -27,7 +27,7 @@ export function handleDebugEvent(e: vscode.DebugSessionCustomEvent) {
     case daf.infosetEvent:
       let update: daf.InfosetEvent = e.body
       let path = ensureFile(tmpFile(e.session.id))
-      fs.copyFileSync(path, `${path}.prev`)
+      fs.copyFileSync(path, `${path}.prev.xml`)
       fs.writeFileSync(path, update.content)
       break
     // this allows for any error event to be caught in this case

--- a/src/infoset.ts
+++ b/src/infoset.ts
@@ -78,7 +78,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
       if (sid !== undefined) {
         let filepath = tmpFile(sid)
         fs.rmSync(`${filepath}`, { force: true })
-        fs.rmSync(`${filepath}.prev`, { force: true })
+        fs.rmSync(`${filepath}.prev.xml`, { force: true })
       }
       sid = undefined
       await openInfosetFilePrompt()
@@ -151,7 +151,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
     vscode.commands.registerCommand('infoset.diff', async () => {
       if (sid !== undefined) {
         let filepath = ensureFile(tmpFile(sid))
-        let prev = ensureFile(`${filepath}.prev`)
+        let prev = ensureFile(`${filepath}.prev.xml`)
         vscode.commands.executeCommand(
           'vscode.diff',
           Uri.file(prev),


### PR DESCRIPTION
Now, when  openInfosetDiffView option is turned on within Launch.json file, it will highlight prev file with proper xml tags highlighting at startup.

Steps to test:

- Select openInfosetDiffView options to be true in Launch.json file

- Run Debugger and step through the schema few times to generate content within .prev file and verify that xml tags are properly highlighted as shown below,

![image](https://github.com/user-attachments/assets/fe9c6fed-747a-4511-8126-c321344391d3)


closes #1011