### PR TITLE
1355 - return if user cancels during file prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -379,8 +379,7 @@
         "command": "extension.dfdl-debug.createTDML",
         "title": "Create TDML File",
         "category": "Daffodil Debug",
-        "enablement": "!inDebugMode",
-        "tooltip": "testing123"
+        "enablement": "!inDebugMode"
       },
       {
         "command": "extension.dfdl-debug.toggleFormatting",

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -341,22 +341,36 @@ export function activateDaffodilDebug(
       'extension.dfdl-debug.getSchemaName',
       async (fileRequested = null) => {
         // Open native file explorer to allow user to select data file from anywhere on their machine
-        return await getFile(
+        const retVal = await getFile(
           fileRequested,
           'Select DFDL schema to debug',
           'Select DFDL schema to debug'
         )
+
+        if (!retVal)
+          vscode.window.showInformationMessage(
+            'Invalid DFDL schema path selected'
+          )
+
+        return retVal
       }
     ),
     vscode.commands.registerCommand(
       'extension.dfdl-debug.getDataName',
       async (fileRequested = null) => {
         // Open native file explorer to allow user to select data file from anywhere on their machine
-        return await getFile(
+        const retVal = await getFile(
           fileRequested,
           'Select input data file to debug',
           'Select input data file to debug'
         )
+
+        if (!retVal)
+          vscode.window.showInformationMessage(
+            'Invalid data file path selected'
+          )
+
+        return retVal
       }
     ),
     vscode.commands.registerCommand('extension.dfdl-debug.showLogs', () => {

--- a/src/daffodilDebugger/debugger.ts
+++ b/src/daffodilDebugger/debugger.ts
@@ -145,16 +145,30 @@ export async function getDebugger(
 
     // Get schema file before debugger starts to avoid timeout
     if (config.schema.path.includes('${command:AskForSchemaName}')) {
-      config.schema.path = await vscode.commands.executeCommand(
+      const schemaPath = await vscode.commands.executeCommand(
         'extension.dfdl-debug.getSchemaName'
       )
+
+      // Stop execution if schemaPath is null, undefined, or empty string
+      if (!schemaPath) {
+        return await stopDebugging().then((_) => undefined)
+      }
+
+      config.schema.path = schemaPath
     }
 
     // Get data file before debugger starts to avoid timeout
     if (config.data.includes('${command:AskForDataName}')) {
-      config.data = await vscode.commands.executeCommand(
+      const dataPath = await vscode.commands.executeCommand(
         'extension.dfdl-debug.getDataName'
       )
+
+      // Stop execution if dataPath is null, undefined, or empty string
+      if (!dataPath) {
+        return await stopDebugging().then((_) => undefined)
+      }
+
+      config.data = dataPath
     }
 
     let workspaceFolder = vscode.workspace.workspaceFolders[0].uri.fsPath


### PR DESCRIPTION
## Problem Description
Closes #1355 
Quoted from [issue 1355](https://github.com/apache/daffodil-vscode/issues/1355)
"If a user starts a daffodil parse, through the command palette or launch config, they may get a input dialog of some kind asking them to provide the dfdl schema or the data file. If they press escape or cancel out of the dialog, the backend is started, we send the launch config to the backend, and then the backend throws an exception and creates an error dialog. If the input is cancelled, we shouldn't even be starting the backend as we know that it's an invalid config."

## Testing
1. Build this branch and start an extension debugging session. Open a workspace folder. 
2. Start a debugging session based on known good `launch.json` 
<img width="285" height="50" alt="image" src="https://github.com/user-attachments/assets/fa9fe904-2fed-473d-a94d-f0e0e2561fb7" />

3. Observe the prompt for the DFDL Schema
<img width="1072" height="127" alt="image" src="https://github.com/user-attachments/assets/b7ecab52-0027-48b0-ba6d-97771ac35320" />

4. Press escape.
5. Observe that the debugging session gracefully ends and the following error messages are shown
<img width="733" height="164" alt="image" src="https://github.com/user-attachments/assets/61013fde-905c-4703-a2f8-ea36201d8e79" />

6. Repeat 1-3 above. Provide a valid DFDL Schema this time.
7. Observe the prompt for the data file 
<img width="1074" height="120" alt="image" src="https://github.com/user-attachments/assets/da6f3f5b-b8c9-4817-93e2-08167c3e436e" />

8. Press Escape
9. . Observe that the debugging session gracefully ends and the following error messages are shown
<img width="768" height="167" alt="image" src="https://github.com/user-attachments/assets/0dd16407-8930-4042-bf41-0a8df4bf3a3e" />

10. Test the same behavior when executing a TDML file from the `launch.json` or via the "Execute TDML" button present went a `.tdml` file is selected.
11.  Observe that the debugging session gracefully ends with the appropriate error messages.
