### PR TITLE
Insert and remove quotes around pathing for debugger where appropriat…

### DIFF
--- a/debugger/src/templates/bat-template
+++ b/debugger/src/templates/bat-template
@@ -122,7 +122,7 @@ if defined DAFFODIL_DEBUG_CLASSPATH (
 
 
 rem Call the application and pass all arguments unchanged.
-"%_JAVACMD%" !_JAVA_OPTS! !DAFFODIL_DEBUGGER_OPTS! -cp "%NEW_CLASSPATH%" %MAIN_CLASS% !_APP_ARGS!
+"%_JAVACMD%" !_JAVA_OPTS! !DAFFODIL_DEBUGGER_OPTS! -cp %NEW_CLASSPATH% %MAIN_CLASS% !_APP_ARGS!
 
 @endlocal
 

--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -1317,6 +1317,11 @@ async function serverStart() {
     throw new Error(`Log config file '${logConfigFile}' not found`)
   }
 
+  const x = OMEGA_EDIT_HOST
+  const y = getPidFile(omegaEditPort)
+  const z = logConfigFile
+
+  console.log(x, y, z)
   // Start the server and wait up to 10 seconds for it to start
   const serverPid = (await Promise.race([
     startServer(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -296,11 +296,10 @@ export async function runScript(
   const terminal = getTerminal(hideTerminal, env, createTerminal)
 
   // Create debugger run command
-  const fullPathToScript = path
-    .join(scriptPath, 'bin', scriptName)
-    // fix pathing as emtpy space needs a \ before it to not cause errors
-    .replace(' ', '\\ ')
-  const debuggerRunCommand = `${fullPathToScript} ${shellArgs.join(' ')}`
+  const fullPathToScript = path.join(scriptPath, 'bin', scriptName)
+
+  // Surround path to script with quotes to account for spaces
+  const debuggerRunCommand = `"${fullPathToScript}" ${shellArgs.join(' ')}`
 
   // Send debugger run command to terminal, when exists terminal will stay open
   terminal.sendText(debuggerRunCommand)


### PR DESCRIPTION
…e to handle folder names w/ spaces

Closes #1075

## Description

See #1075

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
   - This is developer-related only. No need to inform users about this.
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots
[Add review instructions including screenshots or GIFs to help explain the change visually.]

sampleWorkspace: [sampleWorkspace.zip](https://github.com/user-attachments/files/20490547/sampleWorkspace.zip)

#### Verifying Functionality While Debugging the Extension 

1. Clone the jy/1075 branch onto your machine where a space exists in the path. Example: `C:\Users\jeremy.yao\repos\space test\daffodil-vscode-ctc>`
2. Copy the sampleWorkspace contents into the same folder where the is a space in the path. Example: `C:\Users\jeremy.yao\repos\space test\sampleWorkspace`
3. Debug the extension as normal 
![image](https://github.com/user-attachments/assets/07952461-364a-4fcf-92ca-c097615f66b2)

4. Run the `jpeg` launch.json configuration and verify that debugging went as expected. 
![image](https://github.com/user-attachments/assets/600c6dc4-4762-442e-a3d4-dc148bff438f)

5. You may want to run `jpeg` again but also have the following be set to true in launch.json

```JSON
            "openDataEditor": true,
            "openInfosetView": true,
            "openInfosetDiffView": true,
```

6. Verify the data editor and the two infoset views open up. 
7. As a regression test, perform steps 1 - 6, but reclone the branch and the sampleWorkspace folder into a path without any spaces. Example: `C:\Users\jeremy.yao\repos`

#### Verifying Functionality with Packaged Extension 

1. Package the extension via `yarn package` and install it into VSCode
2. Copy the sampleWorkspace contents into a folder where the is a space in the path. Example: `C:\Users\jeremy.yao\repos\space test\sampleWorkspace`
3. Run the `jpeg` launch.json configuration and verify that debugging went as expected. 
![image](https://github.com/user-attachments/assets/600c6dc4-4762-442e-a3d4-dc148bff438f)

4. You may want to run `jpeg` again but also have the following be set to true in launch.json

```JSON
            "openDataEditor": true,
            "openInfosetView": true,
            "openInfosetDiffView": true,
```

5. Verify the data editor and the two infoset views open up. 

