### PR TITLE
Data editor: add profile source target selection

### DIFF
--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -473,7 +473,42 @@ export class DataEditorClient implements vscode.Disposable {
       data: data,
     })
   }
+    
+  private async runProfile(
+    sessionId: string,
+    startOffset: number,
+    length: number
+  ) {
+    const byteProfile = await profileSession(sessionId, startOffset, length)
+    const characterCount = await countCharacters(
+      sessionId,
+      startOffset,
+      length
+    )
+    const contentType = await getContentType(sessionId, startOffset, length)
+    const language = await getLanguage(
+      sessionId,
+      startOffset,
+      length,
+      characterCount.getByteOrderMark()
+    )
 
+    return {
+      byteProfile,
+      numAscii: numAscii(byteProfile),
+      language: language.getLanguage(),
+      contentType: contentType.getContentType(),
+      characterCount: {
+        byteOrderMark: characterCount.getByteOrderMark(),
+        byteOrderMarkBytes: characterCount.getByteOrderMarkBytes(),
+        singleByteCount: characterCount.getSingleByteChars(),
+        doubleByteCount: characterCount.getDoubleByteChars(),
+        tripleByteCount: characterCount.getTripleByteChars(),
+        quadByteCount: characterCount.getQuadByteChars(),
+        invalidBytes: characterCount.getInvalidBytes(),
+      },
+    }
+  }
   // handle messages from the webview
   private async messageReceiver(message: EditorMessage) {
     switch (message.command) {
@@ -549,53 +584,49 @@ export class DataEditorClient implements vscode.Disposable {
         })
         break
 
-      case MessageCommand.profile:
-        {
-          const startOffset: number = message.data.startOffset
-          const length: number = message.data.length
-          const byteProfile: number[] = await profileSession(
-            this.omegaSessionId,
-            startOffset,
-            length
-          )
-          const characterCount = await countCharacters(
-            this.omegaSessionId,
-            startOffset,
-            length
-          )
-          const contentTypeResponse = await getContentType(
-            this.omegaSessionId,
-            startOffset,
-            length
-          )
-          const languageResponse = await getLanguage(
-            this.omegaSessionId,
-            startOffset,
-            length,
-            characterCount.getByteOrderMark()
-          )
-          await this.panel.webview.postMessage({
-            command: MessageCommand.profile,
-            data: {
-              startOffset: startOffset,
-              length: length,
-              byteProfile: byteProfile,
-              numAscii: numAscii(byteProfile),
-              language: languageResponse.getLanguage(),
-              contentType: contentTypeResponse.getContentType(),
-              characterCount: {
-                byteOrderMark: characterCount.getByteOrderMark(),
-                byteOrderMarkBytes: characterCount.getByteOrderMarkBytes(),
-                singleByteCount: characterCount.getSingleByteChars(),
-                doubleByteCount: characterCount.getDoubleByteChars(),
-                tripleByteCount: characterCount.getTripleByteChars(),
-                quadByteCount: characterCount.getQuadByteChars(),
-                invalidBytes: characterCount.getInvalidBytes(),
-              },
-            },
-          })
-        }
-        break
+  case MessageCommand.profile: {
+    const startOffset: number = message.data.startOffset
+    const length: number = message.data.length
+    const target: string | undefined = message.data.target
+
+    let sessionId = this.omegaSessionId
+    let isDiskProfile = false
+
+    try {
+      if (target === 'disk') {
+        const tempSession = await createSession(
+          this.fileToEdit,
+          undefined,
+          checkpointPath
+        )
+        sessionId = tempSession.getSessionId()
+        addActiveSession(sessionId)
+        isDiskProfile = true
+    }
+
+    const profileData = await this.runProfile(
+      sessionId,
+      startOffset,
+      length
+    )
+
+    await this.panel.webview.postMessage({
+      command: MessageCommand.profile,
+      data: {
+        startOffset,
+        length,
+        ...profileData,
+      },
+    })
+  } finally {
+    if (isDiskProfile) {
+      await removeActiveSession(sessionId)
+    }
+  }
+
+  break
+}
+
 
       case MessageCommand.clearChanges:
         if (

--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -473,18 +473,14 @@ export class DataEditorClient implements vscode.Disposable {
       data: data,
     })
   }
