### PR TITLE
Updated DataEditorClient disposal ordering.

### DIFF
--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -154,8 +154,8 @@ export class DataEditorClient implements vscode.Disposable {
     })
     this.panel.webview.onDidReceiveMessage(this.messageReceiver, this)
     this.panel.onDidDispose(async () => {
-      await removeActiveSession(this.omegaSessionId)
       await this.dispose()
+      await removeActiveSession(this.omegaSessionId)
     })
     this.disposables.push(
       this.panel,

--- a/src/dataEditor/include/server/Sessions.ts
+++ b/src/dataEditor/include/server/Sessions.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { destroySession, getSessionCount } from '@omega-edit/client'
+import { destroySession, getLogger, getSessionCount } from '@omega-edit/client'
 import { updateHeartbeatInterval } from './heartbeat'
 import { serverStop } from '../../dataEditorClient'
 
@@ -35,6 +35,10 @@ export async function removeActiveSession(sessionId: string) {
 
   // Only stop the server if there are no active sessions
   if ((await getSessionCount()) === 0) {
+    getLogger().info(
+      { fn: 'DataEditorClient::removeActiveSession' },
+      'Stopping server!'
+    )
     await serverStop()
   }
 }


### PR DESCRIPTION
Closes #1428 

## Description

Moved the DataEditorClient's disposal function above the session removal function as this was interfering with the heartbeat / shutdown process for Omega Edit.

## Wiki

- [ ] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots
Run the extension

Start a Data Editor session

Exit the entire VSCode window

Repeat steps 1 & 2 and the data editors should open without an issue.
  - For Windows, the terminal window opened by the gRPC Omega Edit server should close.
  - For Unix, no process associated with the Omega Edit server should be active.
