### PR TITLE
DAPodil comm timeout error

### DIFF
--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
@@ -487,7 +487,7 @@ object DAPodil extends IOApp {
         .recoverWith {
           // format: off
           case _: SocketTimeoutException =>
-            Logger[IO].warn(s"timed out listening for connection on $uri, exiting").as(ExitCode.Error)
+            Logger[IO].error(s"timed out listening for connection on $uri, exiting").as(ExitCode.Error)
           // format: on
         }
 


### PR DESCRIPTION
Closes #18 

## Description

Changed timeout warning to error. The Terminal window contains detailed info about the problem that caused the failure and the ECONNREFUSED pop-up.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots
To easily test this change, temporarily change DAPodil.scala line 478 by adding a "+1" as shown below and rebuild. This will force the code to open a port at one address, but look for it on a different one.
<img width="929" height="210" alt="image" src="https://github.com/user-attachments/assets/91d8da72-eda9-4bc7-a0d1-cbdce4ca0670" />