-    
+
   private async runProfile(
     sessionId: string,
     startOffset: number,
     length: number
   ) {
     const byteProfile = await profileSession(sessionId, startOffset, length)
-    const characterCount = await countCharacters(
-      sessionId,
-      startOffset,
-      length
-    )
+    const characterCount = await countCharacters(sessionId, startOffset, length)
     const contentType = await getContentType(sessionId, startOffset, length)
     const language = await getLanguage(
       sessionId,
@@ -584,49 +580,48 @@ export class DataEditorClient implements vscode.Disposable {
         })
         break
 
-  case MessageCommand.profile: {
-    const startOffset: number = message.data.startOffset
-    const length: number = message.data.length
-    const target: string | undefined = message.data.target
+      case MessageCommand.profile: {
+        const startOffset: number = message.data.startOffset
+        const length: number = message.data.length
+        const target: string | undefined = message.data.target
 
-    let sessionId = this.omegaSessionId
-    let isDiskProfile = false
+        let sessionId = this.omegaSessionId
+        let isDiskProfile = false
 
-    try {
-      if (target === 'disk') {
-        const tempSession = await createSession(
-          this.fileToEdit,
-          undefined,
-          checkpointPath
-        )
-        sessionId = tempSession.getSessionId()
-        addActiveSession(sessionId)
-        isDiskProfile = true
-    }
+        try {
+          if (target === 'disk') {
+            const tempSession = await createSession(
+              this.fileToEdit,
+              undefined,
+              checkpointPath
+            )
+            sessionId = tempSession.getSessionId()
+            addActiveSession(sessionId)
+            isDiskProfile = true
+          }
 
-    const profileData = await this.runProfile(
-      sessionId,
-      startOffset,
-      length
-    )
+          const profileData = await this.runProfile(
+            sessionId,
+            startOffset,
+            length
+          )
 
-    await this.panel.webview.postMessage({
-      command: MessageCommand.profile,
-      data: {
-        startOffset,
-        length,
-        ...profileData,
-      },
-    })
-  } finally {
-    if (isDiskProfile) {
-      await removeActiveSession(sessionId)
-    }
-  }
+          await this.panel.webview.postMessage({
+            command: MessageCommand.profile,
+            data: {
+              startOffset,
+              length,
+              ...profileData,
+            },
+          })
+        } finally {
+          if (isDiskProfile) {
+            await removeActiveSession(sessionId)
+          }
+        }
 
-  break
-}
-
+        break
+      }
 
       case MessageCommand.clearChanges:
         if (

--- a/src/svelte/src/components/DataMetrics/DataMetrics.svelte
+++ b/src/svelte/src/components/DataMetrics/DataMetrics.svelte
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <script lang="ts">
+  let profileTarget: 'editor' | 'disk' = 'editor'
   import Button from '../Inputs/Buttons/Button.svelte'
   import { vscode } from '../../utilities/vscode'
   import { MessageCommand } from '../../utilities/message'
@@ -73,7 +74,6 @@ limitations under the License.
   let errorMessageTimeout: NodeJS.Timeout | null = null
   let asciiOverlay: boolean = true
   let logScale: boolean = false
-
   $: {
     sum = byteProfile.reduce((a, b) => a + b, 0)
     mean = sum / byteProfile.length
@@ -156,21 +156,28 @@ limitations under the License.
       },
     })
   }
-
+  
+  let lastProfileTarget: 'editor' | 'disk' | null = null
+  let lastRequestedTarget: 'editor' | 'disk' = 'editor'
   function requestSessionProfile(startOffset: number, length: number) {
-    setStatusMessage(
-      `Profiling bytes from ${startOffset} to ${startOffset + length}...`,
-      0
-    )
-    vscode.postMessage({
-      command: MessageCommand.profile,
-      data: {
-        startOffset: startOffset,
-        length: length,
-      },
-    })
-  }
-
+  lastRequestedTarget = profileTarget
+  setStatusMessage(
+    `Profiling bytes from ${startOffset} to ${startOffset + length}...`,
+    0
+  )
+  vscode.postMessage({
+    command: MessageCommand.profile,
+    data: {
+      startOffset,
+      length,
+      target: profileTarget === 'disk' ? 'disk' : undefined,
+    },
+  })
+}
+$: if (profileTarget !== lastProfileTarget) {
+  lastProfileTarget = profileTarget
+  requestSessionProfile(startOffset, length)
+}
   function handleInputEnter(e: CustomEvent) {
     switch (e.detail.id) {
       case 'start-offset-input':
@@ -283,6 +290,10 @@ limitations under the License.
     window.addEventListener('message', (msg) => {
       switch (msg.data.command) {
         case MessageCommand.profile:
+          if(msg.data.data?.target && msg.data.data.target !== profileTarget) {
+            // ignore messages not for the current profile target
+            break
+          }
           numAscii = msg.data.data.numAscii as number
           byteProfile = msg.data.data.byteProfile as number[]
           language = msg.data.data.language as string
@@ -313,11 +324,19 @@ limitations under the License.
       }
     })
     endOffset = startOffset + length
-    requestSessionProfile(startOffset, length)
   })
 </script>
 
 <div class="container">
