### PR TITLE
Switch prompts for path from TDML generate to TDML execute in launch …

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "onCommand:extension.dfdl-debug.getSchemaName",
     "onCommand:extension.dfdl-debug.getDataName",
     "onCommand:extension.dfdl-debug.getTDMLName",
-    "onCommand:extension.dfdl-debug.getTDMLPath",
     "onCommand:extension.dfdl-debug.getValidatedTDMLPath",
     "onCommand:extension.dfdl-debug.getValidatedTDMLCopyPath"
   ],
@@ -576,7 +575,7 @@
                   },
                   "path": {
                     "type": "string",
-                    "default": "${command:AskForTDMLPath}",
+                    "default": "${command:AskForValidatedTDMLPath}",
                     "description": "TDML Case Path"
                   }
                 },
@@ -788,7 +787,8 @@
                 "path": "^\"\\${workspaceFolder}/target/infoset.xml\""
               },
               "tdmlConfig": {
-                "action": "generate"
+                "action": "generate",
+                "name": "Default Test Case"
               },
               "debugServer": 4711,
               "openDataEditor": false,
@@ -816,7 +816,6 @@
         "variables": {
           "AskForSchemaName": "extension.dfdl-debug.getSchemaName",
           "AskForDataName": "extension.dfdl-debug.getDataName",
-          "AskForTDMLPath": "extension.dfdl-debug.getTDMLPath",
           "AskForValidatedTDMLPath": "extension.dfdl-debug.getValidatedTDMLPath",
           "AskForValidatedTDMLCopyPath": "extension.dfdl-debug.getValidatedTDMLCopyPath"
         }

--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -440,22 +440,6 @@ export function activateDaffodilDebug(
     )
   )
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'extension.dfdl-debug.getTDMLPath',
-      async (_) => {
-        return await vscode.window
-          .showInputBox({
-            prompt: 'TDML File: ',
-            value: '${workspaceFolder}/infoset.tdml',
-          })
-          .then((value) => {
-            return value
-          })
-      }
-    )
-  )
-
   // register a configuration provider for 'dfdl' debug type
   const provider = new DaffodilConfigurationProvider(context)
   context.subscriptions.push(

--- a/src/daffodilDebugger/debugger.ts
+++ b/src/daffodilDebugger/debugger.ts
@@ -58,13 +58,18 @@ async function getTDMLConfig(
     config.data = ''
     config.schema.path = ''
 
-    config.tdmlConfig.path =
-      config.tdmlConfig.path ||
-      (await vscode.commands.executeCommand(
+    if (
+      config.tdmlConfig.path === '${command:AskForValidatedTDMLPath}' ||
+      !config.tdmlConfig.path
+    ) {
+      config.tdmlConfig.path = await vscode.commands.executeCommand(
         'extension.dfdl-debug.getValidatedTDMLPath'
-      ))
+      )
+    }
 
-    if (!config.tdmlConfig.path) return false
+    if (!config.tdmlConfig.path) {
+      return false
+    }
 
     config.tdmlConfig.name =
       config.tdmlConfig.name ||

--- a/src/launchWizard/launchWizard.ts
+++ b/src/launchWizard/launchWizard.ts
@@ -495,8 +495,16 @@ class LaunchWizard {
       }
     })
 
-    let tdmlActionSelect = 'none'
-    let tdmlActions = ['none', 'generate', 'execute']
+    const TDML_EXECUTE_ACTION = 'execute'
+    const TDML_NONE_ACTION = 'none'
+    const TDML_GENERATE_ACTION = 'generate'
+
+    let tdmlActionSelect = TDML_NONE_ACTION
+    let tdmlActions = [
+      TDML_NONE_ACTION,
+      TDML_GENERATE_ACTION,
+      TDML_EXECUTE_ACTION,
+    ]
     let tdmlAction =
       'tdmlConfig' in defaultValues ? defaultValues.tdmlConfig['action'] : null
     let tdmlName =
