### PR TITLE
Remove people who will no longer be collaborators or are now PMC members from .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,15 +25,9 @@ github:
     merge:    false
     rebase:   true
   collaborators:
-    - ds-nteligen
-    - egbicker
     - hdalsania
     - lrbarber
     - michael-hoke
-    - nlewis05
-    - NolanMatt
-    - rthomas320
-    - stricklandrbls
     - JeremyYao
     - naga-panchumarty
 notifications:


### PR DESCRIPTION
Remove people who will no longer be collaborators or are now PMC members from .asf.yaml