### PR TITLE
Remove duplicate data editor panel disposal calls

### DIFF
--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -157,11 +157,6 @@ export class DataEditorClient implements vscode.Disposable {
     this.panel = panel
     this.panel.webview.onDidReceiveMessage(this.messageReceiver, this)
 
-    this.panel.onDidDispose(async () => {
-      await this.dispose()
-      await removeActiveSession(this.omegaSessionId)
-    })
-
     this.disposables = [
       this.panel,
       vscode.debug.onDidReceiveDebugSessionCustomEvent(async (e) => {
@@ -229,6 +224,7 @@ export class DataEditorClient implements vscode.Disposable {
       await removeActiveSession(editor.sessionId())
       await editor.dispose()
     })
+
     if (isDFDLDebugSessionActive()) {
       editor.addDisposable(
         vscode.debug.onDidTerminateDebugSession(async () => {


### PR DESCRIPTION
Closes #1461

## Description

This change removes the duplicate disposal behavior as observed in https://github.com/apache/daffodil-vscode/issues/1461#issuecomment-3398455824. More specifically, remove duplicate removeActiveSession() calls.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots

**_PLEASE TEST ON MULTIPLE OS-es!!!!!!_** 
**_PLEASE TEST ON MULTIPLE OS-es!!!!!!_** 
**_PLEASE TEST ON MULTIPLE OS-es!!!!!!_** 
**_PLEASE TEST ON MULTIPLE OS-es!!!!!!_** 
**_PLEASE TEST ON MULTIPLE OS-es!!!!!!_** 

### Windows 10/11

Follow the `Steps to Reproduce` section in https://github.com/apache/daffodil-vscode/issues/1461. 

Verify that when you close on of the data editor windows. The background `java` cmd window doesn't close. 

Also verify the DE functionality of the opened DE window(s) work. 

### Other OS-es
Open multiple data editor windows as outlined in the `Steps to Reproduce` section in https://github.com/apache/daffodil-vscode/issues/1461. 

Verify that when you close on of the data editor windows the DE functionality of the opened DE window(s) work. 