### PR TITLE
Added issue templates and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -1,0 +1,25 @@
+## Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behavior
+
+What did you expect to happen?
+
+## Actual behavior
+
+What actually happened?
+
+## Screenshots and additional context (optional) 
+
+## Environment
+
+- OS: 
+- Browser/VS Code version: 
+- Extension version: 

--- a/.github/ISSUE_TEMPLATE/Enhancement_Request.md
+++ b/.github/ISSUE_TEMPLATE/Enhancement_Request.md
@@ -1,0 +1,15 @@
+# Enhancement Request: [Concise Title of Enhancement]
+
+## Summary
+
+[Provide a brief, high-level overview of the proposed enhancement. What is it, and what problem does it solve?]
+
+## Proposed Solution / Description
+
+[Describe the enhancement in detail. How will it work? What are the key features or changes involved? Include any relevant technical details, design considerations, or user flows. You can use bullet points, numbered lists, and code blocks for clarity.]
+
+### Addtional Context
+
+-   **New Feature:** Add a search bar to the user dashboard.
+-   **Improved Workflow:** Streamline the data import process by adding a progress indicator.
+-   **Technical Changes:** Implement a new API endpoint for `GET /users/{id}/data`.

--- a/.github/ISSUE_TEMPLATE/Feature_Request,md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request,md
@@ -1,0 +1,38 @@
+# Feature Request: [Concise Title of the Feature]
+
+## Problem Description
+
+Clearly describe the problem or pain point this feature aims to solve. Explain the current limitations or challenges faced by users or the system.
+
+## Proposed Solution
+
+Detail the proposed solution for the feature. Describe how it will work, including key functionalities and user interactions. If applicable, mention any technical considerations or architectural changes.
+
+## User Stories (Optional but Recommended)
+
+Provide one or more user stories to illustrate how users will interact with and benefit from the feature.
+*   As a [type of user], I want to [action], so that [benefit].
+*   As a [type of user], I want to [action], so that [benefit].
+
+## Acceptance Criteria
+
+List the specific conditions that must be met for the feature to be considered complete and successful. These should be testable and measurable.
+*   [Criterion 1]
+*   [Criterion 2]
+*   [Criterion 3]
+
+## Impact and Benefits
+
+Explain the expected positive impact of this feature on users, the product, or the business. Quantify benefits where possible.
+
+## Alternatives Considered (Optional)
+
+If other solutions were explored and rejected, briefly describe them and explain why the chosen solution is preferred.
+
+## Dependencies (Optional)
+
+List any other features, systems, or data that this feature relies on.
+
+## Open Questions / Discussion Points (Optional)
+
+Include any unresolved questions or areas that require further discussion or clarification.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+Closes #(issue)
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Also include relevant context or motivation.
+
+## Wiki
+
+- [ ] I have determined that no wiki updates are needed for these changes
+- [ ] I have added documentation to the wiki for these changes
+
+## Review Instructions including Screenshots
+Add review instructions including screenshots or GIFs to help explain the change visually.


### PR DESCRIPTION
Closes #1374 

Let's review following issue templates 
 - Bug_Report
 - Enhancement_Request
 - Feature_Request

Let's review pull request template also as a part of this PR.  

Pull request template includes checkboxes for wiki documentation and we can enforce this by updating PR Workflow (for disallowing a merge if the checkbox isn't checked by adding following jon in CI.yaml file. 

Please share your thoughts on that. 

```
name: Enforce Wiki Checkbox

on:
  pull_request:
    types: [opened, edited, synchronize, reopened]

jobs:
  enforce-checkbox:
    runs-on: ubuntu-latest
    steps:
      - name: Check required confirmation checkbox
        uses: actions/github-script@v7
        with:
          script: |
            const prBody = context.payload.pull_request.body || "";
            const checkbox1Text = "- [x] I have determined that no wiki updates are needed for these changes";
            const checkbox2Text = "- [x] I have added documentation to the wiki for these changes";

            if (!prBody.includes(checkbox1Text) && !prBody.includes(checkbox2Text) {
              core.setFailed("❌ Required wiki checkbox not checked. Please check the box before merging.");
            } else {
              core.info("✅ Required wiki checkbox is checked.");
            }

```