### PR TITLE
Fix premature shutdown of Ωedit server when multiple data editor tabs are open

### DIFF
--- a/src/dataEditor/include/server/Sessions.ts
+++ b/src/dataEditor/include/server/Sessions.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { destroySession } from '@omega-edit/client'
+import { destroySession, getSessionCount } from '@omega-edit/client'
 import { updateHeartbeatInterval } from './heartbeat'
 import { serverStop } from '../../dataEditorClient'
 
@@ -32,5 +32,9 @@ export async function removeActiveSession(sessionId: string) {
   activeSessions.splice(index, 1)
   updateHeartbeatInterval(activeSessions)
   await destroySession(sessionId)
-  await serverStop()
+
+  // Only stop the server if there are no active sessions
+  if ((await getSessionCount()) === 0) {
+    await serverStop()
+  }
 }


### PR DESCRIPTION
Fix premature shutdown of Ωedit server when multiple data editor tabs are open

Closes #1312