### PR TITLE
Add alert for invalid Daffodil version requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,9 +110,13 @@ jobs:
       matrix:
         java_distribution: [temurin]
         java_version: [8, 11, 17, 21]
-        os: [macos-13, ubuntu-22.04, windows-2022]
+        os: [macos-15, ubuntu-22.04, windows-2022]
         node: ["20.19.4", "22.14.0"]
         vscode: ["1.90.0", "stable"] # v1.90.0 is the first version of VSCode to use Node 20
+        exclude:
+          # java 8 not available on macos-15
+          - os: macos-15
+            java_version: 8
       fail-fast: false # don't immediately fail all other jobs if a single job fails
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os:
           [
-            macos-13,
+            macos-15,
             ubuntu-22.04,
             windows-2022,
             macos-latest,
@@ -41,6 +41,8 @@ jobs:
         java_version: [8, 11, 17, 21]
         exclude:
           # java 8 not available on latest macos
+          - os: macos-15
+            java_version: 8
           - os: macos-latest
             java_version: 8
       fail-fast: false # don't immediately fail all other jobs if a single job fails

--- a/src/daffodilDebugger/utils.ts
+++ b/src/daffodilDebugger/utils.ts
@@ -121,6 +121,15 @@ export async function runDebugger(
   // Download the daffodil CLI jars if needed
   const daffodilPath = await checkIfDaffodilJarsNeeded(dfdlVersion)
 
+  /**
+   * If 'error' returned from checkIfDaffodilJarsNeeded then there was an error hit somewhere inside of that
+   * function, most likely downloading/extracting the JARS. Whenever any error is hit from that function, the
+   * extension shouldn't run the debugger.
+   */
+  if (daffodilPath === 'error') {
+    return undefined
+  }
+
   const artifact = daffodilArtifact(dfdlVersion)
   const scriptPath = path.join(
     rootPath,


### PR DESCRIPTION
## Description
Add alert for invalid Daffodil version requests

- Pull and parse https://daffodil.apache.org/doap.rdf to find if provided daffodil version is valid or not.
- Bump to macos-15 in CI since macos-13 are being deprecated

Closes https://github.com/apache/daffodil-vscode/issues/1476

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes
