### PR TITLE
Fix Visibility/Enablement for Extension Commands and Unify Conditions

### DIFF
--- a/build/package/LICENSE
+++ b/build/package/LICENSE
@@ -705,6 +705,30 @@ conditions of the following licenses.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+- 'jsep' in extension/dist/ext/extension.js
+  This product bundles the 'jsep' from the above files.
+  These files are available under the MIT License
+    Copyright (c) 2013 Stephen Oney, https://ericsmekens.github.io/jsep/
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 - 'jsonc-parser' in extension/dist/ext/extension.js
   This product bundles 'jsonc-parser' from the above files.
   This package is available under the MIT License:

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "await-notify": "1.0.1",
     "hexy": "0.3.5",
     "iso-639-1": "^3.1.0",
+    "jsep": "^1.4.0",
     "jsonc-parser": "3.2.1",
     "semver": "7.5.4",
     "unzip-stream": "0.3.4",
@@ -105,24 +106,14 @@
   },
   "main": "./dist/ext/extension.js",
   "activationEvents": [
-    "onLanguage:dfdl",
     "onDebugResolve:dfdl",
     "onDebugDynamicConfigurations:dfdl",
     "onCommand:extension.dfdl-debug.getSchemaName",
     "onCommand:extension.dfdl-debug.getDataName",
-    "onCommand:extension.dfdl-debug.runEditorContents",
-    "onCommand:extension.dfdl-debug.debugEditorContents",
-    "onCommand:extension.dfdl-debug.appendTDML",
-    "onCommand:extension.dfdl-debug.executeTDML",
-    "onCommand:extension.dfdl-debug.createTDML",
     "onCommand:extension.dfdl-debug.getTDMLName",
     "onCommand:extension.dfdl-debug.getTDMLPath",
     "onCommand:extension.dfdl-debug.getValidatedTDMLPath",
-    "onCommand:extension.dfdl-debug.getValidatedTDMLCopyPath",
-    "onCommand:launch.config",
-    "onCommand:extension.data.edit",
-    "onCommand:extension.dfdl-debug.debugLastEditorContents",
-    "onView:commandsView"
+    "onCommand:extension.dfdl-debug.getValidatedTDMLCopyPath"
   ],
   "workspaceTrust": {
     "request": "never"
@@ -212,93 +203,91 @@
       "editor/title": [
         {
           "command": "launch.config",
+          "when": "true",
           "group": "navigation@1"
         },
         {
           "command": "infoset.display",
-          "when": "resourceLangId == dfdl",
+          "when": "inDebugMode && editorLangId == 'dfdl'",
           "group": "navigation@2"
         },
         {
           "command": "infoset.diff",
-          "when": "resourceLangId == dfdl",
+          "when": "inDebugMode && editorLangId == 'dfdl'",
           "group": "navigation@3"
         },
         {
           "command": "tdml-editor.openInTextEditor",
-          "when": "activeCustomEditorId == 'tdml-editor.editor' && activeEditorIsNotPreview == false",
+          "when": "activeEditor == 'tdml-editor.editor'",
           "group": "navigation@1"
         },
         {
           "command": "tdml-editor.openPreview",
-          "when": "(resourceExtname == '.tdml' || resourceExtname == '.tdml.xsd') && activeEditor == 'workbench.editors.files.textFileEditor'",
+          "when": "editorLangId == 'tdml' && editorTextFocus",
           "group": "navigation@1"
         },
         {
           "command": "tdml-editor.openInTdmlEditor",
-          "when": "(resourceExtname == '.tdml' || resourceExtname == '.tdml.xsd') && activeEditor == 'workbench.editors.files.textFileEditor'",
+          "when": "editorLangId == 'tdml' && editorTextFocus",
           "group": "navigation@1"
         }
       ],
       "webview/context": [
         {
           "command": "tdml-editor.deleteTest",
-          "when": "activeCustomEditorId == 'tdml-editor.editor'"
+          "when": "false"
         }
       ],
       "editor/title/run": [
         {
           "command": "extension.dfdl-debug.runEditorContents",
-          "when": "resourceLangId == dfdl"
+          "when": "!inDebugMode && editorLangId == 'dfdl'"
         },
         {
           "command": "extension.dfdl-debug.debugEditorContents",
-          "when": "resourceLangId == dfdl"
+          "when": "!inDebugMode && editorLangId == 'dfdl'"
         },
         {
           "command": "extension.dfdl-debug.debugLastEditorContents",
-          "when": "resourceLangId == dfdl"
+          "when": "!inDebugMode && editorLangId == 'dfdl'"
         },
         {
           "command": "extension.dfdl-debug.appendTDML",
-          "when": "resourceLangId == tdml"
+          "when": "!inDebugMode && ((editorLangId == 'tdml' && editorTextFocus) || activeEditor == 'tdml-editor.editor')"
         },
         {
           "command": "extension.dfdl-debug.executeTDML",
-          "when": "resourceLangId == tdml"
-        },
-        {
-          "command": "extension.dfdl-debug.createTDML",
-          "when": "resourceLangId == dfdl"
+          "when": "!inDebugMode && ((editorLangId == 'tdml' && editorTextFocus) || activeEditor == 'tdml-editor.editor')"
         }
       ],
       "commandPalette": [
         {
           "command": "extension.dfdl-debug.debugEditorContents",
-          "when": "resourceLangId == dfdl"
+          "when": "!inDebugMode && editorLangId == 'dfdl'"
         },
         {
           "command": "extension.dfdl-debug.runEditorContents",
-          "when": "resourceLangId == dfdl"
+          "when": "!inDebugMode && editorLangId == 'dfdl'"
         },
         {
           "command": "extension.dfdl-debug.appendTDML",
-          "when": "resourceLangId == tdml"
+          "when": "!inDebugMode && ((editorLangId == 'tdml' && editorTextFocus) || activeEditor == 'tdml-editor.editor')"
         },
         {
           "command": "extension.dfdl-debug.executeTDML",
-          "when": "resourceLangId == tdml"
+          "when": "!inDebugMode && ((editorLangId == 'tdml' && editorTextFocus) || activeEditor == 'tdml-editor.editor')"
         },
         {
           "command": "extension.dfdl-debug.createTDML",
-          "when": "resourceLangId == dfdl"
+          "when": "true"
         },
         {
-          "command": "extension.data.edit"
+          "command": "extension.data.edit",
+          "when": "true"
         },
         {
           "command": "extension.dfdl-debug.debugLastEditorContents",
-          "when": "resourceLangId == dfdl"
+          "when": "!inDebugMode && editorLangId == 'dfdl'"
         },
         {
           "command": "tdml-editor.deleteTest",
@@ -306,19 +295,19 @@
         },
         {
           "command": "tdml-editor.addNewTest",
-          "when": "activeCustomEditorId == 'tdml-editor.editor'"
-        },
-        {
-          "command": "tdml-editor.openInTextEditor",
-          "when": "activeCustomEditorId == 'tdml-editor.editor'"
-        },
-        {
-          "command": "tdml-editor.openPreview",
           "when": "false"
         },
         {
+          "command": "tdml-editor.openInTextEditor",
+          "when": "activeEditor == 'tdml-editor.editor'"
+        },
+        {
+          "command": "tdml-editor.openPreview",
+          "when": "editorLangId == 'tdml' && editorTextFocus"
+        },
+        {
           "command": "tdml-editor.openInTdmlEditor",
-          "when": "(resourceExtname == '.tdml' || resourceExtname == '.tdml.xsd') && activeCustomEditorId != 'tdml-editor.editor'"
+          "when": "editorLangId == 'tdml' && editorTextFocus"
         }
       ],
       "debug/variables/context": [
@@ -343,34 +332,34 @@
         "command": "extension.dfdl-debug.debugEditorContents",
         "title": "Debug File",
         "category": "Daffodil Debug",
-        "enablement": "!inDebugMode",
+        "enablement": "!inDebugMode && editorLangId == 'dfdl'",
         "icon": "$(debug-alt)"
       },
       {
         "command": "extension.dfdl-debug.runEditorContents",
         "title": "Run File",
         "category": "Daffodil Debug",
-        "enablement": "!inDebugMode",
+        "enablement": "!inDebugMode && editorLangId == 'dfdl'",
         "icon": "$(play)"
       },
       {
         "command": "extension.dfdl-debug.debugLastEditorContents",
         "title": "Debug Last File",
         "category": "Daffodil Debug",
-        "enablement": "!inDebugMode",
+        "enablement": "!inDebugMode && editorLangId == 'dfdl'",
         "icon": "$(debug-alt)"
       },
       {
         "command": "extension.dfdl-debug.appendTDML",
         "title": "Append TDML",
         "category": "Daffodil Debug",
-        "enablement": "!inDebugMode"
+        "enablement": "!inDebugMode && ((editorLangId == 'tdml' && editorTextFocus) || activeEditor == 'tdml-editor.editor')"
       },
       {
         "command": "extension.dfdl-debug.executeTDML",
         "title": "Execute TDML",
         "category": "Daffodil Debug",
-        "enablement": "!inDebugMode"
+        "enablement": "!inDebugMode && ((editorLangId == 'tdml' && editorTextFocus) || activeEditor == 'tdml-editor.editor')"
       },
       {
         "command": "extension.dfdl-debug.createTDML",
@@ -388,14 +377,14 @@
         "command": "infoset.display",
         "title": "Display the infoset view",
         "category": "Daffodil Debug",
-        "enablement": "inDebugMode",
+        "enablement": "inDebugMode && editorLangId == 'dfdl'",
         "icon": "$(file-code)"
       },
       {
         "command": "infoset.diff",
         "title": "View infoset diff",
         "category": "Daffodil Debug",
-        "enablement": "inDebugMode",
+        "enablement": "inDebugMode && editorLangId == 'dfdl'",
         "icon": "$(diff)"
       },
       {
@@ -408,45 +397,53 @@
         "command": "launch.config",
         "title": "Configure launch.json",
         "category": "Daffodil Debug",
+        "enablement": "true",
         "icon": "$(debug-configure)"
       },
       {
         "command": "extension.data.edit",
         "title": "Data Editor",
-        "category": "Daffodil Debug"
+        "category": "Daffodil Debug",
+        "enablement": "true"
       },
       {
         "command": "position.goto",
         "title": "Go to position",
-        "category": "Daffodil Debug"
+        "category": "Daffodil Debug",
+        "enablement": "true"
       },
       {
         "command": "tdml-editor.deleteTest",
         "title": "Delete Resource",
-        "category": "TDML Editor"
+        "category": "TDML Editor",
+        "enablement": "false"
       },
       {
         "command": "tdml-editor.addNewTest",
         "title": "Add New Test",
-        "category": "TDML Editor"
+        "category": "TDML Editor",
+        "enablement": "false"
       },
       {
         "command": "tdml-editor.openInTextEditor",
         "title": "Open in Text Editor",
         "category": "TDML Editor",
-        "icon": "$(notebook-open-as-text)"
+        "icon": "$(notebook-open-as-text)",
+        "enablement": "activeEditor == 'tdml-editor.editor'"
       },
       {
         "command": "tdml-editor.openPreview",
         "title": "Open Preview",
         "category": "TDML Editor",
-        "icon": "$(open-preview)"
+        "icon": "$(open-preview)",
+        "enablement": "editorLangId == 'tdml' && editorTextFocus"
       },
       {
         "command": "tdml-editor.openInTdmlEditor",
         "title": "Open in TDML Editor",
         "category": "TDML Editor",
-        "icon": "$(notebook-render-output)"
+        "icon": "$(notebook-render-output)",
+        "enablement": "editorLangId == 'tdml' && editorTextFocus"
       }
     ],
     "keybindings": [

--- a/src/tests/suite/daffodil.test.ts
+++ b/src/tests/suite/daffodil.test.ts
@@ -173,10 +173,12 @@ suite('Daffodfil', () => {
     })
   })
 
