### PR TITLE
Add the ability to trigger CI with a PR number

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,20 @@ on:
     branches-ignore: ["dependabot/**"]
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to verify (e.g., 1400)'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ci-${{ github.event_name }}-${{ inputs.pr || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   single-commit:
@@ -58,9 +72,63 @@ jobs:
       ############################################################
       # Setup
       ############################################################
+      - name: Resolve PR metadata
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Handle workflow_dispatch, pull_request, and fallback (push/other)
+            if (context.eventName === 'workflow_dispatch') {
+              const raw = (context.payload.inputs && context.payload.inputs.pr) || '';
+              const prNumber = Number(raw);
+              if (!Number.isFinite(prNumber) || prNumber <= 0) {
+                core.setFailed("Missing or invalid 'pr' input for workflow_dispatch.");
+                return;
+              }
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              if (pr.state !== 'open') {
+                core.setFailed(`PR #${prNumber} is not open (state=${pr.state}).`);
+                return;
+              }
+              core.setOutput('head_repo', pr.head.repo.full_name);
+              core.setOutput('head_ref',  pr.head.ref);
+              core.setOutput('head_sha',  pr.head.sha);
+              core.info(`Verifying PR #${prNumber} from ${pr.head.repo.full_name}:${pr.head.ref} @ ${pr.head.sha}`);
+              return;
+            }
 
-      - name: Check out Repository
+            if (context.eventName === 'pull_request') {
+              const prNumber = context.issue.number;
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              core.setOutput('head_repo', pr.head.repo.full_name);
+              core.setOutput('head_ref',  pr.head.ref);
+              core.setOutput('head_sha',  pr.head.sha);
+              core.info(`Resolved PR #${prNumber} from ${pr.head.repo.full_name}:${pr.head.ref} @ ${pr.head.sha}`);
+              return;
+            }
+
+            // Fallback for push/other events
+            core.setOutput('head_repo', `${context.repo.owner}/${context.repo.repo}`);
+            core.setOutput('head_ref',  process.env.GITHUB_REF || context.ref || '');
+            core.setOutput('head_sha',  context.sha);
+            core.info(`Non-PR event; using ${context.repo.owner}/${context.repo.repo}:${process.env.GITHUB_REF || context.ref} @ ${context.sha}`);
+
+      - name: Check out repository (PR head or repo)
         uses: actions/checkout@v5.0.0
+        with:
+          repository: ${{ steps.meta.outputs.head_repo }}
+          ref: ${{ steps.meta.outputs.head_sha || steps.meta.outputs.head_ref || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
 
       - name: Setup Java
         uses: actions/setup-java@v4.7.1
@@ -72,6 +140,11 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
 
       ############################################################
       # Lint/format checks
@@ -84,7 +157,7 @@ jobs:
         run: $SBT scalafmtSbtCheck
 
       - name: Install node dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: TypeScript lint
         run: yarn lint
@@ -109,9 +182,63 @@ jobs:
       ############################################################
       # Setup
       ############################################################
+      - name: Resolve PR metadata
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Handle workflow_dispatch, pull_request, and fallback (push/other)
+            if (context.eventName === 'workflow_dispatch') {
+              const raw = (context.payload.inputs && context.payload.inputs.pr) || '';
+              const prNumber = Number(raw);
+              if (!Number.isFinite(prNumber) || prNumber <= 0) {
+                core.setFailed("Missing or invalid 'pr' input for workflow_dispatch.");
+                return;
+              }
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              if (pr.state !== 'open') {
+                core.setFailed(`PR #${prNumber} is not open (state=${pr.state}).`);
+                return;
+              }
+              core.setOutput('head_repo', pr.head.repo.full_name);
+              core.setOutput('head_ref',  pr.head.ref);
+              core.setOutput('head_sha',  pr.head.sha);
+              core.info(`Verifying PR #${prNumber} from ${pr.head.repo.full_name}:${pr.head.ref} @ ${pr.head.sha}`);
+              return;
+            }
 
-      - name: Check out Repository
+            if (context.eventName === 'pull_request') {
+              const prNumber = context.issue.number;
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              core.setOutput('head_repo', pr.head.repo.full_name);
+              core.setOutput('head_ref',  pr.head.ref);
+              core.setOutput('head_sha',  pr.head.sha);
+              core.info(`Resolved PR #${prNumber} from ${pr.head.repo.full_name}:${pr.head.ref} @ ${pr.head.sha}`);
+              return;
+            }
+
+            // Fallback for push/other events
+            core.setOutput('head_repo', `${context.repo.owner}/${context.repo.repo}`);
+            core.setOutput('head_ref',  process.env.GITHUB_REF || context.ref || '');
+            core.setOutput('head_sha',  context.sha);
+            core.info(`Non-PR event; using ${context.repo.owner}/${context.repo.repo}:${process.env.GITHUB_REF || context.ref} @ ${context.sha}`);
+
+      - name: Check out repository (PR head or repo)
         uses: actions/checkout@v5.0.0
+        with:
+          repository: ${{ steps.meta.outputs.head_repo }}
+          ref: ${{ steps.meta.outputs.head_sha || steps.meta.outputs.head_ref || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
 
       - name: Setup Java
         uses: actions/setup-java@v4.7.1
@@ -127,13 +254,15 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       ############################################################
       # Build & Package
       ############################################################
 
       - name: Install node dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Runs tests - Linux
         run: xvfb-run -a yarn test

--- a/.github/workflows/licenes.yml
+++ b/.github/workflows/licenes.yml
@@ -82,9 +82,11 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: ${{ matrix.node }}
-
+          cache: yarn
+          cache-dependency-path: yarn.lock
+  
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       ############################################################
       # Node Missing LICENSE Data Check
@@ -117,9 +119,11 @@ jobs:
         uses: actions/setup-node@v4.4.0
         with:
           node-version: ${{ matrix.node }}
-      
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       ############################################################
       # Node LICENSE Compatibility Check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,7 @@ jobs:
       ############################################################
 
       - name: Install node dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Runs tests - Linux
         run: xvfb-run -a yarn test

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -62,9 +62,11 @@ jobs:
         uses: actions/setup-node@5e2628c959b9ade56971c0afcebbe5332d44b398 # v4.4.0
         with:
           node-version: 20
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: Install node dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Create Binary Artifacts
         run: |


### PR DESCRIPTION
Adds the ability to trigger CI given a PR number. This will help us clear the PR backlog especially for those PRs that lack CI verification (like scala-steward).

closes #1406