### PR TITLE
Document IntelliSense AttributeHoverProvider + relevant files

### DIFF
--- a/src/language/intellisense-development.md
+++ b/src/language/intellisense-development.md
@@ -39,6 +39,7 @@ This document contains an overview of how Intellisense works, as well as a gener
       - [Individual File Deep-Dives](#individual-file-deep-dives)
         - [Core Provider Files](#core-provider-files)
           - [attributeCompletion.ts](#attributecompletionts)
+          - [attributeHover.ts](#attributehoverts)
           - [attributeValueCompletion.ts](#attributevaluecompletionts)
         - [Intellisense Data Files (intellisense subdirectory)](#intellisense-data-files-intellisense-subdirectory)
           - [attributeItems.ts](#attributeitemsts)
@@ -149,6 +150,30 @@ Hover tooltips can be found under `attributeHoverValues()` in `attributeHoverIte
 - `prunedDuplicateAttributes()`: Removes attributes already present on the element
 
 **Trigger:** Space (` `) or newline (`\n`)
+
+##### attributeHover.ts
+
+**Purpose:** Hover provider that displays documentation tooltips when users hover over DFDL/XSD attribute names. The attribute's tooltips are obtained from `attributeItems.ts`
+
+**Key Functionality:**
+
+- Provides rich formatted documentation for DFDL properties and XSD attributes
+- Displays attribute descriptions, valid values, usage examples, and spec references
+- Handles both prefixed (dfdl:property) and unprefixed attribute names
+- Quick reference without leaving the editor
+
+**Documentation Categories:**
+
+- XSD Core Attributes (name, ref, minOccurs, maxOccurs)
+- DFDL Length Properties (dfdl:length, dfdl:lengthKind, dfdl:lengthUnits)
+- DFDL Encoding (dfdl:encoding, dfdl:utf16Width)
+- DFDL Binary/Text Properties (dfdl:binaryNumberRep, dfdl:textNumberPattern)
+- DFDL Delimiters (dfdl:separator, dfdl:terminator, dfdl:initiator)
+- DFDL Assertions (testKind, test, testPattern)
+
+**Provider Registered:**
+
+- `getAttributeHoverProvider()`: For DFDL documents
 
 ###### attributeValueCompletion.ts
 

--- a/src/language/providers/attributeHover.ts
+++ b/src/language/providers/attributeHover.ts
@@ -15,9 +15,41 @@
  * limitations under the License.
  */
 
+/**
+ * Attribute Hover Provider for DFDL Documents
+ *
+ * This module provides documentation tooltips when users hover over DFDL attribute names
+ * in XML elements. It displays helpful information including:
+ * - Attribute description and purpose
+ * - Valid values and their meanings
+ * - Usage examples
+ * - Default values and behaviors
+ *
+ * Features:
+ * - Rich formatted hover text with markdown support
+ * - Context-sensitive documentation for DFDL properties
+ * - Handles both prefixed (dfdl:property) and unprefixed attribute names
+ * - Quick reference without leaving the editor
+ *
+ * The hover information is displayed automatically when the user positions their cursor
+ * over a DFDL attribute name in the schema.
+ */
+
 import * as vscode from 'vscode'
 import { attributeCompletion } from './intellisense/attributeItems'
 
+/**
+ * Registers the hover provider for DFDL attribute documentation.
+ *
+ * This provider displays documentation when users hover over DFDL attribute names.
+ * It works by:
+ * 1. Detecting the word under the cursor
+ * 2. Checking if it's a valid DFDL attribute name
+ * 3. Adding the 'dfdl:' prefix if not already present
+ * 4. Displaying attribute's hover tooltip
+ *
+ * @returns A VS Code Disposable for the registered hover provider
+ */
 export function getAttributeHoverProvider() {
   return vscode.languages.registerHoverProvider('dfdl', {
     provideHover(
@@ -25,6 +57,7 @@ export function getAttributeHoverProvider() {
       position: vscode.Position,
       token: vscode.CancellationToken
     ) {
+      // Get the word at the cursor position (the attribute name being hovered)
       const range = document.getWordRangeAtPosition(position)
       if (!range) {
         return undefined // No word found at the position
@@ -38,6 +71,7 @@ export function getAttributeHoverProvider() {
 
       const attributeItems: AttributeItem[] = []
 
+      // Build a list of all valid DFDL attribute names
       attributeCompletion('', '', 'dfdl', '', '').items.forEach((r) =>
         attributeItems.push(r)
       )
@@ -47,12 +81,14 @@ export function getAttributeHoverProvider() {
       )
 
       if (foundItem == undefined) {
+        // Normalize the attribute name to include the 'dfdl:' prefix if needed
         hoverItem = 'dfdl:' + hoverItem
         foundItem = attributeItems.find(
           (attributeItem) => attributeItem.item === hoverItem
         )
       }
 
+      // return hover doucumentation
       if (foundItem?.item === hoverItem) {
         return new vscode.Hover(foundItem.markdownString)
       }


### PR DESCRIPTION
Closes #1493

## Description

Document IntelliSense AttributeHoverProvider + relevant files

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots

Ensure comments and documentation looks valid. Additionally, items in src/language/providers/intellisense/attributeItems.ts have been shuffled around. Make sure no items in there are missing or omitted. 