### PR TITLE
Fix documentation workflow to ignore pull requests from dependabot and scala-steward

### DIFF
--- a/.github/workflows/documentaion.yml
+++ b/.github/workflows/documentaion.yml
@@ -17,19 +17,18 @@
 name: Enforce Documentation Checkbox
 
 on:
-  push:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
     branches-ignore:
       - "dependabot/**" # dependabot PRs/branches
       - "update/**" # scala-steward PRs/branches
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
 
 jobs:
   enforce-checkbox:
     runs-on: ubuntu-22.04
     steps:
       - name: Check required confirmation checkbox
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const prBody = context.payload.pull_request.body || "";


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->

## Description

Update documentation workflow

- Make it so documentation workflow does not run on pull requests for dependabot or scala-steward.
- Update actions/github-script to use hash instead oof version.
- Make workflow only run on pull_requests and not on push.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes

[List added wiki/docs documentaion here for review, if applicable]

## Review Instructions including Screenshots

No real instructions since it strictly related to GitHub workflows.
