### PR TITLE
Data Editor: Don't Force Replace Operation with Invalid Input

### DIFF
--- a/src/svelte/src/components/Header/fieldsets/SearchReplace.svelte
+++ b/src/svelte/src/components/Header/fieldsets/SearchReplace.svelte
@@ -137,7 +137,7 @@ limitations under the License.
   }
 
   function replaceStart() {
-    if (replaceable && !replaceErr) {
+    if (replaceable && !replaceErrDisplay) {
       matchOffset = -1
       replaceStarted = true
       searchStarted = false
@@ -403,7 +403,7 @@ limitations under the License.
           <Button
             fn={replace}
             description="Replace the current match"
-            disabledBy={!replaceable}
+            disabledBy={!replaceable || replaceErrDisplay}
           >
             <span slot="left" class="btn-icon material-symbols-outlined"
               >find_replace</span


### PR DESCRIPTION
Closes #1522

Revised version of https://github.com/apache/daffodil-vscode/pull/1527

## Description

Fixes an issue where in the Data Editor, invalid input to the `Replace` text field shouldn't be able to be used in a replace operation. For example `[📙 Emojipedia — 😃 Home of Emoji Meanings 💁👌🎍😍](https://emojipedia.org/)` 

## Wiki

- [x] I have determined that no documentation updates are needed for these changes
   - Rationale: Bug fix
- [ ] I have added following documentation for these changes

## Review Instructions including Screenshots

### Confirmation Testing
1. Open the data editor
2. Open a sample file. I used [staircase_bytes_v.txt](https://github.com/user-attachments/files/23424519/staircase_bytes_v.txt)
3. Type in a snippet of text in the Search field like `aaa`

<img width="1090" height="588" alt="Image" src="https://github.com/user-attachments/assets/3db3b28d-0fc9-47a8-b3df-908aa8a3bacc" />

4. Paste some invalid string into the `Replace` field. I used `[📙 Emojipedia — 😃 Home of Emoji Meanings 💁👌🎍😍](https://emojipedia.org/)` due to there being emoji content
5. Observe that there's a red warning symbol indication that I can't do the replace

<img width="906" height="572" alt="Image" src="https://github.com/user-attachments/assets/544848c2-ce76-43cf-b186-a561db356190" />

6. Press enter while you have the `Replace` text field highlighted. 
7. Make sure the search button doesn't appear 

<img width="921" height="578" alt="image" src="https://github.com/user-attachments/assets/8425f39c-aafc-450c-bc63-318be6505b06" />

### Regression Testing

3. Type in a snippet of text that exists in the Search field like `222`
 
<img width="1260" height="847" alt="image" src="https://github.com/user-attachments/assets/22c96c9f-c790-4459-84a9-749b486615a8" />

4. Start replacement w/ a valid string and click on the `Replace current match` button

<img width="1251" height="823" alt="image" src="https://github.com/user-attachments/assets/0afeecdc-fdcd-4700-b356-2b763d8f16cc" />

5. Change to invalid string

<img width="1277" height="842" alt="image" src="https://github.com/user-attachments/assets/fd04eecf-513d-49b6-a9c6-b39356fc8c09" />

6. Back to valid. Replace button should be enabled 


