### PR TITLE
Test if release candidate SVN secrets are set correctly

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -37,6 +37,20 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Check if SVN secrets are set
+        run: |
+          if [ -z "${{ secrets.DAFFODIL_SVN_DEV_USERNAME }}" ]; then
+            echo "DAFFODIL_SVN_DEV_USERNAME is not set"
+          else
+            echo "DAFFODIL_SVN_DEV_USERNAME is set"
+          fi
+
+          if [ -z "${{ secrets.DAFFODIL_SVN_DEV_PASSWORD }}" ]; then
+            echo "DAFFODIL_SVN_DEV_PASSWORD is not set"
+          else
+            echo "DAFFODIL_SVN_DEV_PASSWORD is set"
+          fi
+
       - name: ASF Release Candidate
         id: rc
         uses: apache/daffodil-infrastructure/actions/release-candidate@main


### PR DESCRIPTION
For only the daffodil-vscode repo, testing the release candidate action fails with the error:

  Input required and not supplied: svn_username

The same configuration works with other repots, and other secrets work correctly in this repo. To help debug this, temporarily add a new step to the release candidate action that determines if the svn secrets are set or not.

This commit will be reverted once we determine if secret is missing or empty.