### PR TITLE
Update Data Editor not to Default to Config

### DIFF
--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -83,7 +83,6 @@ import {
 import { getCurrentHeartbeatInfo } from './include/server/heartbeat'
 import * as child_process from 'child_process'
 import { osCheck } from '../utils'
-import { getCurrentConfig } from '../utils'
 import { isDFDLDebugSessionActive } from './include/utils'
 
 // *****************************************************************************
@@ -121,11 +120,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
       DATA_EDITOR_COMMAND,
       async (fileToEdit: string = '') => {
         let configVars = editor_config.extractConfigurationVariables()
-        return await createDataEditorWebviewPanel(
-          ctx,
-          configVars,
-          vscode.debug.activeDebugSession ? getCurrentConfig().data : fileToEdit
-        )
+        return await createDataEditorWebviewPanel(ctx, configVars, fileToEdit)
       }
     )
   )


### PR DESCRIPTION
Closes #1530 

## Description

Fixed bug that defaults filename to config file value when running a debug session.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes  
- [ ] I have added the following documentation for these changes

## Review Instructions including Screenshots

Ensure the pop-up for opening the same file in the data editor does not pop up when opening a different file when in a debugging session.
<img width="326" height="43" alt="image" src="https://github.com/user-attachments/assets/95eba2dd-d7f6-4cfa-bdf4-eb56649f2c72" />

See confirmation testing below for steps to test this.

### Confirmation Testing

1. Start a debugging session with a data editor.
2. After the Data Editor opens, use`Ctrl+Shift+P` to open the command palette.
3. Select "Daffodil Debug: Data Editor"
4. Ensure File Explorer pops up and select a file.
5. Ensure Data Editor opens file.

### Regression Testing

Ensure that the duplicate file error pop-up still appears when trying to open the same file that is already open, both in and outside of a debug session.
