### PR TITLE
Change generated yarn test debugger log file location to temp directory and removal logic for removing them.

### DIFF
--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -19,6 +19,7 @@ import * as vscode from 'vscode'
 import * as assert from 'assert'
 import * as path from 'path'
 import * as fs from 'fs'
+import * as os from 'os'
 import { PROJECT_ROOT, PACKAGE_PATH, TEST_SCHEMA } from './common'
 import { getConfig, killProcess } from '../../utils'
 import { runDebugger, stopDebugging } from '../../daffodilDebugger'
@@ -54,13 +55,13 @@ suite('Daffodil Debugger', () => {
     {
       logging: {
         level: 'INFO',
-        file: 'daffodil-debugger-4711.log',
+        file: path.join(os.tmpdir(), 'yarn-test-daffodil-debugger-4711.log'),
       },
     },
     {
       logging: {
         level: 'INFO',
-        file: 'daffodil-debugger-4712.log',
+        file: path.join(os.tmpdir(), 'yarn-test-daffodil-debugger-4712.log'),
       },
     },
   ]
@@ -97,10 +98,6 @@ suite('Daffodil Debugger', () => {
     // No need to deleted the debugging server because upon re-run, webpack cleans and re-extracts it.
     if (fs.existsSync(XML_INFOSET_PATH)) fs.rmSync(XML_INFOSET_PATH)
     if (fs.existsSync(JSON_INFOSET_PATH)) fs.rmSync(JSON_INFOSET_PATH)
-    dfdlDebuggers.forEach((dfdlDebugger) => {
-      if (fs.existsSync(dfdlDebugger.logging.file))
-        fs.rmSync(dfdlDebugger.logging.file)
-    })
   })
 
   test('should output xml infoset', async () => {


### PR DESCRIPTION
Closes #1292

### How to test

1. Remove daffodil-debugger-4712.log and daffodil-debugger-4711.log from your home directory (~) if they exist
2. Run `yarn test`
3. Check your system's temp directory to make sure you see yarn-test-daffodil-debugger-4712.log and yarn-test-daffodil-debugger-4711.log
4. Take note each of the files' sizes
5. To ensure the files aren't able to grow to a huge file size, run `yarn test` again
6. Repeat step 3 again and make sure the files aren't doubled in size. 
7. Check your home directory and make sure there are no debugger files.