### PR TITLE
add jansi dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,8 @@ lazy val debugger = project
       "co.fs2" %% "fs2-io" % "3.12.0",
       "com.monovore" %% "decline-effect" % "2.5.0",
       "org.typelevel" %% "log4cats-slf4j" % "2.7.1",
-      "org.scalameta" %% "munit" % "1.0.4" % Test
+      "org.scalameta" %% "munit" % "1.0.4" % Test,
+      "org.fusesource.jansi" % "jansi" % "1.18"
     ),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, "daffodilVersion" -> daffodilVer),
     buildInfoPackage := "org.apache.daffodil.debugger.dap",

--- a/build/package/NONOTICE
+++ b/build/package/NONOTICE
@@ -159,3 +159,8 @@ The following binary components distributed with this project are licensed under
   This package is available under the Apache License v2 without a NOTICE:
       Repository at: https://github.com/hidekatsu-izuno/jsonic/
       NOTE: This one appears to be in a different language does this cause any issues?
+
+- org.fusesource.jansi-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
+  This product bundles 'jansi' from the above files.
+  This package is available under the Apache License v2 without a NOTICE:
+      Repository at: https://github.com/fusesource/jansi


### PR DESCRIPTION
Closes #1321 

**To test:**

Using a Windows environment, configure and run a launch.json, or use an existing launch.json. Ensure the following error is not outputted to the terminal or the debugger log file.
```shell
10:01:37,625 |-WARN in ch.qos.logback.core.ConsoleAppender[STDOUT] - Failed to create WindowsAnsiOutputStream. Falling back on the default stream. ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type org.fusesource.jansi.WindowsAnsiOutputStream   
        at ch.qos.logback.core.util.DynamicClassLoadingException: Failed to instantiate type org.fusesource.jansi.WindowsAnsiOutputStream 
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:68)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:39)
        at      at ch.qos.logback.core.ConsoleAppender.getTargetStreamForWindows(ConsoleAppender.java:88)
        at      at ch.qos.logback.core.ConsoleAppender.start(ConsoleAppender.java:79)
        at      at ch.qos.logback.core.joran.action.AppenderAction.end(AppenderAction.java:90)
        at      at ch.qos.logback.core.joran.spi.Interpreter.callEndAction(Interpreter.java:309)
        at      at ch.qos.logback.core.joran.spi.Interpreter.endElement(Interpreter.java:193)
        at      at ch.qos.logback.core.joran.spi.Interpreter.endElement(Interpreter.java:179)
        at      at ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:62)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:165)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:152)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:110)
        at      at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:53)
        at      at ch.qos.logback.classic.util.ContextInitializer.configureByResource(ContextInitializer.java:64)
        at      at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:134)
        at      at org.slf4j.impl.StaticLoggerBinder.init(StaticLoggerBinder.java:84)
        at      at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:55)
        at      at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
        at      at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
        at      at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:417)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
        at      at org.typelevel.log4cats.slf4j.Slf4jLogger$.getLoggerFromName(Slf4jLogger.scala:30)
        at      at org.typelevel.log4cats.slf4j.Slf4jLogger$.getLogger(Slf4jLogger.scala:27)
        at      at org.apache.daffodil.debugger.dap.DAPodil$.<clinit>(DAPodil.scala:439)
        at      at org.apache.daffodil.debugger.dap.DAPodil.main(DAPodil.scala)
Caused by: java.lang.ClassNotFoundException: org.fusesource.jansi.WindowsAnsiOutputStream
        at      at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at      at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at      at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
        at      at ch.qos.logback.core.util.OptionHelper.instantiateByClassNameAndParameter(OptionHelper.java:55)
        at      ... 24 common frames omitted
``` 