### PR TITLE
Ctc oss 1297 execute tdml

### DIFF
--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -289,7 +289,7 @@ export function activateDaffodilDebug(
     vscode.commands.registerCommand(
       'extension.dfdl-debug.executeTDML',
       (resource: vscode.Uri) => {
-        createDebugRunFileConfigs(resource, 'run', 'execute')
+        createDebugRunFileConfigs(resource, 'debug', 'execute')
       }
     ),
     vscode.commands.registerCommand(

--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -203,6 +203,7 @@ export class DataEditorClient implements vscode.Disposable {
         openLabel: 'Select',
         canSelectFiles: true,
         canSelectFolders: false,
+        title: 'Select Data File',
       })
       if (fileUri && fileUri[0]) {
         this.fileToEdit = fileUri[0].fsPath


### PR DESCRIPTION
Closes #1297 

Set "TDML execute" to run in debug mode by default. This allows breakpoints to carry over from the schema when running the TDML 

@JeremyYao Documented a procedure to test this [here](https://github.com/apache/daffodil-vscode/issues/1297).

I also  added a title to the file prompt for the data editor. I had the follwing setting in my launch.json `"openDataEditor": true` and I couldnt figure out what was causing the prompt and what it was asking for. Ideally when testing this run with `"openDataEditor": false`