### PR TITLE
Set max-parallel for all GitHub action jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,7 @@ jobs:
   code-format:
     name: TypeScript/Scala/Svelte Formatting
     strategy:
+      max-parallel: 1
       matrix:
         java_distribution: [temurin]
         java_version: [17]
@@ -107,6 +108,7 @@ jobs:
   build-test-package:
     name: "Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, Java: ${{ matrix.java_version }}, VS Code: ${{ matrix.vscode }})"
     strategy:
+      max-parallel: 15
       matrix:
         java_distribution: [temurin]
         java_version: [8, 11, 17, 21]

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -27,6 +27,7 @@ jobs:
   rat-check:
     name: Rat Check
     strategy:
+      max-parallel: 1
       matrix:
         java_distribution: [temurin]
         java_version: [17]
@@ -63,6 +64,7 @@ jobs:
   node-missing-license-data-check:
     name: Node Missing LICENSE Data Check
     strategy:
+      max-parallel: 1
       matrix:
         os: [ubuntu-22.04]
         node: ["22.14.0"]
@@ -100,6 +102,7 @@ jobs:
   node-license-compatibility:
     name: Node LICENSE Compatibility Check
     strategy:
+      max-parallel: 1
       matrix:
         os: [ubuntu-22.04]
         node: ["22.14.0"]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,7 @@ jobs:
   build-test-package:
     name: "Build, Test, and Package (OS: ${{ matrix.os }}, Node: ${{ matrix.node }}, Java: ${{ matrix.java_version }}, VS Code: ${{ matrix.vscode }})"
     strategy:
+      max-parallel: 15
       matrix:
         os:
           [


### PR DESCRIPTION
In accordance with ASF policy, set job.strategy.max-parallel to the recommended 15 or less. Most values are set to 1, except for when there are matrices, in which case the value is set to the number of expected jobs for the matrix, with a maximum of 15.

DAFFODIL-3069

Closes #[issue]

## Description

[Please include a summary of the change and which issue is fixed. Also include relevant context or motivation.]

## Wiki

- [x] I have determined that no documentation updates are needed for these changes  
- [ ] I have added the following documentation for these changes

[List added wiki/docs documentation here for review, if applicable]

## Review Instructions including Screenshots

[Add review instructions including screenshots or GIFs to help explain the change visually.]

### Confirmation Testing

[OPTIONAL: Describe the tests you performed to confirm that the change works as intended.  
Include steps, commands, test data, or screenshots/GIFs as necessary.]

### Regression Testing

[OPTIONAL: Describe any regression testing performed to ensure existing functionality was not broken.  
List relevant test suites, manual checks, or validation steps.]
