### PR TITLE
correct default configuration loading

### DIFF
--- a/src/adapter/activateDaffodilDebug.ts
+++ b/src/adapter/activateDaffodilDebug.ts
@@ -174,12 +174,16 @@ async function createDebugRunFileConfigs(
       })
     } else {
       var tdmlConfig: TDMLConfig | undefined = undefined
+      var newData: string | undefined = undefined
+      var newSchema: string | undefined = normalizedResource
 
       if (tdmlAction) {
         tdmlConfig = { action: tdmlAction }
 
         if (tdmlAction === 'execute') {
           tdmlConfig.path = normalizedResource
+          newData = undefined
+          newSchema = undefined
         }
       }
 
@@ -188,13 +192,11 @@ async function createDebugRunFileConfigs(
         request: 'launch',
         type: 'dfdl',
         schema: {
-          path: tdmlConfig?.action === 'execute' ? '' : normalizedResource,
+          path: newSchema,
           rootName: null,
           rootNamespace: null,
         },
-        data:
-          tdmlConfig?.action === 'execute' ? '' : '${command:AskForDataName}',
-        debugServer: false,
+        data: newData,
         infosetFormat: 'xml',
         infosetOutput: {
           type: 'file',
@@ -603,10 +605,6 @@ class DaffodilConfigurationProvider
     // if launch.json is missing or empty
     if (!config.type && !config.request && !config.name) {
       config = getConfig({ name: 'Launch', request: 'launch', type: 'dfdl' })
-    }
-
-    if (!config.debugServer) {
-      config.debugServer = 4711
     }
 
     // default schema path and data paths to ask for file prompts if they are null, undefined, or '' in launch.json config


### PR DESCRIPTION
Closes #64

## Description

Certain settings withing VSCode that affect the Daffodil Extension can be set outside of the launch.json file. If there is no launch.json file, then these values need to be utilized rather than blindly replaced with built-in defaults.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes


## Review Instructions including Screenshots
If you debug the extension or install via VSIX, and run "Ctrl" + "," or "Cmd" + ",". Navigate to Workspace > Extensions > Apache Daffodil Extension for Visual Studio Code there is a list of settings. Some can only be set in the settings.json as they have more than one attribute to be set.
<img width="941" height="586" alt="image" src="https://github.com/user-attachments/assets/8a725925-cea0-4502-8d52-1117843d14cf" />

I've been testing by renaming my launch.json file, then starting debugging using both the command pallet and the RUN/F5 menu option. These techniques result in different execution paths, and both required changes.
The idea, again, is that these VSCode settings will not be overwritten with built in defaults. Examples of settings include debugServer port number and specifying a data file rather than using the default "ask for data file"