### PR TITLE
Update checkout action to version 5.0.0

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Checkout Repository
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
+        uses: actions/checkout@v5.0.0
 
       - name: ASF Release Candidate
         id: rc


### PR DESCRIPTION
Sync actions/checkout release version of release-candidate CI with the rest of the CI workflows, which are using v5.0.0.