### PR TITLE
Fix lstat "" issue and Daffodil Debugger part of `yarn test` hanging

### DIFF
--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -595,11 +595,11 @@ class DaffodilConfigurationProvider
    * Massage a debug configuration just before a debug session is being launched,
    * e.g. add all missing attributes to the debug configuration.
    */
-  async resolveDebugConfiguration(
+  resolveDebugConfiguration(
     folder: WorkspaceFolder | undefined,
     config: DebugConfiguration,
     token?: CancellationToken
-  ): Promise<DebugConfiguration | undefined> {
+  ): ProviderResult<DebugConfiguration> {
     // if launch.json is missing or empty
     if (!config.type && !config.request && !config.name) {
       config = getConfig({ name: 'Launch', request: 'launch', type: 'dfdl' })
@@ -609,57 +609,14 @@ class DaffodilConfigurationProvider
       config.debugServer = 4711
     }
 
-    const schemaMissing = !config.schema?.path || config.schema.path === ''
-    const dataMissing = !config.data || config.data === ''
-
-    let schemaPath: string | undefined
-    let dataPath: string | undefined
-
-    // --- If either is missing, always prompt in the correct order ---
-    if (schemaMissing || dataMissing) {
-      // Always prompt for schema first
-      schemaPath = await vscode.commands.executeCommand<string>(
-        'extension.dfdl-debug.getSchemaName'
-      )
-      if (!schemaPath) {
-        return undefined
-      }
-      config.schema.path = schemaPath
-
-      dataPath = await vscode.commands.executeCommand<string>(
-        'extension.dfdl-debug.getDataName'
-      )
-      if (!dataPath) {
-        return undefined
-      }
-      config.data = dataPath
-    }
-
-    // --- Clean up placeholders safely (no accidental empty strings) ---
-    if (config.schema?.path?.includes('${command:AskForSchemaName}')) {
-      if (schemaPath && schemaPath.trim() !== '') {
-        config.schema.path = schemaPath
-      } else {
-        config.schema.path = config.schema.path.replace(
-          '${command:AskForSchemaName}',
-          ''
-        )
-        console.warn(
-          'Schema placeholder removed but no schema file was selected.'
-        )
-      }
-    }
-
-    if (
-      typeof config.data === 'string' &&
-      config.data.includes('${command:AskForDataName}')
-    ) {
-      if (dataPath && dataPath.trim() !== '') {
-        config.data = dataPath
-      } else {
-        config.data = config.data.replace('${command:AskForDataName}', '')
-        console.warn('Data placeholder removed but no data file was selected.')
-      }
+    // default schema path and data paths to ask for file prompts if they are null, undefined, or '' in launch.json config
+    config = {
+      ...config,
+      schema: {
+        ...config.schema,
+        path: config.schema?.path || '${command:AskForSchemaName}',
+      },
+      data: config.data || '${command:AskForDataName}',
     }
 
     let dataFolder = config.data


### PR DESCRIPTION
Closes #1518
Closes #1519

## Description

Fixes an issue where https://github.com/apache/daffodil-vscode/commit/3e518ec86ba9c395f21aee20e4b4bacaca885494 would cause the default launch.json config generated by the launch config wizard to fail and not run a DFDL debugging session. 

Fixes an issue where `yarn test` Daffodil Debugger tests had the VS Code window hang instead of downloading Daffodil JAR files

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
   - Rationale: These are bug fixes. No documentation needed
- [ ] I have added following documentation for these changes


## Review Instructions including Screenshots

Do all two sections please.

### Testing launch.json issues

1. Delete your launch.json file
2. Create a launch.json from the launch configuration wizard 

<img width="627" height="85" alt="image" src="https://github.com/user-attachments/assets/b7e513c1-3e08-4805-9aaf-7dd284cf8fec" />

3. Do not update anything in there. Press save. 
4. Run a DFDL debugging session with your preferred DFDL schema and data file of choice

<img width="934" height="589" alt="image" src="https://github.com/user-attachments/assets/7c43104d-341c-433e-90e6-f57a387c4ac7" />

<img width="946" height="590" alt="image" src="https://github.com/user-attachments/assets/0089ca03-c53c-422e-ae50-422012b0ce30" />

6. Modify your launch.json configuration to include several permutations of schema.path and data being `""`, their respective `${command:AskFor...}`, or the JSON property being missing,

<img width="537" height="292" alt="image" src="https://github.com/user-attachments/assets/8ae8364c-c22c-436b-895b-84dbae6a20bf" />

### Testing `yarn test` Daffodil Debugger hanging

1. At the top-level folder of the repo, type in one-liner command `git clean -fdx; yarn; yarn package; yarn test` 
2. Verify nothing hangs and the test VS Code window shows it downloading the Daffodil Jar and performing DFDL debugging items. 
3. WARNING: IT MIGHT TAKE A WHILE AS IT DOWNLOADS PREVIOUS DAFFODIL VS CODE JARS

<img width="469" height="367" alt="image" src="https://github.com/user-attachments/assets/20e4398b-22ac-4fbb-9c9a-672a182d60d4" />




