### PR TITLE
Display Data Editor tab name displays file base name

### DIFF
--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -198,7 +198,8 @@ export class DataEditorClient implements vscode.Disposable {
     configVars: editor_config.IConfig,
     fileToEdit: string = ''
   ): Promise<DataEditorClient | undefined> {
-    const title = 'Data Editor'
+    const title = !fileToEdit ? 'Data Editor' : path.basename(fileToEdit)
+
     const column =
       fileToEdit !== '' ? vscode.ViewColumn.Two : vscode.ViewColumn.Active
 
@@ -903,6 +904,28 @@ async function createDataEditorWebviewPanel(
   launchConfigVars: editor_config.IConfig,
   fileToEdit: string
 ): Promise<DataEditorClient | undefined> {
+  //prompt file prompt first.
+  if (!fileToEdit) {
+    const fileUri = await vscode.window.showOpenDialog({
+      canSelectMany: false,
+      openLabel: 'Select',
+      canSelectFiles: true,
+      canSelectFolders: false,
+      title: 'Select Data File',
+    })
+
+    // If user cancels file prompt, display info message
+    if (!fileUri || !fileUri[0]) {
+      vscode.window.showInformationMessage(
+        'Data Editor file opening cancelled.'
+      )
+      return
+    }
+
+    // file was selected by user, note file path to selected file
+    fileToEdit = fileUri[0].fsPath
+  }
+
   // Ensure the app data path exists
   fs.mkdirSync(APP_DATA_PATH, { recursive: true })
   assert(fs.existsSync(APP_DATA_PATH), 'app data path does not exist')

--- a/src/tests/suite/dataEditor.test.ts
+++ b/src/tests/suite/dataEditor.test.ts
@@ -146,7 +146,11 @@ suite('Data Editor Test Suite', () => {
         await vscode.commands.executeCommand(DATA_EDITOR_COMMAND, TEST_SCHEMA)
       assert.ok(dataEditWebView)
       assert.strictEqual(dataEditWebView.panel.active, true)
-      assert.strictEqual(dataEditWebView.panel.title, 'Data Editor')
+      assert.strictEqual(
+        // Check if data editor panel has the basename of the file
+        dataEditWebView.panel.title,
+        path.basename(TEST_SCHEMA)
+      )
 
       // Listen for the dispose event
       let isDisposed = false


### PR DESCRIPTION
Closes #1523
Closes #1525

## Description

Data Editor Tab now displays the base name of the file

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
   - Rationale: Bug fix
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots


### Command Palette 

1. Open the data editor
2. Cancel selecting a file. Make sure nothing odd happens and an info message pops up on the bottom right
3. Re-open the data editor
4. Select a file
5. Make sure nothing odd happens, verify the tab name is the base name of the file

<img width="319" height="301" alt="image" src="https://github.com/user-attachments/assets/6ef45779-1172-4011-b886-c9a266b56849" />

7. Open another instance of data editor
8. Try to re-open the same file, verify that the data editor says something about not opening duplicate files 

### DFDL debugging session

1. Run a DFDL debugging session with `"openDataEditor": true,`

Example config you could use:

```JSON
 {
            "request": "launch",
            "type": "dfdl",
            "name": "Wizard Config",
            "schema": {
                "path": "${command:AskForSchemaName}",
                "rootName": null,
                "rootNamespace": null
            },
            "data": "${command:AskForDataName}",
            "debugServer": 4711,
            "infosetFormat": "xml",
            "infosetOutput": {
                "type": "file",
                "path": "${workspaceFolder}/target/infoset.xml"
            },
            "tdmlConfig": {
                "action": "generate",
                "name": "Default Test Case"
            },
            "trace": true,
            "stopOnEntry": true,
            "useExistingServer": false,
            "openDataEditor": true,
            "openInfosetView": false,
            "openInfosetDiffView": false,
            "daffodilDebugClasspath": [],
            "dataEditor": {
                "port": 9000,
                "logging": {
                    "file": "${workspaceFolder}/dataEditor-${omegaEditPort}.log",
                    "level": "info"
                }
            },
            "dfdlDebugger": {
                "daffodilVersion": "3.11.0",
                "timeout": "10s",
                "logging": {
                    "file": "${workspaceFolder}/daffodil-debugger.log",
                    "level": "INFO"
                }
            }
        }
```
2. Verify the data editor tab shows the base file name and nothing odd happens 