### PR TITLE
Use xml-formatter npm library for formatting DFDL files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "icon": "images/daffodil.ico",
   "categories": [
     "Debuggers",
-    "Programming Languages"
+    "Programming Languages",
+    "Formatters"
   ],
   "repository": {
     "type": "git",
@@ -64,7 +65,7 @@
     "unzip-stream": "0.3.4",
     "wait-port": "1.1.0",
     "xdg-app-paths": "8.3.0",
-    "xml-formatter": "^3.6.0",
+    "xml-formatter": "^3.6.6",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {
@@ -958,6 +959,16 @@
             "type": "boolean",
             "default": false,
             "description": "Enable verbose logging"
+          }
+        }
+      },
+      {
+        "title": "Editor",
+        "properties": {
+          "daffodil.enableFormatter": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable or disable the formatter for DFDL files"
           }
         }
       }

--- a/src/language/dfdl.ts
+++ b/src/language/dfdl.ts
@@ -23,6 +23,7 @@ import { getCloseElementProvider } from './providers/closeElement'
 import { getAttributeValueCompletionProvider } from './providers/attributeValueCompletion'
 import { getCloseElementSlashProvider } from './providers/closeElementSlash'
 import { getAttributeHoverProvider } from './providers/attributeHover'
+import { getDocumentFormattingEditProvider } from './providers/documentFormattingEdit'
 
 export function activate(context: vscode.ExtensionContext) {
   let dfdlFormat = fs
@@ -41,4 +42,9 @@ export function activate(context: vscode.ExtensionContext) {
     getCloseElementSlashProvider(),
     getAttributeHoverProvider()
   )
+
+  const daffodilSettingsConfig = vscode.workspace.getConfiguration('daffodil')
+  if (daffodilSettingsConfig.get<boolean>('enableFormatter')) {
+    context.subscriptions.push(getDocumentFormattingEditProvider())
+  }
 }

--- a/src/language/providers/documentFormattingEdit.ts
+++ b/src/language/providers/documentFormattingEdit.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode'
+import xmlFormat from 'xml-formatter'
+
+export function getDocumentFormattingEditProvider() {
+  return vscode.languages.registerDocumentFormattingEditProvider('dfdl', {
+    provideDocumentFormattingEdits(
+      document: vscode.TextDocument
+    ): vscode.TextEdit[] {
+      return [
+        vscode.TextEdit.replace(
+          new vscode.Range(0, 0, document.lineCount, 0),
+          xmlFormat(document.getText())
+        ),
+      ]
+    },
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,7 +5539,7 @@ xdg-portable@^10.6.0:
   optionalDependencies:
     fsevents "*"
 
-xml-formatter@^3.6.0:
+xml-formatter@^3.6.6:
   version "3.6.6"
   resolved "https://registry.yarnpkg.com/xml-formatter/-/xml-formatter-3.6.6.tgz#e7f275cba7565e5afd6c6d74e1ef6f589f0b4ac6"
   integrity sha512-yfofQht42x2sN1YThT6Er6GFXiQinfDAsMTNvMPi2uZw5/Vtc2PYHfvALR8U+b2oN2ekBxLd2tGWV06rAM8nQA==


### PR DESCRIPTION
Closes #1261

DO NOT MERGE THIS IN UNTIL WE DECIDE TO MERGE 1.4.2 PRs IN.

Note: This formatter likes to extend XML elements into one single line. In https://github.com/DFDLSchemas/JPEG/blob/master/src/main/resources/com/mitre/jpeg/xsd/jpeg.dfdl.xsd, the dfdl:format element spans multiple lines but the formatter does the following to the line. 

![image](https://github.com/user-attachments/assets/6935c9f2-b760-4c95-b7fc-526798e3d6c2)

### Testing Instructions

1. Use `yarn package` and install the extension
2. Go to your VSCode settings and make sure the Enable Formatter option is checked.
![image](https://github.com/user-attachments/assets/2214642b-6245-4d18-a160-50db6a37e0ad)
3. Paste the following into a file called `test.dfdl.xsd`
```XML
<?xml version="1.0" encoding="UTF-8"?>

<xs:schema xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:xs="http://www.w3.org/2001/XMLSchema"><xs:annotation><xs:appinfo source="http://www.ogf.org/dfdl/"><dfdl:defineFormat name="GeneralFormatBase"><dfdl:format alignment="1" alignmentUnits="bytes" binaryFloatRep="ieee" binaryNumberCheckPolicy="lax" binaryNumberRep="binary" binaryCalendarEpoch="1970-01-01T00:00:00" bitOrder="mostSignificantBitFirst" byteOrder="bigEndian" calendarCenturyStart="53" calendarCheckPolicy="strict" calendarDaysInFirstWeek="4" calendarFirstDayOfWeek="Sunday" calendarLanguage="en" calendarObserveDST="yes" calendarPatternKind="implicit" calendarTimeZone="" choiceLengthKind="implicit" decimalSigned="yes" documentFinalTerminatorCanBeMissing="no" emptyValueDelimiterPolicy="both" encodingErrorPolicy="replace" encoding="US-ASCII" escapeSchemeRef="" fillByte="%#r20;" floating="no" ignoreCase="no" initiatedContent="no" initiator="" leadingSkip="0" lengthKind="implicit" lengthUnits="bytes" occursCountKind="implicit" outputNewLine="%LF;" representation="text" separator="" separatorPosition="infix" separatorSuppressionPolicy="anyEmpty" sequenceKind="ordered" terminator="" textBidi="no" textBooleanPadCharacter="%SP;" textCalendarJustification="left" textCalendarPadCharacter="%SP;" textNumberCheckPolicy="lax" textNumberJustification="right" textNumberPadCharacter="%SP;" textNumberPattern="#,##0.###;-#,##0.###" textNumberRep="standard" textNumberRounding="explicit" textNumberRoundingIncrement="0" textNumberRoundingMode="roundHalfEven" textOutputMinLength="0" textPadKind="none" textStandardBase="10" textStandardDecimalSeparator="." textStandardExponentRep="E" textStandardGroupingSeparator="," textStandardInfinityRep="Inf" textStandardNaNRep="NaN" textStandardZeroRep="" textStringJustification="left" textStringPadCharacter="%SP;" textTrimKind="none" trailingSkip="0" truncateSpecifiedLengthString="no" utf16Width="fixed"/></dfdl:defineFormat></xs:appinfo></xs:annotation></xs:schema>
```
4. Format the document and ensure it looks formatted.
5. Then unhceck Enable Formatter
![image](https://github.com/user-attachments/assets/25931cac-1c03-45c9-8f6e-e4ea912bb72c)
6. Reload the window
![image](https://github.com/user-attachments/assets/95fa146c-8e7b-4e42-ad78-cf966a087fc0)
7. Formatting shouldn't work
8. In your user's settings JSON ![image](https://github.com/user-attachments/assets/efb101ef-8e8f-431a-baa7-0b9b7b6a6449), make sure `  "daffodil.enableFormatter": false,` is in the JSON file. 