### PR TITLE
Fixed Data Editor inconsistent themes

### DIFF
--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -1048,7 +1048,7 @@ class DisplayState {
     vscode.window.onDidChangeActiveColorTheme(async (event) => {
       this.colorThemeKind = event.kind
       await this.sendUIThemeUpdate()
-    })
+    }, this)
     this.sendUIThemeUpdate()
   }
 

--- a/src/svelte/src/App.svelte
+++ b/src/svelte/src/App.svelte
@@ -65,8 +65,6 @@ limitations under the License.
   import { byte_count_divisible_offset } from './utilities/display'
   import Help from './components/layouts/Help.svelte'
 
-  $: $UIThemeCSSClass = $darkUITheme ? CSSThemeClass.Dark : CSSThemeClass.Light
-
   function requestEditedData() {
     if ($requestable) {
       vscode.postMessage({
@@ -296,6 +294,9 @@ limitations under the License.
 
       case MessageCommand.setUITheme:
         $darkUITheme = msg.data.theme === 2
+        $UIThemeCSSClass = $darkUITheme
+          ? CSSThemeClass.Dark
+          : CSSThemeClass.Light
         break
       case MessageCommand.viewportRefresh:
         // the viewport has been refreshed, so the editor views need to be updated


### PR DESCRIPTION
Closes #1449

## Description

Fix for inconsistent color themes in the Data Editor UI.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots
1. Start the Extension
2. Open the Data Editor
3. Open the VSCode Color Theme Selector (_Ctrl + K, Ctrl+T_)
4. Cycle through the variety of available color themes to witness the inconsistencies between each theme.

> **NOTE:** Use the up / down arrow keys to have VSCode apply the color theme in focus while selecting a theme.
