### PR TITLE
Fixes missing intellisense suggestions

### DIFF
--- a/src/language/providers/elementCompletion.ts
+++ b/src/language/providers/elementCompletion.ts
@@ -270,7 +270,7 @@ function nearestOpenTagChildElements(
       )
     case 'complexType':
       return getElementCompletionItems(
-        ['sequence', 'group', 'choice'],
+        ['sequence', 'group', 'choice', 'annotation'],
         '',
         '',
         nsPrefix

--- a/src/language/providers/utils.ts
+++ b/src/language/providers/utils.ts
@@ -397,6 +397,7 @@ export function checkMultiLineTag(
   if (itemsOnLine > 1) {
     return [false, isDfdlTag, attributeNames]
   }
+  let triggerLine = position.line
   let currentLine = position.line
   let openTagLine = position.line
   let closeTagLine = position.line
@@ -448,7 +449,8 @@ export function checkMultiLineTag(
 
     if (
       currentText.includes('<' + nsPrefix + tag) &&
-      currentText.includes('>')
+      currentText.includes('>') &&
+      closeTagLine >= triggerLine
     ) {
       attributeNames = getAttributeNames(document, position, nsPrefix, tag)
       return [true, isDfdlTag, attributeNames]

--- a/src/tests/DfdlIntellisenseTestingChecklist.md
+++ b/src/tests/DfdlIntellisenseTestingChecklist.md
@@ -85,7 +85,7 @@ Place the cursor at line 68 column 98, within the double quotes containing the v
 - [ ] Verify the dropdown contains binary an text. Select "text" as the value.
 - [ ] verify that "binary" is replaced with "text".
 
-Place the cursor at line 68 column 252 at the end of the line. Backspace over the last 2 characters "/>". The cursor shoul;d be directly after dfdl:length="{../../Length - fn:string-length(../Keyword) - 2}". Type a / (slash '/').
+Place the cursor at line 68 column 252 at the end of the line. Backspace over the last 2 characters "/>". The cursor shoulld be directly after dfdl:length="{../../Length - fn:string-length(../Keyword) - 2}". Type a / (slash '/').
 
 - [ ] Verify that the self closing tag "/> was added to the end of the line.
 
@@ -100,7 +100,7 @@ Place a cursor at line 71 column 20, after </xs:element>. Backspace until the cl
 
 Place the cursor at line 73 column 129, before <xs:annotation>. Type CTRL+space.
 
-- [ ] Verify the dropdown contains xs:annotation, xs:complexType, xs:complexType name=,xs:simpleType, and xs:simpleType name=.
+- [ ] Verify the dropdown contains xs:annotation, xs:complexType, xs:complexType name, xs:simpleType, and xs:simpleType name.
 
 Place the cursor at line 73 column 263, after </xs:annotation>. Backspace to remove the annoation closing tag. With your cursor just after the </xs:appinfo> tag, type > (the greater than symbol).
 
@@ -121,14 +121,14 @@ Place the cursor at line 31 column 39, after ref="GeneralFormat". Type a space.
 
 - [ ] Verify the dropdown doesnot contain ref,dfdl:encoding,dfdl:alignment,dfdl:lengthKind,dfdl:representation
 
-Select alignment from the dropdown. select 1 as the value for alignment.
+Place the cursor at line 31 column 39, after alignment="1". Backspace until alignment="1" is erased. Type ctrl+space. Select alignment from the dropdown. select 1 as the value for alignment.
 
 - [ ] Verify that alignment="1" is inserted.
 - [ ] Verfiy that alignment does not have the dfdl: prefix.
 
 Place the cursor at line 33 column 1. Type CTRL+space.
 
-- [ ] Verify the dropdown contains dfdl:defineEscapeScheme,dfdl:defineFormat,dfdl:defineVariable,dfdl:format.
+- [ ] Verify the dropdown contains dfdl:defineEscapeScheme,dfdl:defineFormat,dfdl:defineVariable,dfdl:definbeVariable name,dfdl:format.
 
 Place the cursor at line 52 column 56 at the end of the line. Backspace over the last two characters "/>". The cursor should be directly after encoding="ascii". Type a / (slash '/').
 
@@ -141,7 +141,7 @@ Place the cursor at line 59, column 46, after representation="text". Type a spac
 
 - [ ] Verify the dropdown does not contain dfdl:encoding,dfdl:alignment,dfdl:initiator,dfdl:lengthKind,dfdl:representation,dfdl:textNumberRep
 
-Select dfdl:alignment from the dropdown. select 1 as the value.
+Place the cursor after alignment="1". Backspace until alignment="1" is erased. Type ctrl+space. Select dfdl:alignment from the dropdown. select 1 as the value.
 
 - [ ] Verify that alignment="1" was inserted.
 - [ ] Verify that alignment does not contian the dfdl: prefix.


### PR DESCRIPTION
Fixes missing element suggestions for schema., fixes missing attribute suggestion for complex type, corrects some grammar and spelling errors in intellisense checklist

Closes #1533
Closes #1534

## Description

Fixes missing suggestions for schema elements and for complexType attributes

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots

For missing schema element https://github.com/apache/daffodil-vscode/issues/1533:
Steps to Reproduce
Open any dfdl schema
place the cursor after the tag closing symbol '>' of the schema tag
ex:
<xs:schema xmlns:xs="http://www.w3.org/2001/xmlSchema"
xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
xmlns:fn="http:/www.w3.org/2005/xpath-functions"
elementFormDefault="unqualified">
---------------------place cursor here ^
Type CTRL space to trigger intellisense

Expected Behavior
Intellisense should return the element suggestions for the schema tag

Actual Behavior
Intellisense returns "no suggestions"

For missing complexType attributes https://github.com/apache/daffodil-vscode/issues/1534:
Steps to Reproduce
use the file: src/tests/data/testDfdlMixedLineFormats.dfdl.xsd
Place cursor at line 69, column 25, before </xs:sequence>. Type CTRL+space.
Verify the dropdown contains xs:annotation, xs:choice, xs:element, xs:element
name, xs:element ref, and xs:sequence.

Expected Behavior
xs:annotation, xs:choice, xs:element, xs:element
name, xs:element ref, and xs:sequence.
should be supplied in the attribute suggestion list

Actual Behavior
xs:annotation is missing from the attribute suggestion list

