### PR TITLE
Update popup messages for debugger errors

### DIFF
--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -35,11 +35,7 @@ import {
 } from 'tdmlEditor/utilities/tdmlXmlUtils'
 import xmlFormat from 'xml-formatter'
 import { CommandsProvider } from '../views/commands'
-import {
-  DaffodilDataLeftOver,
-  extractDaffodilData,
-  extractDaffodilEvent,
-} from '../daffodilDebugger/daffodil'
+import * as daffodilDebugErrors from './daffodilDebugErrors'
 
 export const outputChannel: vscode.OutputChannel =
   vscode.window.createOutputChannel('Daffodil')
@@ -562,19 +558,7 @@ export function activateDaffodilDebug(
   tdmlEditor.activate(context)
   rootCompletion.activate(context)
 
-  vscode.debug.onDidReceiveDebugSessionCustomEvent(async (e) => {
-    const debugEvent = extractDaffodilEvent(e)
-    if (debugEvent === undefined) return
-    const debugEventObject = debugEvent.asObject()
-
-    if (debugEventObject.command == 'daffodil.dataLeftOver') {
-      const dataLeftOver = extractDaffodilData(
-        debugEventObject
-      ) as DaffodilDataLeftOver
-
-      vscode.window.showErrorMessage(dataLeftOver.message)
-    }
-  })
+  daffodilDebugErrors.activate()
 }
 
 class DaffodilConfigurationProvider

--- a/src/adapter/daffodilDebugErrors.ts
+++ b/src/adapter/daffodilDebugErrors.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode'
+import {
+  DaffodilDataLeftOver,
+  DaffodilParseError,
+  dataLeftOverEvent,
+  extractDaffodilData,
+  extractDaffodilEvent,
+  parseErrorEvent,
+} from '../daffodilDebugger/daffodil'
+
+export const activate = () =>
+  vscode.debug.onDidReceiveDebugSessionCustomEvent(async (e) => {
+    const debugEvent = extractDaffodilEvent(e)
+    if (debugEvent === undefined) return
+    const debugEventObject = debugEvent.asObject()
+
+    let message = ''
+
+    switch (debugEventObject.command) {
+      case dataLeftOverEvent:
+        const dataLeftOver = extractDaffodilData(
+          debugEventObject
+        ) as DaffodilDataLeftOver
+        message = dataLeftOver.message
+        break
+      case parseErrorEvent:
+        const parseError = extractDaffodilData(
+          debugEventObject
+        ) as DaffodilParseError
+        message = parseError.message
+        break
+    }
+
+    if (message !== '') {
+      // Make the message have two line breaks between each line to make the message look better.
+      message = message.replaceAll('\n', '\n\n')
+      vscode.window.showErrorMessage(message, { modal: true })
+    }
+  })

--- a/src/adapter/daffodilEvent.ts
+++ b/src/adapter/daffodilEvent.ts
@@ -32,9 +32,7 @@ export function handleDebugEvent(e: vscode.DebugSessionCustomEvent) {
       break
     // this allows for any error event to be caught in this case
     case e.event.startsWith('daffodil.error') ? e.event : '':
-      vscode.window.showErrorMessage(
-        `An error was received from the Daffodil debugger. ([show logs](command:extension.dfdl-debug.showLogs "show logs"))`
-      )
+      vscode.window.showErrorMessage(e.body.message, { modal: true })
       outputChannel.appendLine(e.body.message)
       break
   }

--- a/src/daffodilDebugger/daffodil.ts
+++ b/src/daffodilDebugger/daffodil.ts
@@ -33,6 +33,11 @@ export interface DaffodilDataLeftOver {
   message: string
 }
 
+export const parseErrorEvent = 'daffodil.parseError'
+export interface DaffodilParseError {
+  message: string
+}
+
 export const infosetEvent = 'daffodil.infoset'
 export interface InfosetEvent {
   content: string
@@ -77,17 +82,21 @@ export interface IDaffodilEvent {
 
 export type DaffodilEventType =
   | 'daffodil.data'
+  | 'daffodil.dataLeftOver'
+  | 'daffodil.parseError'
   | 'daffodil.infoset'
   | 'daffodil.config'
 export type DaffodilEventData = { command: string; data: any }
 export type DaffodilDataType =
   | DaffodilData
   | DaffodilDataLeftOver
+  | DaffodilParseError
   | InfosetEvent
   | ConfigEvent
 export type DaffodilDataTypeMap = {
   'daffodil.data': DaffodilData
   'daffodil.dataLeftOver': DaffodilDataLeftOver
+  'daffodil.parseError': DaffodilParseError
   'daffodil.infoset': InfosetEvent
   'daffodil.config': ConfigEvent
 }


### PR DESCRIPTION
Update popup messages for debugger errors.

- Add support of communication between debugger and extension for parse errors.
- All errors relayed to extension, e.g. left over data, parse errors, bad schema definition, etc. will have a more aggressive popup in the center of the screen.

Closes #1206
Closes #1207