### PR TITLE
Bump windows runner to windows-2022 as windows-2019 is being removed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,7 +95,7 @@ jobs:
       matrix:
         java_distribution: [temurin]
         java_version: [8, 11, 17]
-        os: [macos-13, ubuntu-22.04, windows-2019]
+        os: [macos-13, ubuntu-22.04, windows-2022]
         node: ["20.18.3", "22.14.0"]
         vscode: ["1.90.0", "stable"] # v1.90.0 is the first version of VSCode to use Node 20
       fail-fast: false # don't immediately fail all other jobs if a single job fails

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
           [
             macos-13,
             ubuntu-22.04,
-            windows-2019,
+            windows-2022,
             macos-latest,
             ubuntu-latest,
             windows-latest,


### PR DESCRIPTION
This will the fix the issue with some PRs and main CI failing due to windows-2019 being removed as a supported runner