### PR TITLE
Disable popup for Schema Definition Errors

### DIFF
--- a/src/adapter/daffodilEvent.ts
+++ b/src/adapter/daffodilEvent.ts
@@ -32,8 +32,11 @@ export function handleDebugEvent(e: vscode.DebugSessionCustomEvent) {
       break
     // this allows for any error event to be caught in this case
     case e.event.startsWith('daffodil.error') ? e.event : '':
-      vscode.window.showErrorMessage(e.body.message, { modal: true })
+      if (!e.body.message.startsWith('Schema Definition Error:')) {
+        vscode.window.showErrorMessage(e.body.message, { modal: true })
+      }
       outputChannel.appendLine(e.body.message)
+      outputChannel.show(true)
       break
   }
 }


### PR DESCRIPTION
Closes #58 

Removes the popup in cases where invalid XML is sent to the parser. An Output window is created that contains the error text, and it is also contained in the terminal window.