### PR TITLE
#1588 - doc: remove CI testing status badges from main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@
 
 # Apache Daffodil™ Extension for Visual Studio Code
 
-[![CI](https://github.com/apache/daffodil-vscode/workflows/CI/badge.svg)](https://github.com/apache/daffodil-vscode/actions/workflows/CI.yml)
-[![Nightly Tests](https://github.com/apache/daffodil-vscode/actions/workflows/nightly.yml/badge.svg)](https://github.com/apache/daffodil-vscode/actions/workflows/nightly.yml)
-
 </div>
 
 The Apache Daffodil™ Extension for Visual Studio Code is an extension to the Microsoft® Visual Studio Code (VS Code) editor, designed for Data Format Description Language<sup><a href="#footnotes">1</a></sup> [(DFDL)](https://daffodil.apache.org/docs/dfdl/) Schema developers. 


### PR DESCRIPTION
Closes #1588

## Description

Remove CI job status badges from main README.md.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes

## Review Instructions including Screenshots

The main README.md should no longer display CI job status badges.