### PR TITLE
Make Infoset Not Automatically Open

### DIFF
--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -205,20 +205,6 @@ async function createDebugRunFileConfigs(
 
       vscode.debug.startDebugging(undefined, config, { noDebug: noDebug })
     }
-
-    vscode.debug.onDidTerminateDebugSession(async () => {
-      if (!vscode.workspace.workspaceFolders) {
-        return
-      }
-
-      vscode.workspace
-        .openTextDocument(
-          `${vscode.workspace.workspaceFolders[0].uri.fsPath}/${infosetFile}`
-        )
-        .then((doc) => {
-          vscode.window.showTextDocument(doc)
-        })
-    })
   }
 }
 


### PR DESCRIPTION
Closes #1421 

## Description

Made the infoset not automatically open for consistency. This also fixes the issue with the schema file in preview mode closing when the debug session ends.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots

1. Start a debugging session from the command palette.
2. Continue through the debug session until it ends.
3. Ensure the infoset does not automatically open and the following popup appears at the bottom and the infoset opens when the open button is clicked.
<img width="394" height="99" alt="image" src="https://github.com/user-attachments/assets/7e3f806c-90e2-49aa-a07d-94a270f0c9e1" />

4. Go back and repeat steps 1-3 but instead start a debug session using a launch.json file. 

Additionally, test that a file in preview mode is not closed when the debug session ends when started from the command palette. To open a file in preview mode, single click the file in the file explorer. The label for the file tab should be in italics and say in preview mode when hovered over.