@@ -510,11 +518,11 @@ class LaunchWizard {
 
     // tdml items need 0 height and width when hidden so there is no large empty space
     let tdmlNameDesVisOrHiddenStyle =
-      tdmlAction !== null && tdmlAction !== 'none' // Hide TDML name and desc fields if tdmlAction is none
+      tdmlAction !== null && tdmlAction !== TDML_NONE_ACTION // Hide TDML name and desc fields if tdmlAction is none
         ? 'margin-top: 10px; visibility: visible;'
         : 'width: 0px; height: 0px; visibility: hidden'
     let tdmlPathVisOrHiddenStyle =
-      tdmlAction === 'generate'
+      tdmlAction === TDML_EXECUTE_ACTION
         ? 'margin-top: 10px; visibility: visible;'
         : 'width: 0px; height: 0px; visibility: hidden'
 
@@ -729,7 +737,7 @@ class LaunchWizard {
 
       <div id="tdmlActionDiv" class="setting-div">
         <p>TDML Action:</p>
-        <p class="setting-description">TDML Action (none | generate | execute)</p>
+        <p class="setting-description">TDML Action (${TDML_NONE_ACTION} | ${TDML_GENERATE_ACTION} | ${TDML_EXECUTE_ACTION})</p>
         <select onChange="updateTDMLAction()" class="file-input" style="width: 200px;" id="tdmlAction">
           ${tdmlActionSelect}
         </select>

--- a/src/launchWizard/script.js
+++ b/src/launchWizard/script.js
@@ -226,11 +226,16 @@ function updateTDMLAction() {
       'width: 0px; height: 0px; visibility: hidden;'
   }
 
-  if (tdmlSelectedValue === 'generate') {
+  if (tdmlSelectedValue === 'execute') {
     document.getElementById('tdmlPathLabel').style =
       'margin-top: 10px; visibility: visible;'
     document.getElementById('tdmlPath').style =
       'margin-top: 10px; visibility: visible;'
+
+    // Catch case when we switch from another TDML action to execute and it shows undefined b/c path is not in tdmlConfig object
+    if (document.getElementById('tdmlPath').value === 'undefined') {
+      document.getElementById('tdmlPath').value = ''
+    }
   } else {
     document.getElementById('tdmlPathLabel').style =
       'width: 0px; height: 0px; visibility: hidden;'
@@ -314,9 +319,9 @@ function save() {
   switch (configValues.tdmlAction) {
     case 'none':
       break
-    case 'generate':
-      obj.configurations[0].tdmlConfig.path = configValues.tdmlPath
     case 'execute':
+      obj.configurations[0].tdmlConfig.path = configValues.tdmlPath
+    case 'generate':
       obj.configurations[0].tdmlConfig.name = configValues.tdmlName
       break
     default:

--- a/src/tests/suite/utils.test.ts
+++ b/src/tests/suite/utils.test.ts
@@ -18,7 +18,6 @@
 import * as assert from 'assert'
 import * as utils from '../../utils'
 import { VSCodeLaunchConfigArgs } from '../../classes/vscode-launch'
-import { getTmpTDMLFilePath } from 'tdmlEditor/utilities/tdmlXmlUtils'
 
 suite('Utils Test Suite', () => {
   var name = 'Default Config'
@@ -44,7 +43,7 @@ suite('Utils Test Suite', () => {
     tdmlConfig: {
       action: 'generate',
       name: 'Default Test Case',
-      path: getTmpTDMLFilePath(),
+      path: '${command:AskForValidatedTDMLPath}',
     },
     stopOnEntry: true,
     useExistingServer: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,6 @@ import * as child_process from 'child_process'
 import path from 'path'
 import { VSCodeLaunchConfigArgs } from './classes/vscode-launch'
 import { InfosetOutput } from './daffodilDebugger'
-import { getTmpTDMLFilePath } from './tdmlEditor/utilities/tdmlXmlUtils'
 import { XMLParser } from 'fast-xml-parser'
 
 let currentConfig: vscode.DebugConfiguration
@@ -139,7 +138,7 @@ export function getConfig(jsonArgs: object): vscode.DebugConfiguration {
       ...{
         action: 'generate',
         name: 'Default Test Case',
-        path: getTmpTDMLFilePath(),
+        path: '${command:AskForValidatedTDMLPath}',
       },
       ...((defaultConf.get('tdmlConfig') as object) || {}),
     },


### PR DESCRIPTION
…config.

Add Default Test Case name when adding config with the blue Add Configuration... button

Closes #1347

### Description

Refer to #1347

### Wiki

- [ ] I have determined that no wiki updates are needed for these changes
   - yes, updates are needed
- [x] I have added following documentation for these changes
   - See https://github.com/apache/daffodil-vscode/pull/1403#issuecomment-3292625611 for more details


### How to test (sample test case)

#### Example Files

[test_images.zip](https://github.com/user-attachments/files/22125186/test_images.zip)

#### Validating generate still works

0. Delete launch.json if it exists
1. Open the launch config wizard. 
2. Ensure no path field shows for generate

<img width="465" height="205" alt="image" src="https://github.com/user-attachments/assets/a129c6b1-6f33-4151-9c1c-53bdebd8f5e1" />

3. Save the config. You should have something that looks like 

<img width="690" height="891" alt="image" src="https://github.com/user-attachments/assets/9511d574-a5a4-4611-9ce3-9a456f0194a4" />

4. Run `Wizard Config` and select a sample DFDL file and data file

6. Navigate to your OS's temp directory and verify generatedTDML.tdml was created and/or updated after the DFDL debugging session is over 

<img width="734" height="139" alt="image" src="https://github.com/user-attachments/assets/fa9c6fcf-a075-4398-b5c7-bbf2bd9b4c1f" />

7. Create the TDML file 

<img width="247" height="160" alt="image" src="https://github.com/user-attachments/assets/c4664a49-0432-4742-adc9-33a7ee94f602" />

I named the TDML file `1347.tdml`

#### Validate Execute

1. Go back to `Wizard Config`
2. Select TDML action to be execute
3. Type in the path to the TDML file previously created

<img width="478" height="218" alt="image" src="https://github.com/user-attachments/assets/75456249-ee4e-4d7f-9963-815dfd48ab12" />

4. Run the config

#### Execute with blank string in path

1. Create new config

<img width="425" height="405" alt="image" src="https://github.com/user-attachments/assets/6a904274-d16e-45bc-861b-aa2ad1bb83b7" />

2. Set execute to empty string path 

<img width="456" height="240" alt="image" src="https://github.com/user-attachments/assets/1ffb0b88-fe83-4317-afb2-2ee162dcf916" />

The following config item should be added 
```JSON
{
            "request": "launch",
            "type": "dfdl",
            "name": "Wizard Config 2",
            "schema": {
                "path": "${command:AskForSchemaName}",
                "rootName": null,
                "rootNamespace": null
            },
            "data": "${command:AskForDataName}",
            "debugServer": 4711,
            "infosetFormat": "xml",
            "infosetOutput": {
                "type": "file",
                "path": "${workspaceFolder}/target/infoset.xml"
            },
            "tdmlConfig": {
                "action": "execute",
                "path": "",
                "name": "Default Test Case"
            },
            "trace": true,
            "stopOnEntry": true,
            "useExistingServer": false,
            "openDataEditor": false,
            "openInfosetView": false,
            "openInfosetDiffView": false,
            "daffodilDebugClasspath": [],
            "dataEditor": {
                "port": 9000,
                "logging": {
                    "file": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
                    "level": "info"
                }
            },
            "dfdlDebugger": {
                "logging": {
                    "file": "${workspaceFolder}/daffodil-debugger.log",
                    "level": "INFO"
                }
            }
        }
```

3. Run this config
4. Validate prompt for .tdml file pops up
5. Select a .tdml file that has a test case name of `Default Test Case` (example `1347.tdml` created in prior step)
6. Verify debugging session runs smoothly

#### Execute with ${AskForValidatedTDMLPath}

Follow steps above, but use this launch config as mentioned in https://github.com/apache/daffodil-vscode/pull/1403#issuecomment-3271741062 instead 




