### PR TITLE
Change copy tdml to create tdml

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "onCommand:extension.dfdl-debug.debugEditorContents",
     "onCommand:extension.dfdl-debug.appendTDML",
     "onCommand:extension.dfdl-debug.executeTDML",
-    "onCommand:extension.dfdl-debug.copyTDML",
+    "onCommand:extension.dfdl-debug.createTDML",
     "onCommand:extension.dfdl-debug.getTDMLName",
     "onCommand:extension.dfdl-debug.getTDMLPath",
     "onCommand:extension.dfdl-debug.getValidatedTDMLPath",
@@ -271,7 +271,7 @@
           "when": "resourceLangId == tdml"
         },
         {
-          "command": "extension.dfdl-debug.copyTDML",
+          "command": "extension.dfdl-debug.createTDML",
           "when": "resourceLangId == dfdl"
         }
       ],
@@ -293,7 +293,7 @@
           "when": "resourceLangId == tdml"
         },
         {
-          "command": "extension.dfdl-debug.copyTDML",
+          "command": "extension.dfdl-debug.createTDML",
           "when": "resourceLangId == dfdl"
         },
         {
@@ -376,10 +376,11 @@
         "enablement": "!inDebugMode"
       },
       {
-        "command": "extension.dfdl-debug.copyTDML",
-        "title": "Copy TDML File",
+        "command": "extension.dfdl-debug.createTDML",
+        "title": "Create TDML File",
         "category": "Daffodil Debug",
-        "enablement": "!inDebugMode"
+        "enablement": "!inDebugMode",
+        "tooltip": "testing123"
       },
       {
         "command": "extension.dfdl-debug.toggleFormatting",

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -282,7 +282,7 @@ export function activateDaffodilDebug(
       }
     ),
     vscode.commands.registerCommand(
-      'extension.dfdl-debug.copyTDML',
+      'extension.dfdl-debug.createTDML',
       async (_) => {
         if (!fs.existsSync(getTmpTDMLFilePath())) {
           vscode.window.showErrorMessage(


### PR DESCRIPTION
Closes #1270 

Testing

1. Open up a DFDL schema. Confirm that the menu now says "Create TDML File" instead of "Copy TDML File" .
<img width="1209" height="72" alt="image" src="https://github.com/user-attachments/assets/39f1a53c-1a32-48d2-b792-16e01183854b" />
