### PR TITLE
Resolved persistent profiler tooltip in the Data Editor

### DIFF
--- a/src/svelte/src/components/layouts/Tooltip.svelte
+++ b/src/svelte/src/components/layouts/Tooltip.svelte
@@ -63,6 +63,9 @@ limitations under the License.
   <span
     on:mouseenter={showTooltip ? NULL : renderTooltip}
     on:mouseleave={showTooltip ? renderTooltip : NULL}
+    on:focusout={() => {
+      showTooltip = false
+    }}
   >
     <slot />
   </span>


### PR DESCRIPTION
Added additional Tooltip event listener for when events occur which do not trigger the `on:mouseleave` listener.

Closes #1300 