+  <div class="input-container">
+  <label>
+    Profile source:
+    <select bind:value={profileTarget}>
+      <option value="editor">Current editor</option>
+      <option value="disk">On-disk file</option>
+    </select>
+  </label>
+</div>
   {#if title.length > 0}
     <div class="header">
       <h3>{title}</h3>

--- a/src/svelte/src/components/DataMetrics/DataMetrics.svelte
+++ b/src/svelte/src/components/DataMetrics/DataMetrics.svelte
@@ -156,28 +156,28 @@ limitations under the License.
       },
     })
   }
-  
+
   let lastProfileTarget: 'editor' | 'disk' | null = null
   let lastRequestedTarget: 'editor' | 'disk' = 'editor'
   function requestSessionProfile(startOffset: number, length: number) {
-  lastRequestedTarget = profileTarget
-  setStatusMessage(
-    `Profiling bytes from ${startOffset} to ${startOffset + length}...`,
-    0
-  )
-  vscode.postMessage({
-    command: MessageCommand.profile,
-    data: {
-      startOffset,
-      length,
-      target: profileTarget === 'disk' ? 'disk' : undefined,
-    },
-  })
-}
-$: if (profileTarget !== lastProfileTarget) {
-  lastProfileTarget = profileTarget
-  requestSessionProfile(startOffset, length)
-}
+    lastRequestedTarget = profileTarget
+    setStatusMessage(
+      `Profiling bytes from ${startOffset} to ${startOffset + length}...`,
+      0
+    )
+    vscode.postMessage({
+      command: MessageCommand.profile,
+      data: {
+        startOffset,
+        length,
+        target: profileTarget === 'disk' ? 'disk' : undefined,
+      },
+    })
+  }
+  $: if (profileTarget !== lastProfileTarget) {
+    lastProfileTarget = profileTarget
+    requestSessionProfile(startOffset, length)
+  }
   function handleInputEnter(e: CustomEvent) {
     switch (e.detail.id) {
       case 'start-offset-input':
@@ -290,7 +290,7 @@ $: if (profileTarget !== lastProfileTarget) {
     window.addEventListener('message', (msg) => {
       switch (msg.data.command) {
         case MessageCommand.profile:
-          if(msg.data.data?.target && msg.data.data.target !== profileTarget) {
+          if (msg.data.data?.target && msg.data.data.target !== profileTarget) {
             // ignore messages not for the current profile target
             break
           }
@@ -329,14 +329,14 @@ $: if (profileTarget !== lastProfileTarget) {
 
 <div class="container">
   <div class="input-container">
-  <label>
-    Profile source:
-    <select bind:value={profileTarget}>
-      <option value="editor">Current editor</option>
-      <option value="disk">On-disk file</option>
-    </select>
-  </label>
-</div>
+    <label>
+      Profile source:
+      <select bind:value={profileTarget}>
+        <option value="editor">Current editor</option>
+        <option value="disk">On-disk file</option>
+      </select>
+    </label>
+  </div>
   {#if title.length > 0}
     <div class="header">
       <h3>{title}</h3>


### PR DESCRIPTION
Closes #1563

## Description

This PR adds support for profiling different data targets in the Data Editor, allowing users to choose between profiling:
- the current in-memory (unapplied) editor buffer, or
- the on-disk data.

This resolves cases where profiling previously ignored unapplied edits and aligns the profiler behavior with user expectations.

## Wiki

- [ ] I have determined that no documentation updates are needed for these changes

## Review Instructions

1. Open the Data Editor
2. Navigate to the Data Metrics / Profiler panel
3. Select a profiling target (Editor or Disk)
4. Modify data in the editor without applying changes
5. Run profiling and verify the selected target is respected

### Confirmation Testing

- Manually tested profiling with unapplied editor changes
- Verified on-disk profiling continues to behave as before

### Regression Testing

- Existing profiling functionality verified with no UI regressions observed