### PR TITLE
Auto detect the data file when the data editor is opened

### DIFF
--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -24,12 +24,7 @@ import {
   WorkspaceFolder,
 } from 'vscode'
 import { getDataFileFromFolder, getDebugger } from '../daffodilDebugger'
-import {
-  getConfig,
-  getCurrentConfig,
-  getTDMLTestCaseItems,
-  setCurrentConfig,
-} from '../utils'
+import { getConfig, getCurrentConfig, getTDMLTestCaseItems } from '../utils'
 import { FileAccessor } from './daffodilRuntime'
 import { TDMLConfig } from '../classes/tdmlConfig'
 import { handleDebugEvent } from './daffodilEvent'
@@ -657,14 +652,14 @@ class DaffodilConfigurationProvider
     ) {
       return getDataFileFromFolder(dataFolder).then((dataFile) => {
         config.data = dataFile
-        return getDebugger(this.context, config).then((updatedConfig) => {
-          return setCurrentConfig(updatedConfig ?? config)
+        return getDebugger(this.context, config).then((_) => {
+          return getCurrentConfig()
         })
       })
     }
 
-    return getDebugger(this.context, config).then((updatedConfig) => {
-      return setCurrentConfig(updatedConfig ?? config)
+    return getDebugger(this.context, config).then((_) => {
+      return getCurrentConfig()
     })
   }
 }

--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -84,6 +84,7 @@ import {
 import { getCurrentHeartbeatInfo } from './include/server/heartbeat'
 import * as child_process from 'child_process'
 import { osCheck } from '../utils'
+import { getCurrentConfig } from '../utils'
 
 // *****************************************************************************
 // global constants
@@ -119,7 +120,11 @@ export function activate(ctx: vscode.ExtensionContext): void {
       DATA_EDITOR_COMMAND,
       async (fileToEdit: string = '') => {
         let configVars = editor_config.extractConfigurationVariables()
-        return await createDataEditorWebviewPanel(ctx, configVars, fileToEdit)
+        return await createDataEditorWebviewPanel(
+          ctx,
+          configVars,
+          vscode.debug.activeDebugSession ? getCurrentConfig().data : fileToEdit
+        )
       }
     )
   )


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-->

Closes #1362

## Description

When running a parse from a launch config and the openDataEditor flag is set to true, the data editor would prompt the user for the data file, even though it could be inferred from the launch config.

Additionally, when opening the data editor via the command palette while in an active debug session, the user would be prompted for the data file, even though it could be inferred based on the config from the active debugging session.

In both of these cases, the data editor will now infer which data file to open. However, when there is no active debug session, the data editor will still prompt the user for which file to open.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes

On my Linux environment, I couldn't get the data editor to load. I'm pretty sure (but not 100% - will confirm soon) I'm seeing this on main as well. I'm seeing this notification. I know that the file path is correct because it will show up in the top left of the data editor along with mime type, file size, etc.

<img width="555" height="123" alt="image" src="https://github.com/user-attachments/assets/342951dc-f2a0-44a4-9ce3-ed8648f08195" />

