### PR TITLE
Remove dependency on Highlight Matching Tag extension

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -228,7 +228,6 @@ Upon opening, VSCode may prompt you to install recommended extensions. Go ahead 
 Daffodil-VSCode depends on the following extensions
 
 - [JAR Viewer - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=wmanth.jar-viewer)
-- [Highlight Matching Tag - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=vincaslt.highlight-matching-tag)
 
 ### Verifying Setup Can Build
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "webpack-cli": "6.0.1"
   },
   "extensionDependencies": [
-    "vincaslt.highlight-matching-tag",
     "wmanth.jar-viewer"
   ],
   "main": "./dist/ext/extension.js",

--- a/src/tests/runTest.ts
+++ b/src/tests/runTest.ts
@@ -60,21 +60,11 @@ async function main() {
       resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath)
 
     // Install required extensions
-    cp.spawnSync(
-      cli,
-      [
-        ...args,
-        '--install-extension',
-        'vincaslt.highlight-matching-tag',
-        '--install-extension',
-        'wmanth.jar-viewer',
-      ],
-      {
-        encoding: 'utf-8',
-        stdio: 'inherit',
-        shell: os.platform().toLowerCase() != 'darwin',
-      }
-    )
+    cp.spawnSync(cli, [...args, '--install-extension', 'wmanth.jar-viewer'], {
+      encoding: 'utf-8',
+      stdio: 'inherit',
+      shell: os.platform().toLowerCase() != 'darwin',
+    })
 
     // Download VS Code, unzip it and run the integration tests
     const runTestsResult = await runTests({


### PR DESCRIPTION
Closes #1335 

We had a dependency on the Highlight Matching Tag extension. We don't appear to actually be depending on this extension - it was just installed alongside ours as a quality of life extension for schemas. Removing it as a dependency allows the DFDL extension to install over an ssh connection, and the Highlight Matching Tag extension will appear in the list of recommended extensions if users wish to install it.