### PR TITLE
TDML Generate is not creating/updating the TDML file in /tmp

### DIFF
--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -162,10 +162,10 @@ async function createDebugRunFileConfigs(
         noDebug: noDebug,
       })
     } else {
-      var tdmlConfig = <TDMLConfig>{}
+      var tdmlConfig: TDMLConfig | undefined = undefined
 
       if (tdmlAction) {
-        tdmlConfig.action = tdmlAction
+        tdmlConfig = { action: tdmlAction }
 
         if (tdmlAction === 'execute') {
           tdmlConfig.path = targetResource.fsPath.toString()
@@ -198,19 +198,19 @@ async function createDebugRunFileConfigs(
         request: 'launch',
         type: 'dfdl',
         schema: {
-          path: tdmlConfig.action === 'execute' ? '' : targetResource.fsPath,
+          path: tdmlConfig?.action === 'execute' ? '' : targetResource.fsPath,
           rootName: null,
           rootNamespace: null,
         },
         data:
-          tdmlConfig.action === 'execute' ? '' : '${command:AskForDataName}',
+          tdmlConfig?.action === 'execute' ? '' : '${command:AskForDataName}',
         debugServer: false,
         infosetFormat: 'xml',
         infosetOutput: {
           type: 'file',
           path: '${workspaceFolder}/' + infosetFile,
         },
-        tdmlConfig: tdmlConfig,
+        ...(tdmlConfig && { tdmlConfig: tdmlConfig }),
       })
 
       vscode.debug.startDebugging(undefined, config, { noDebug: noDebug })
@@ -675,7 +675,7 @@ class DaffodilConfigurationProvider
       !dataFolder.includes('${command:AskForSchemaName}') &&
       !dataFolder.includes('${command:AskForDataName}') &&
       !dataFolder.includes('${workspaceFolder}') &&
-      config.tdmlConfig.action !== 'execute' &&
+      config.tdmlConfig?.action !== 'execute' &&
       vscode.workspace.workspaceFolders &&
       dataFolder !== vscode.workspace.workspaceFolders[0].uri.fsPath &&
       dataFolder.split('.').length === 1 &&


### PR DESCRIPTION
Closes #1350 

Set default tdmlConfig to be missing/undefined instead of empty. The default handling of this was already correct, but it didn't want to "overwrite" the tdmlConfig if it was defined but empty.

Tested with and without #1354 changes. Should be able to be merged in either order, but should prefer to do this one second as it's much smaller.