### PR TITLE
Updating workflow operation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,6 @@
 ---
 name: CI
 on:
-  push:
-    branches-ignore: ["dependabot/**"]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/documentaion.yml
+++ b/.github/workflows/documentaion.yml
@@ -25,6 +25,8 @@ on:
 
 jobs:
   enforce-checkbox:
+    # this if is to further ensure that this job won't run on dependabot or scala-steward PRs
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-22.04
     steps:
       - name: Check required confirmation checkbox

--- a/.github/workflows/licenes.yml
+++ b/.github/workflows/licenes.yml
@@ -16,8 +16,6 @@
 ---
 name: LICENES CI
 on:
-  push:
-    branches-ignore: ["dependabot/**"]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -21,6 +21,10 @@ on:
 
 name: Scala Steward CI
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   scala-steward:
     if: github.repository == 'apache/daffodil-vscode'


### PR DESCRIPTION
## Description

Updating workflow operation

- Update workflows to only run on pull_requests.
  - This will significantly reduce the amount of CI jobs being ran, especially for the main CI workflow.
- Update the documentation workflow to add another fail safe to ensure the enforce-checkbox job does not run on dependabot and scala-steward PRs.
- Add a permissions section to scala-steward to see if it will make the PRs automatically run CI.

### Workflows only running on pull_requests justification

The reason for updating the workflows to only run on pull_requests is to significantly reduce the amount of CI jobs being ran for a PR. Whenever a PR was being open all workflows were running 2 times, 1 for the push and 1 for PR.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes
