### PR TITLE
Make tdmlConfig.path always use default value for generate

### DIFF
--- a/src/daffodilDebugger/debugger.ts
+++ b/src/daffodilDebugger/debugger.ts
@@ -24,6 +24,7 @@ import {
   getDefaultTDMLTestCaseName,
   getTmpTDMLFilePath,
 } from '../tdmlEditor/utilities/tdmlXmlUtils'
+import { outputChannel } from '../adapter/activateDaffodilDebug'
 
 // Function to get data file given a folder
 export async function getDataFileFromFolder(dataFolder: string) {
@@ -78,7 +79,12 @@ async function getTDMLConfig(
   if (config?.tdmlConfig?.action === 'generate') {
     config.tdmlConfig.name =
       config.tdmlConfig.name || getDefaultTDMLTestCaseName()
-    config.tdmlConfig.path = config.tdmlConfig.path || getTmpTDMLFilePath()
+    config.tdmlConfig.path = getTmpTDMLFilePath()
+
+    outputChannel.appendLine(
+      `TDML File generated at: ${config.tdmlConfig.path}`
+    )
+    outputChannel.show()
   }
 
   if (config?.tdmlConfig?.action !== 'execute' && config.data === '') {


### PR DESCRIPTION
Closes #1376 

## Description

@shanedell If you don't believe this is something we should merge in, hold off with merging until we can figure out at least an intermediate solution that we all agree on.

Hardcode path for TDML generate to always go into the /tmp directory. We should properly address this at some point post 1.4.2 release so that it will be configurable for Generate, Create, and Append.

Also puts a message in the Daffodil Output Channel containing the path to the generated file - could change that to a notification if it isn't loud enough.

## Wiki

- [ ] I have determined that no documentation updates are needed for these changes
- [x] I have added following documentation for these changes

Documented in wiki - diff here: https://github.com/apache/daffodil-vscode/wiki/Apache-Daffodil%E2%84%A2-Extension-for-Visual-Studio-Code:-v1.4.2-%E2%80%90-In-Development/_compare/8c5f447149f53adfe3b5eaeed90ea7a8b661269c...a7845a450e81b2b07ea028cc96eda737e21d375e