### PR TITLE
Increase Data Profiler Panel fixed min width to be 285px to show all …

### DIFF
--- a/src/svelte/src/components/Header/fieldsets/FileMetrics.svelte
+++ b/src/svelte/src/components/Header/fieldsets/FileMetrics.svelte
@@ -124,7 +124,7 @@ limitations under the License.
 <SidePanel
   position="top-left"
   title="Data Profiler"
-  panelWidth="270px"
+  panelWidth="285px"
   bind:open={isProfilerOpen}
 >
   {#if isProfilerOpen}


### PR DESCRIPTION
…bytes in graph

Closes #1253

Screenshots (1920 x 1080) monitor

![image](https://github.com/user-attachments/assets/7da4eff5-ebcc-457c-a72e-b0f8a8797459)

Ultrawide 3440 x 1440

![image](https://github.com/user-attachments/assets/4e9da80e-e828-4b92-abcf-5bec9fcab821)

Data file used 

[staircase_bytes_reverse.txt](https://github.com/user-attachments/files/20126675/staircase_bytes_reverse.txt)
