### PR TITLE
Reverting changes clears data highlighting

### DIFF
--- a/src/svelte/src/App.svelte
+++ b/src/svelte/src/App.svelte
@@ -64,6 +64,7 @@ limitations under the License.
   } from './components/DataDisplays/CustomByteDisplay/BinaryData'
   import { byte_count_divisible_offset } from './utilities/display'
   import Help from './components/layouts/Help.svelte'
+  import { viewportByteIndicators } from 'utilities/highlights'
 
   function requestEditedData() {
     if ($requestable) {
@@ -253,6 +254,8 @@ limitations under the License.
     $selectionDataStore = new SelectionData_t()
     $editorSelection = ''
     $editedDataSegment = new Uint8Array(0)
+    viewportByteIndicators.clearIndication('replacement')
+    viewportByteIndicators.clearIndication('searchresult')
   }
 
   function clearQueryableData() {


### PR DESCRIPTION
Closes #1536

## Description

Submitting an `undo` command through the Data Editor clears any existing search/replace result highlighting.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes  
- [ ] I have added the following documentation for these changes

## Review Instructions including Screenshots

Perform the steps outlined in #1536 

