### PR TITLE
Fix typo in release-candidate action name

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: ASF Release Candidate
         id: rc
-        uses: apache/daffodil-infrastructure/actions/asf-release-candidate@main
+        uses: apache/daffodil-infrastructure/actions/release-candidate@main
         with:
           tlp_dir: 'daffodil'
           project_name: 'Apache Daffodil VS Code'


### PR DESCRIPTION
The original name of this was asf-release-candidate thinking it could be useful for ASF project in general. There wasn't much interest so that was dropped and moved to daffodil-infrastrucutre. Forgot to update this name in the workflow file.

DAFFODIL-2971