### PR TITLE
Update scala dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,12 +205,12 @@ lazy val debugger =
         "com.microsoft.java" % "com.microsoft.java.debug.core" % "0.34.0",
         "org.fusesource.jansi" % "jansi" % "1.18",
         // scala-steward:on
-        "co.fs2" %% "fs2-io" % "3.12.2",
-        "com.monovore" %% "decline-effect" % "2.6.0",
-        "org.typelevel" %% "log4cats-slf4j" % "2.7.1",
+        "co.fs2" %% "fs2-io" % "3.13.0",
+        "com.monovore" %% "decline-effect" % "2.6.1",
+        "org.typelevel" %% "log4cats-slf4j" % "2.8.0",
         "org.scalameta" %% "munit" % "1.2.4" % Test
       ),
-      dependencyOverrides += "commons-io" % "commons-io" % "[2.14.0,)",
+      dependencyOverrides += "commons-io" % "commons-io" % "2.21.0",
       libraryDependencies ++= getPlatformSpecificLibraries(scalaBinaryVersion.value),
       buildInfoPackage := "org.apache.daffodil.debugger.dap",
       buildInfoKeys := Seq[BuildInfoKey](
@@ -223,7 +223,7 @@ lazy val debugger =
     )
     .jvmPlatform(
       scalaVersions =
-        Seq("2.12.20", "2.13.16") ++ (if (scala.util.Properties.isJavaAtLeast("17")) Seq("3.3.6") else Seq())
+        Seq("2.12.20", "2.13.18") ++ (if (scala.util.Properties.isJavaAtLeast("17")) Seq("3.3.6") else Seq())
     )
 
 def getPlatformSpecificLibraries(scalaBinaryVersion: String) =

--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/DAPodil.scala
@@ -127,7 +127,7 @@ object DAPSession {
 class DAPodil(
     session: DAPSession[Request, Response, DebugEvent],
     state: Ref[IO, DAPodil.State],
-    hotswap: Hotswap[IO, DAPodil.State], // manages those states that have their own resource management
+    hotswap: NonEmptyHotswap[IO, DAPodil.State], // manages those states that have their own resource management
     debugee: Request => EitherNel[String, Resource[IO, DAPodil.Debugee]],
     whenDone: Deferred[IO, DAPodil.Done]
 ) {
@@ -229,7 +229,7 @@ class DAPodil(
           case Right(dbgee) =>
             for {
               launched <- hotswap.swap {
-                DAPodil.State.Launched.resource(session, dbgee)
+                DAPodil.State.Launched.resource(session, dbgee).evalTap(state.set)
               }.attempt
 
               _ <- launched match {
@@ -239,9 +239,8 @@ class DAPodil(
                       .FailedToLaunch(request, NonEmptyList.of("couldn't launch from created debuggee"), Some(t))
                   ) *>
                     session.abort(ErrorEvent.RequestError(t.getMessage), show"couldn't launch, request $request", t)
-                case Right(launchedState) =>
-                  state.set(launchedState) *>
-                    session.sendResponse(request.respondSuccess())
+                case Right(_) => // launchedState is now Unit, so we just send the success response
+                  session.sendResponse(request.respondSuccess())
               }
             } yield ()
         }
@@ -362,7 +361,7 @@ class DAPodil(
     session
       .sendResponse(request.respondSuccess())
       .guarantee {
-        hotswap.clear *> whenDone.complete(DAPodil.Done(args.restart)).void
+        whenDone.complete(DAPodil.Done(args.restart)).void
       }
 
   def scopes(request: Request, args: ScopesArguments): IO[Unit] =
@@ -545,8 +544,7 @@ object DAPodil extends IOApp {
   ): Resource[IO, IO[Done]] =
     for {
       state <- Ref[IO].of[State](State.Uninitialized).toResource
-      hotswap <- Hotswap
-        .create[IO, State]
+      hotswap <- NonEmptyHotswap[IO, State](Resource.pure(State.Uninitialized))
         .onFinalizeCase(ec => Logger[IO].debug(s"hotswap: $ec"))
       whenDone <- Deferred[IO, Done].toResource
       dapodil = new DAPodil(

--- a/project/build.properties
+++ b/project/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sbt.version = 1.12.6
+sbt.version = 1.12.7


### PR DESCRIPTION
## Description

Update scala dependencies

- Update scala 2.13 version 2.13.18 from 2.13.16 to prevent errors.
- cat-effects Hotswap was deprecated so needed to move to NonEmptyHotswap.

Closes #1628
Closes #1631
Closes #1634
Closes #1642
Closes #1643

## Wiki

- [x] I have determined that no documentation updates are needed for these changes  
- [ ] I have added the following documentation for these changes
