### PR TITLE
Set tdmlConfig.action to 'none' when testing daffodil

### DIFF
--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -32,15 +32,11 @@ suite('Daffodil Debugger', () => {
   // debugger options
   const DATA = path.join(PROJECT_ROOT, 'src/tests/data/test.txt')
   const XML_INFOSET_PATH = path.join(PROJECT_ROOT, 'testinfoset.xml')
-  const TDML_PATH = path.join(PROJECT_ROOT, 'tdmltest.tdml')
   const JSON_INFOSET_PATH = path.join(PROJECT_ROOT, 'testinfoset.json')
   const debuggers: vscode.Terminal[] = []
 
   const tdmlConf = {
-    action: 'generate',
-    name: 'tdmlConf',
-    description: 'testtdml',
-    path: TDML_PATH,
+    action: 'none',
   }
 
   const dataEditor: DataEditorConfig = {


### PR DESCRIPTION
The TDML file that was being created during the tests is no longer being created. The 'Invalid TDML Path Selected' notification should be showing up. We are running a test where we call getValidatedTDMLPath with a non-existent path. The correct result of this is the notification.