### PR TITLE
Store relevant tdmlConfig properties depending on action specified in…

### DIFF
--- a/src/launchWizard/script.js
+++ b/src/launchWizard/script.js
@@ -294,9 +294,7 @@ function save() {
         },
         tdmlConfig: {
           action: configValues.tdmlAction,
-          name: configValues.tdmlName,
-          description: configValues.tdmlDescription,
-          path: configValues.tdmlPath,
+          // Additional fields are added below
         },
         trace: configValues.trace,
         stopOnEntry: configValues.stopOnEntry,
@@ -320,6 +318,24 @@ function save() {
         },
       },
     ],
+  }
+
+  // Add relevant TDML properties based on action specified
+  switch (configValues.tdmlAction) {
+    case 'none':
+      break
+    case 'generate':
+      obj.configurations[0].tdmlConfig.path = configValues.tdmlPath
+    case 'append':
+    case 'execute':
+      obj.configurations[0].tdmlConfig.name = configValues.tdmlName
+      obj.configurations[0].tdmlConfig.description =
+        configValues.tdmlDescription
+      break
+    default:
+      throw new Error(
+        'Unable to save configuration item in launch.json. tdmlAction save actions not defined!'
+      )
   }
 
   vscode.postMessage({


### PR DESCRIPTION
… launch.json

Closes #1247

Note: When testing out the generate action, you'll need to give a valid filePath, otherwise you'll run into https://github.com/apache/daffodil-vscode/issues/1246

Use a valid file path, like C:\Users\jeremy.yao\repos\test.tdml so that it'll generate the TDML file. 