-  suite('non-debug specifc commands', () => {
+  suite('non-debug specific commands', () => {
     const nonDebugSpecificCmds = [
       'extension.dfdl-debug.debugEditorContents',
       'extension.dfdl-debug.runEditorContents',
+      'extension.dfdl-debug.debugLastEditorContents',
+      'extension.dfdl-debug.executeTDML',
     ]
 
     // This breaks when the omega-edit tests run for some reason
@@ -201,7 +203,7 @@ suite('Daffodfil', () => {
     })
   })
 
-  suite('debug specifc commands', () => {
+  suite('debug specific commands', () => {
     const debugSpecificCmds = [
       'extension.dfdl-debug.toggleFormatting',
       'infoset.display',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,6 +3054,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jsep@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.4.0.tgz#19feccbfa51d8a79f72480b4b8e40ce2e17152f0"
+  integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
+
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"


### PR DESCRIPTION
Closes #1358 
Closes #1344

This PR is also meant to be a trial run for a PR template - please provide any feedback in #1374 

## Description

- Dynamically evaluate a command's enablement conditions for displaying it in the Daffodil Explorer Pane
- Unify all commands from all sources to have (mostly) the same enablement/when conditions
- Fix keywords used in enablement/when conditions to be common and succinct

## Wiki
- [ ] I have determined that no wiki updates are needed for these changes
- [x] I have added following documentation for these changes

Documented a slightly modified version of the screenshot in the wiki: https://github.com/apache/daffodil-vscode/wiki/Apache-Daffodil%E2%84%A2-Extension-for-Visual-Studio-Code:-v1.4.2-%E2%80%90-In-Development/_compare/a7845a450e81b2b07ea028cc96eda737e21d375e...d93088265b1834cbbc4be29a40e21c5194b99415

## Screenshots (if applicable)

Here is a spreadsheet containing all 18 of our extension's commands (not including the 2 commandsView commands that were separately getting filtered out). Conditions for when they should appear are showing at the top, except for the one bolded note. I have unified all commands on all locations (command palette, editor/title, editor/title/run, commands view) to be the same (except for the one note). Please review these as well and make sure that these all make sense.

<img width="1704" height="252" alt="image" src="https://github.com/user-attachments/assets/80710ec3-4f8f-4aaf-8023-3624834880b3" />

The keywords are variables/macros that appear in the context of the contributes/commands section in the package.json. The commands view keys off of a command's enablement field, and we have to supply the value to the parser so that it can evaluate the statements. These keys are internal values that VSCode is able to fill in when looking at something like the command palette, but it does not expose a way for us to read these values in our code.
