### PR TITLE
Make it clear that the output stream chunk is 4KB in Parse.scala

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
@@ -95,9 +95,12 @@ object Parse {
       done <- Ref[IO].of(false)
       pleaseStop <- Deferred[IO, Unit]
     } yield new Parse {
+      // Define run function associated w/ Parse instances
       def run(): Stream[IO, Byte] =
+        // Note that .drain() and .through() being called on this do not consume data
         fs2.io
-          .readOutputStream(4096) { os =>
+          .readOutputStream(4096) { os => // Sufficiently sized 4KB chunk size for consumption process.
+
             val stopper =
               pleaseStop.get *> IO.canceled // will cancel the concurrent parse effect
 


### PR DESCRIPTION
Closes #712

## Description

Small change-- make it clear that 4096 refers to 4KB

## Wiki

- [x] I have determined that no wiki updates are needed for these changes
- [ ] I have added documentation to the wiki for these changes

## Review Instructions including Screenshots

N/A