### PR TITLE
Upgrade Omega Edit to v2.0.0-rc1

### DIFF
--- a/build/package/LICENSE
+++ b/build/package/LICENSE
@@ -1103,6 +1103,41 @@ conditions of the following licenses.
     TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+- '@protobuf-ts/runtime' in extension/dist/ext/extension.js
+- '@protobuf-ts/runtime' in node_modules/@omega-edit/client
+  This product bundles '@protobuf-ts/runtime' from the above files.
+  This package is available under the BSD-3-Clause License and Apache License 2.0:
+
+    BSD 3-Clause License
+
+    Copyright (c) Timo Stamm
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 - 'protobufjs' in extension/dist/ext/extension.js
 - 'protobufjs' in node_modules/@omega-edit/client
   This product bundles 'protobufjs' from the above files.
@@ -5191,6 +5226,33 @@ conditions of the following licenses.
 
 - 'slow-redact' in extension/dist/ext/extension.js
   This produces bundles 'slow-redact' from the above files
+  These files are available under the MIT License:
+
+    MIT License
+
+    Copyright (c) 2025 pinojs contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+- '@pinojs/redact' in extension/dist/ext/extension.js
+- '@pinojs/redact' in node_modules/@omega-edit/client
+  This product bundles '@pinojs/redact' from the above files.
   These files are available under the MIT License:
 
     MIT License

--- a/build/package/NONOTICE
+++ b/build/package/NONOTICE
@@ -33,6 +33,12 @@ The following binary components distributed with this project are licensed under
   This package is available under the Apache License v2 without a NOTICE:
         Repository at: https://github.com/dcodeIO/long.js
 
+- '@protobuf-ts/runtime-rpc' in extension/dist/ext/extension.js
+- '@protobuf-ts/runtime-rpc' in node_modules/@omega-edit/client
+  This product bundles '@protobuf-ts/runtime-rpc' from the above files.
+  This package is available under the Apache License v2 without a NOTICE:
+        Repository at: https://github.com/timostamm/protobuf-ts
+
 - com.fasterxml.woodstox.woodstox-core-<VERSION>.jar in daffodil-debugger-<VERSION>.zip
   This product bundles 'woodstox-core' from the above files.
   These packages are available under the Apache License v2 without a NOTICE:

--- a/build/yarn-scripts.ts
+++ b/build/yarn-scripts.ts
@@ -95,8 +95,7 @@ function package() {
 # limitations under the License.
 
 **/node_modules/**/*
-!node_modules/@omega-edit/server/bin
-!node_modules/@omega-edit/server/lib
+!node_modules/@omega-edit/server/out/**/*
 !node_modules/@vscode/webview-ui-toolkit/**/*
 `
   )

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "watch:vite-dev": "yarn vite build --mode development -c ./vite.config.mjs --watch"
   },
   "dependencies": {
-    "@omega-edit/client": "^1.0.1",
+    "@omega-edit/client": "https://github.com/ctc-oss/omega-edit/releases/download/v2.0.0-rc1/omega-edit-node-client-v2.0.0-rc1.tgz",
+    "@omega-edit/server": "https://github.com/ctc-oss/omega-edit/releases/download/v2.0.0-rc1/omega-edit-node-server-v2.0.0-rc1.tgz",
     "@viperproject/locate-java-home": "1.1.17",
     "@vscode/debugadapter": "1.67.0",
     "@vscode/webview-ui-toolkit": "^1.2.2",
@@ -110,6 +111,7 @@
     "vscode-extension-tester": "5.9.1"
   },
   "resolutions": {
+    "@omega-edit/server": "https://github.com/ctc-oss/omega-edit/releases/download/v2.0.0-rc1/omega-edit-node-server-v2.0.0-rc1.tgz",
     "cookie": ">=0.7.0",
     "diff": ">=8.0.3",
     "serialize-javascript": ">=7.0.3"

--- a/src/dataEditor/dataEditorClient.ts
+++ b/src/dataEditor/dataEditorClient.ts
@@ -17,7 +17,6 @@
 
 import {
   ALL_EVENTS,
-  beginSessionTransaction,
   clear,
   countCharacters,
   CountKind,
@@ -26,9 +25,6 @@ import {
   createViewport,
   del,
   edit,
-  EditorClient,
-  endSessionTransaction,
-  EventSubscriptionRequest,
   getByteOrderMark,
   getClient,
   getClientVersion,
@@ -45,15 +41,16 @@ import {
   profileSession,
   redo,
   replaceOneSession,
+  runSessionTransaction,
   saveSession,
   SaveStatus,
   searchSession,
   setLogger,
   startServer,
   stopProcessUsingPID,
+  subscribeViewportEvents,
   undo,
   ViewportDataResponse,
-  ViewportEvent,
   ViewportEventKind,
 } from '@omega-edit/client'
 import assert from 'assert'
@@ -107,7 +104,6 @@ const OPEN_EDITORS = new Map<string, vscode.WebviewPanel>()
 // *****************************************************************************
 let serverInfo: ServerInfo = new ServerInfo()
 let checkpointPath: string = ''
-let client: EditorClient
 let omegaEditPort: number = 0
 
 // *****************************************************************************
@@ -139,6 +135,11 @@ export class DataEditorClient implements vscode.Disposable {
   private omegaSessionId = ''
   private sendHeartbeatIntervalId: NodeJS.Timeout | number | undefined =
     undefined
+  private viewportSubscription:
+    | {
+        cancel(): void
+      }
+    | undefined = undefined
   private disposables: vscode.Disposable[] = []
 
   constructor(
@@ -179,6 +180,8 @@ export class DataEditorClient implements vscode.Disposable {
       clearInterval(this.sendHeartbeatIntervalId)
       this.sendHeartbeatIntervalId = undefined
     }
+    this.viewportSubscription?.cancel()
+    this.viewportSubscription = undefined
 
     for (let i = 0; i < this.disposables.length; i++)
       this.disposables[i].dispose()
@@ -387,7 +390,10 @@ export class DataEditorClient implements vscode.Disposable {
       )
       this.currentViewportId = viewportDataResponse.getViewportId()
       assert(this.currentViewportId.length > 0, 'currentViewportId is not set')
-      await viewportSubscribe(this.panel, this.currentViewportId)
+      this.viewportSubscription = await viewportSubscribe(
+        this.panel,
+        this.currentViewportId
+      )
       await sendViewportRefresh(this.panel, viewportDataResponse)
     } catch {
       const msg = `Failed to create viewport for ${this.fileToEdit}`
@@ -416,18 +422,25 @@ export class DataEditorClient implements vscode.Disposable {
         latency: heartbeatInfo.latency,
         omegaEditPort: this.configVars.port,
         serverCpuLoadAverage: heartbeatInfo.serverCpuLoadAverage,
+        serverTimestamp: heartbeatInfo.serverTimestamp,
         serverUptime: heartbeatInfo.serverUptime,
-        serverUsedMemory: heartbeatInfo.serverUsedMemory,
+        serverResidentMemoryBytes: heartbeatInfo.serverResidentMemoryBytes,
+        serverVirtualMemoryBytes: heartbeatInfo.serverVirtualMemoryBytes,
+        serverPeakResidentMemoryBytes:
+          heartbeatInfo.serverPeakResidentMemoryBytes,
         sessionCount: heartbeatInfo.sessionCount,
         serverInfo: {
           omegaEditPort: this.configVars.port,
           serverVersion: serverInfo.serverVersion,
           serverHostname: serverInfo.serverHostname,
           serverProcessId: serverInfo.serverProcessId,
-          jvmVersion: serverInfo.jvmVersion,
-          jvmVendor: serverInfo.jvmVendor,
-          jvmPath: serverInfo.jvmPath,
+          runtimeKind: serverInfo.runtimeKind,
+          runtimeName: serverInfo.runtimeName,
+          platform: serverInfo.platform,
           availableProcessors: serverInfo.availableProcessors,
+          compiler: serverInfo.compiler,
+          buildType: serverInfo.buildType,
+          cppStandard: serverInfo.cppStandard,
         },
       },
     })
@@ -436,9 +449,9 @@ export class DataEditorClient implements vscode.Disposable {
   private async sendChangesInfo() {
     // get the counts from the server
     const counts = await getCounts(this.omegaSessionId, [
-      CountKind.COUNT_COMPUTED_FILE_SIZE,
-      CountKind.COUNT_CHANGE_TRANSACTIONS,
-      CountKind.COUNT_UNDO_TRANSACTIONS,
+      CountKind.COMPUTED_FILE_SIZE,
+      CountKind.CHANGE_TRANSACTIONS,
+      CountKind.UNDO_TRANSACTIONS,
     ])
 
     // accumulate the counts into a single object
@@ -450,13 +463,13 @@ export class DataEditorClient implements vscode.Disposable {
     }
     counts.forEach((count) => {
       switch (count.getKind()) {
-        case CountKind.COUNT_COMPUTED_FILE_SIZE:
+        case CountKind.COMPUTED_FILE_SIZE:
           data.computedFileSize = count.getCount()
           break
-        case CountKind.COUNT_CHANGE_TRANSACTIONS:
+        case CountKind.CHANGE_TRANSACTIONS:
           data.changeCount = count.getCount()
           break
-        case CountKind.COUNT_UNDO_TRANSACTIONS:
+        case CountKind.UNDO_TRANSACTIONS:
           data.undoCount = count.getCount()
           break
       }
@@ -750,15 +763,15 @@ export class DataEditorClient implements vscode.Disposable {
         await del(this.omegaSessionId, 0, offset)
         await this.sendChangesInfo()
       } else {
-        // delete from length to the end of the file and from 0 to offset in a single transaction
-        await beginSessionTransaction(this.omegaSessionId)
-        await del(
-          this.omegaSessionId,
-          offset + length,
-          computedFileSize - length
-        )
-        await del(this.omegaSessionId, 0, offset)
-        await endSessionTransaction(this.omegaSessionId)
+        // Trim both sides atomically so undo/redo treats the segment save as one edit.
+        await runSessionTransaction(this.omegaSessionId, async () => {
+          await del(
+            this.omegaSessionId,
+            offset + length,
+            computedFileSize - offset - length
+          )
+          await del(this.omegaSessionId, 0, offset)
+        })
         await this.sendChangesInfo()
       }
       // save the segment to the file using the typical save method
@@ -771,7 +784,7 @@ export class DataEditorClient implements vscode.Disposable {
       const saveResponse = await saveSession(
         this.omegaSessionId,
         fileToSave,
-        IOFlags.IO_FLG_OVERWRITE,
+        IOFlags.OVERWRITE,
         offset,
         length
       )
@@ -789,7 +802,7 @@ export class DataEditorClient implements vscode.Disposable {
           const saveResponse2 = await saveSession(
             this.omegaSessionId,
             fileToSave,
-            IOFlags.IO_FLG_FORCE_OVERWRITE,
+            IOFlags.FORCE_OVERWRITE,
             offset,
             length
           )
@@ -819,7 +832,7 @@ export class DataEditorClient implements vscode.Disposable {
     const saveResponse = await saveSession(
       this.omegaSessionId,
       fileToSave,
-      IOFlags.IO_FLG_OVERWRITE
+      IOFlags.OVERWRITE
     )
     if (saveResponse.getSaveStatus() === SaveStatus.MODIFIED) {
       // the file was modified since the session was created, query user to overwrite the modified file
@@ -835,7 +848,7 @@ export class DataEditorClient implements vscode.Disposable {
         const saveResponse2 = await saveSession(
           this.omegaSessionId,
           fileToSave,
-          IOFlags.IO_FLG_FORCE_OVERWRITE
+          IOFlags.FORCE_OVERWRITE
         )
         saved = saveResponse2.getSaveStatus() === SaveStatus.SUCCESS
       } else {
@@ -933,7 +946,7 @@ async function createDataEditorWebviewPanel(
   if (!(await checkServerListening(omegaEditPort, OMEGA_EDIT_HOST))) {
     await setupLogging(launchConfigVars)
     await serverStart()
-    client = await getClient(omegaEditPort, OMEGA_EDIT_HOST)
+    await getClient(omegaEditPort, OMEGA_EDIT_HOST)
     assert(
       await checkServerListening(omegaEditPort, OMEGA_EDIT_HOST),
       'server not listening'
@@ -1033,28 +1046,17 @@ async function viewportSubscribe(
   panel: vscode.WebviewPanel,
   viewportId: string
 ) {
-  // subscribe to all viewport events
-  client
-    .subscribeToViewportEvents(
-      new EventSubscriptionRequest()
-        .setId(viewportId)
-        .setInterest(ALL_EVENTS & ~ViewportEventKind.VIEWPORT_EVT_MODIFY)
-    )
-    .on('data', async (event: ViewportEvent) => {
+  return await subscribeViewportEvents({
+    viewportId,
+    interest: ALL_EVENTS & ~ViewportEventKind.MODIFY,
+    onEvent: async (event) => {
       getLogger().debug({
         viewportId: event.getViewportId(),
         event: event.getViewportEventKind(),
       })
       await sendViewportRefresh(panel, await getViewportData(viewportId))
-    })
-    .on('error', (err) => {
-      // Call cancelled thrown sometimes when server is shutdown
-      if (
-        !err.message.includes('Call cancelled') &&
-        !err.message.includes('UNAVAILABLE')
-      )
-        throw err
-    })
+    },
+  })
 }
 
 class DisplayState {
@@ -1341,12 +1343,9 @@ async function serverStart() {
 
   // Start the server and wait up to 10 seconds for it to start
   const serverPid = (await Promise.race([
-    startServer(
-      omegaEditPort,
-      OMEGA_EDIT_HOST,
-      getPidFile(omegaEditPort),
-      logConfigFile
-    ),
+    startServer(omegaEditPort, OMEGA_EDIT_HOST, getPidFile(omegaEditPort), {
+      logConfigFile,
+    }),
     new Promise((_resolve, reject) => {
       setTimeout(() => {
         reject((): Error => {

--- a/src/dataEditor/include/server/ServerInfo.ts
+++ b/src/dataEditor/include/server/ServerInfo.ts
@@ -24,10 +24,13 @@ export class ServerInfo implements IServerInfo {
   serverHostname: string = 'unknown'
   serverProcessId: number = 0
   serverVersion: string = 'unknown'
-  jvmVersion: string = 'unknown'
-  jvmVendor: string = 'unknown'
-  jvmPath: string = 'unknown'
+  runtimeKind: string = 'unknown'
+  runtimeName: string = 'unknown'
+  platform: string = 'unknown'
   availableProcessors: number = 0
+  compiler: string = 'unknown'
+  buildType: string = 'unknown'
+  cppStandard: string = 'unknown'
 }
 
 const OMEGA_EDIT_MAX_PORT: number = 65535

--- a/src/dataEditor/include/server/heartbeat/HeartBeatInfo.ts
+++ b/src/dataEditor/include/server/heartbeat/HeartBeatInfo.ts
@@ -17,14 +17,13 @@
 import { IServerHeartbeat } from '@omega-edit/client'
 
 export class HeartbeatInfo implements IServerHeartbeat {
-  omegaEditPort: number = 0 // Ωedit server port
   latency: number = 0 // latency in ms
-  serverCommittedMemory: number = 0 // committed memory in bytes
   serverCpuCount: number = 0 // cpu count
-  serverCpuLoadAverage: number = 0 // cpu load average
-  serverMaxMemory: number = 0 // max memory in bytes
+  serverCpuLoadAverage?: number = 0 // cpu load average
+  serverPeakResidentMemoryBytes?: number = 0 // peak resident memory in bytes
+  serverResidentMemoryBytes?: number = 0 // resident memory in bytes
   serverTimestamp: number = 0 // timestamp in ms
   serverUptime: number = 0 // uptime in ms
-  serverUsedMemory: number = 0 // used memory in bytes
+  serverVirtualMemoryBytes?: number = 0 // virtual memory in bytes
   sessionCount: number = 0 // session count
 }

--- a/src/dataEditor/include/server/heartbeat/index.ts
+++ b/src/dataEditor/include/server/heartbeat/index.ts
@@ -14,26 +14,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { getServerHeartbeat, IServerHeartbeat } from '@omega-edit/client'
+import {
+  IServerHeartbeat,
+  type ServerHeartbeatLoop,
+  startServerHeartbeatLoop,
+} from '@omega-edit/client'
 import { HeartbeatInfo } from './HeartBeatInfo'
 
 const HEARTBEAT_INTERVAL_MS: number = 1000 // 1 second (1000 ms)
 let heartbeatInfo: IServerHeartbeat = new HeartbeatInfo()
-let getHeartbeatIntervalId: NodeJS.Timeout | number | undefined = undefined
+let heartbeatLoop: ServerHeartbeatLoop | undefined = undefined
 
 export function updateHeartbeatInterval(activeSessions: string[]) {
-  if (getHeartbeatIntervalId) {
-    clearInterval(getHeartbeatIntervalId)
+  heartbeatLoop?.stop()
+  heartbeatLoop = undefined
+
+  if (activeSessions.length === 0) {
+    heartbeatInfo = new HeartbeatInfo()
+    return
   }
-  getHeartbeatIntervalId =
-    activeSessions.length > 0
-      ? setInterval(async () => {
-          heartbeatInfo = await getServerHeartbeat(
-            activeSessions,
-            HEARTBEAT_INTERVAL_MS * activeSessions.length
-          )
-        })
-      : undefined
+
+  heartbeatLoop = startServerHeartbeatLoop({
+    intervalMs: HEARTBEAT_INTERVAL_MS * activeSessions.length,
+    getSessionIds: () => [...activeSessions],
+    onHeartbeat: (nextHeartbeatInfo) => {
+      heartbeatInfo = nextHeartbeatInfo
+    },
+    onError: () => {
+      heartbeatInfo = new HeartbeatInfo()
+    },
+  })
 }
 
 export function getCurrentHeartbeatInfo() {

--- a/src/svelte/src/components/ServerMetrics/ServerMetrics.svelte
+++ b/src/svelte/src/components/ServerMetrics/ServerMetrics.svelte
@@ -23,16 +23,21 @@ limitations under the License.
     serverCpuLoadAverage: 0,
     serverTimestamp: 0,
     serverUptime: 0,
-    serverUsedMemory: 0,
+    serverResidentMemoryBytes: 0,
+    serverVirtualMemoryBytes: 0,
+    serverPeakResidentMemoryBytes: 0,
     sessionCount: 0,
     omegaEditPort: 0,
     serverVersion: 'Unknown',
     serverHostname: 'Unknown',
     serverProcessId: 0,
-    jvmVersion: 'Unknown',
-    jvmVendor: 'Unknown',
-    jvmPath: 'Unknown',
+    runtimeKind: 'Unknown',
+    runtimeName: 'Unknown',
+    platform: 'Unknown',
     availableProcessors: 0,
+    compiler: 'Unknown',
+    buildType: 'Unknown',
+    cppStandard: 'Unknown',
   }
   let timerId: NodeJS.Timeout
 
@@ -62,9 +67,10 @@ limitations under the License.
       uptimeString +=
         minutes === 1 ? `${minutes} minute, ` : `${minutes} minutes, `
     }
-    return uptimeString + (seconds === 1)
-      ? `${seconds} second`
-      : `${seconds} seconds`
+    return (
+      uptimeString +
+      (seconds === 1 ? `${seconds} second` : `${seconds} seconds`)
+    )
   }
 
   window.addEventListener('message', (msg) => {
@@ -74,17 +80,25 @@ limitations under the License.
         heartbeat.serverCpuLoadAverage = msg.data.data.serverCpuLoadAverage
         heartbeat.serverTimestamp = msg.data.data.serverTimestamp
         heartbeat.serverUptime = msg.data.data.serverUptime
-        heartbeat.serverUsedMemory = msg.data.data.serverUsedMemory
+        heartbeat.serverResidentMemoryBytes =
+          msg.data.data.serverResidentMemoryBytes ?? 0
+        heartbeat.serverVirtualMemoryBytes =
+          msg.data.data.serverVirtualMemoryBytes ?? 0
+        heartbeat.serverPeakResidentMemoryBytes =
+          msg.data.data.serverPeakResidentMemoryBytes ?? 0
         heartbeat.sessionCount = msg.data.data.sessionCount
         heartbeat.omegaEditPort = msg.data.data.serverInfo.omegaEditPort
         heartbeat.serverVersion = msg.data.data.serverInfo.serverVersion
         heartbeat.serverHostname = msg.data.data.serverInfo.serverHostname
         heartbeat.serverProcessId = msg.data.data.serverInfo.serverProcessId
-        heartbeat.jvmVersion = msg.data.data.serverInfo.jvmVersion
-        heartbeat.jvmVendor = msg.data.data.serverInfo.jvmVendor
-        heartbeat.jvmPath = msg.data.data.serverInfo.jvmPath
+        heartbeat.runtimeKind = msg.data.data.serverInfo.runtimeKind
+        heartbeat.runtimeName = msg.data.data.serverInfo.runtimeName
+        heartbeat.platform = msg.data.data.serverInfo.platform
         heartbeat.availableProcessors =
           msg.data.data.serverInfo.availableProcessors
+        heartbeat.compiler = msg.data.data.serverInfo.compiler
+        heartbeat.buildType = msg.data.data.serverInfo.buildType
+        heartbeat.cppStandard = msg.data.data.serverInfo.cppStandard
 
         // set the serverTimestamp to 0 after 5 seconds of no heartbeat to indicate that no heartbeat has been received
         clearTimeout(timerId)
@@ -135,21 +149,21 @@ limitations under the License.
           <b>CPU Load Avg:</b>
           {heartbeat.serverCpuLoadAverage.toFixed(2)},
         {/if}
-        {#if heartbeat.serverUsedMemory > 0}
-          <b>Memory Usage:</b>
-          {heartbeat.serverUsedMemory},
+        {#if heartbeat.serverResidentMemoryBytes > 0}
+          <b>Resident Memory:</b>
+          {heartbeat.serverResidentMemoryBytes},
         {/if}
         {#if heartbeat.serverProcessId > 0}
           <b>Process ID:</b>
           {heartbeat.serverProcessId},
         {/if}
-        {#if heartbeat.jvmVersion.length > 0}
-          <b>JVM Version:</b>
-          {heartbeat.jvmVersion}
+        {#if heartbeat.runtimeName.length > 0}
+          <b>Runtime:</b>
+          {heartbeat.runtimeName}
         {/if}
-        {#if heartbeat.jvmVendor.length > 0}
-          <b>JVM Vendor:</b>
-          {heartbeat.jvmVendor}
+        {#if heartbeat.platform.length > 0}
+          <b>Platform:</b>
+          {heartbeat.platform}
         {/if}
       </div>
     </FlexContainer>

--- a/src/tests/suite/dataEditor.test.ts
+++ b/src/tests/suite/dataEditor.test.ts
@@ -92,7 +92,7 @@ suite('Data Editor Test Suite', () => {
 
     before(async () => {
       const serverPid = (await Promise.race([
-        startServer(testPort, OMEGA_EDIT_HOST, pidFile, logConfigFile),
+        startServer(testPort, OMEGA_EDIT_HOST, pidFile, { logConfigFile }),
         new Promise((resolve, reject) => {
           setTimeout(
             () =>

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -172,12 +172,8 @@ async function copyToPkgDirPlugin() {
     { from: 'package.json', to: `${pkg_dir}/package.json` },
     { from: 'yarn.lock', to: `${pkg_dir}/yarn.lock` },
     {
-      from: 'node_modules/@omega-edit/server/out/bin',
-      to: `${pkg_dir}/node_modules/@omega-edit/server/out/bin`,
-    },
-    {
-      from: 'node_modules/@omega-edit/server/out/lib',
-      to: `${pkg_dir}/node_modules/@omega-edit/server/out/lib`,
+      from: 'node_modules/@omega-edit/server/out',
+      to: `${pkg_dir}/node_modules/@omega-edit/server/out`,
     },
     {
       from: 'node_modules/@vscode/webview-ui-toolkit',

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,23 +527,20 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@omega-edit/client@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@omega-edit/client/-/client-1.0.1.tgz#8234b9427b3c62d022c59421a68683083cb53a67"
-  integrity sha512-M2K23JtdRyZO+gm1nXG642bhk4vM9DxoZWvBVKTjndSaBNc6cJgpUkRwxPMLr7lyvvU+AWyJcV+XyI9pfYTT0Q==
+"@omega-edit/client@https://github.com/ctc-oss/omega-edit/releases/download/v2.0.0-rc1/omega-edit-node-client-v2.0.0-rc1.tgz":
+  version "2.0.0-rc1"
+  resolved "https://github.com/ctc-oss/omega-edit/releases/download/v2.0.0-rc1/omega-edit-node-client-v2.0.0-rc1.tgz#3dff7ab7a243395d16e0b2531fc8fdb788953695"
   dependencies:
     "@grpc/grpc-js" "1.12.2"
-    "@omega-edit/server" "1.0.1"
-    "@types/google-protobuf" "3.15.12"
-    google-protobuf "3.21.4"
-    pid-port "2.0.0"
-    pino "10.0.0"
+    "@omega-edit/server" "2.0.0-rc1"
+    "@protobuf-ts/runtime" "^2.11.1"
+    "@protobuf-ts/runtime-rpc" "^2.11.1"
+    pino "10.3.1"
     wait-port "1.1.0"
 
-"@omega-edit/server@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@omega-edit/server/-/server-1.0.1.tgz#8d71cc1c84f98211097e3596404ea42527c4311c"
-  integrity sha512-ayQer7NmvM2abjk56m4mjYbeW240Vt57Ia3i6xkiuGjg0Ddh6C9lRiDgqnYwFLxOwci5rBPQjF06fOMhLzsdoQ==
+"@omega-edit/server@2.0.0-rc1", "@omega-edit/server@https://github.com/ctc-oss/omega-edit/releases/download/v2.0.0-rc1/omega-edit-node-server-v2.0.0-rc1.tgz":
+  version "2.0.0-rc1"
+  resolved "https://github.com/ctc-oss/omega-edit/releases/download/v2.0.0-rc1/omega-edit-node-server-v2.0.0-rc1.tgz#5da38a70f9fdef68e5feddcd941a6f798fc37b2c"
 
 "@parcel/watcher-android-arm64@2.5.1":
   version "2.5.1"
@@ -634,6 +631,11 @@
     "@parcel/watcher-win32-ia32" "2.5.1"
     "@parcel/watcher-win32-x64" "2.5.1"
 
+"@pinojs/redact@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@pinojs/redact/-/redact-0.4.0.tgz#c3de060dd12640dcc838516aa2a6803cc7b2e9d6"
+  integrity sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -643,6 +645,18 @@
   version "1.0.0-next.29"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
   integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
+
+"@protobuf-ts/runtime-rpc@^2.11.1":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz#a6eb2f384bceae8d23a01d0b0e37faf0af36c179"
+  integrity sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==
+  dependencies:
+    "@protobuf-ts/runtime" "^2.11.1"
+
+"@protobuf-ts/runtime@^2.11.1":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime/-/runtime-2.11.1.tgz#ee2bf2fac6e2d8deac0ca63471a77481548e5553"
+  integrity sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -822,11 +836,6 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz#4584a8a87b29188a4c1fe987a9fcf701e256d86c"
   integrity sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==
 
-"@sec-ant/readable-stream@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz#60de891bb126abfdc5410fdc6166aca065f10a0c"
-  integrity sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==
-
 "@secretlint/config-creator@^10.2.2":
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/@secretlint/config-creator/-/config-creator-10.2.2.tgz#5d646e83bb2aacfbd5218968ceb358420b4c2cb3"
@@ -938,11 +947,6 @@
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz#719df7fb41766bc143369eaa0dd56d8dc87c9958"
   integrity sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==
-
-"@sindresorhus/merge-streams@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz#abb11d99aeb6d27f1b563c38147a72d50058e339"
-  integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
 
 "@standard-schema/spec@^1.0.0":
   version "1.0.0"
@@ -1087,11 +1091,6 @@
   dependencies:
     "@types/minimatch" "^5.1.2"
     "@types/node" "*"
-
-"@types/google-protobuf@3.15.12":
-  version "3.15.12"
-  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.15.12.tgz#eb2ba0eddd65712211a2b455dc6071d665ccf49b"
-  integrity sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==
 
 "@types/http-cache-semantics@^4.0.2":
   version "4.0.4"
@@ -2299,24 +2298,6 @@ execa@^8.0.1:
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
 
-execa@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-9.6.0.tgz#38665530e54e2e018384108322f37f35ae74f3bc"
-  integrity sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==
-  dependencies:
-    "@sindresorhus/merge-streams" "^4.0.0"
-    cross-spawn "^7.0.6"
-    figures "^6.1.0"
-    get-stream "^9.0.0"
-    human-signals "^8.0.1"
-    is-plain-obj "^4.1.0"
-    is-stream "^4.0.1"
-    npm-run-path "^6.0.0"
-    pretty-ms "^9.2.0"
-    signal-exit "^4.1.0"
-    strip-final-newline "^4.0.0"
-    yoctocolors "^2.1.1"
-
 exenv-es6@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exenv-es6/-/exenv-es6-1.1.1.tgz#80b7a8c5af24d53331f755bac07e84abb1f6de67"
@@ -2382,13 +2363,6 @@ fdir@^6.2.0, fdir@^6.4.4, fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
-
-figures@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-6.1.0.tgz#935479f51865fa7479f6fa94fc6fc7ac14e62c4a"
-  integrity sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==
-  dependencies:
-    is-unicode-supported "^2.0.0"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -2533,14 +2507,6 @@ get-stream@^8.0.1:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
   integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
-get-stream@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-9.0.1.tgz#95157d21df8eb90d1647102b63039b1df60ebd27"
-  integrity sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==
-  dependencies:
-    "@sec-ant/readable-stream" "^0.4.1"
-    is-stream "^4.0.1"
-
 get-tsconfig@^4.7.5:
   version "4.13.6"
   resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.13.6.tgz#2fbfda558a98a691a798f123afd95915badce876"
@@ -2627,11 +2593,6 @@ globby@^14.1.0:
     path-type "^6.0.0"
     slash "^5.1.0"
     unicorn-magic "^0.3.0"
-
-google-protobuf@3.21.4:
-  version "3.21.4"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.4.tgz#2f933e8b6e5e9f8edde66b7be0024b68f77da6c9"
-  integrity sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==
 
 gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
@@ -2769,11 +2730,6 @@ human-signals@^5.0.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
-human-signals@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-8.0.1.tgz#f08bb593b6d1db353933d06156cedec90abe51fb"
-  integrity sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==
-
 iconv-lite@0.6.3, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
@@ -2878,11 +2834,6 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
-is-plain-obj@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
-  integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
-
 is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -2901,11 +2852,6 @@ is-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
   integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
-
-is-stream@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-4.0.1.tgz#375cf891e16d2e4baec250b85926cffc14720d9b"
-  integrity sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==
 
 is-typed-array@^1.1.14:
   version "1.1.15"
@@ -3527,14 +3473,6 @@ npm-run-path@^5.1.0:
   dependencies:
     path-key "^4.0.0"
 
-npm-run-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-6.0.0.tgz#25cfdc4eae04976f3349c0b1afc089052c362537"
-  integrity sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==
-  dependencies:
-    path-key "^4.0.0"
-    unicorn-magic "^0.3.0"
-
 nth-check@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
@@ -3648,11 +3586,6 @@ parse-json@^8.0.0:
     index-to-position "^1.1.0"
     type-fest "^4.39.1"
 
-parse-ms@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-4.0.0.tgz#c0c058edd47c2a590151a718990533fd62803df4"
-  integrity sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==
-
 parse-semver@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parse-semver/-/parse-semver-1.1.1.tgz#9a4afd6df063dc4826f93fba4a99cf223f666cb8"
@@ -3748,17 +3681,10 @@ picomatch@^4.0.2, picomatch@^4.0.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
-pid-port@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pid-port/-/pid-port-2.0.0.tgz#1f792be70c9d9a6dcb3f457cac02f4b65c731bb7"
-  integrity sha512-EDmfRxLl6lkhPjDI+19l5pkII89xVsiCP3aGjS808f7M16DyCKSXEWthD/hjyDLn5I4gKqTVw7hSgdvdXRJDTw==
-  dependencies:
-    execa "^9.6.0"
-
-pino-abstract-transport@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz#de241578406ac7b8a33ce0d77ae6e8a0b3b68a60"
-  integrity sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==
+pino-abstract-transport@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz#b21e5f33a297e8c4c915c62b3ce5dd4a87a52c23"
+  integrity sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==
   dependencies:
     split2 "^4.0.0"
 
@@ -3767,22 +3693,22 @@ pino-std-serializers@^7.0.0:
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz#7c625038b13718dbbd84ab446bd673dc52259e3b"
   integrity sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==
 
-pino@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-10.0.0.tgz#3d1a8abc7a700142edebf02a7b291834da199fbe"
-  integrity sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==
+pino@10.3.1:
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-10.3.1.tgz#6552c8f8d8481844c9e452e7bf0be90bff1939ce"
+  integrity sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==
   dependencies:
+    "@pinojs/redact" "^0.4.0"
     atomic-sleep "^1.0.0"
     on-exit-leak-free "^2.1.0"
-    pino-abstract-transport "^2.0.0"
+    pino-abstract-transport "^3.0.0"
     pino-std-serializers "^7.0.0"
     process-warning "^5.0.0"
     quick-format-unescaped "^4.0.3"
     real-require "^0.2.0"
     safe-stable-stringify "^2.3.1"
-    slow-redact "^0.3.0"
     sonic-boom "^4.0.1"
-    thread-stream "^3.0.0"
+    thread-stream "^4.0.0"
 
 pluralize@^2.0.0:
   version "2.0.0"
@@ -3876,13 +3802,6 @@ prettier@3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
-
-pretty-ms@^9.2.0:
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-9.3.0.tgz#dd2524fcb3c326b4931b2272dfd1e1a8ed9a9f5a"
-  integrity sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==
-  dependencies:
-    parse-ms "^4.0.0"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -4365,11 +4284,6 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-slow-redact@^0.3.0:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/slow-redact/-/slow-redact-0.3.2.tgz#d06e25195aa5c492d32631c53d9ae86043b8b0e2"
-  integrity sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==
-
 sonic-boom@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.2.0.tgz#e59a525f831210fa4ef1896428338641ac1c124d"
@@ -4503,11 +4417,6 @@ strip-final-newline@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
   integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
-
-strip-final-newline@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-4.0.0.tgz#35a369ec2ac43df356e3edd5dcebb6429aa1fa5c"
-  integrity sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -4714,10 +4623,10 @@ textextensions@^6.11.0:
   dependencies:
     editions "^6.21.0"
 
-thread-stream@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-3.1.0.tgz#4b2ef252a7c215064507d4ef70c05a5e2d34c4f1"
-  integrity sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==
+thread-stream@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-4.0.0.tgz#732f007c24da7084f729d6e3a7e3f5934a7380b7"
+  integrity sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==
   dependencies:
     real-require "^0.2.0"
 
@@ -5224,11 +5133,6 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-yoctocolors@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.1.2.tgz#d795f54d173494e7d8db93150cec0ed7f678c83a"
-  integrity sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==
 
 zimmerframe@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
- [x] I have determined that no documentation updates are needed for these changes

## What changed
- upgraded the Omega Edit integration to `v2.0.0-rc1`
- updated the data editor to the Omega Edit 2.x client APIs, including heartbeat and viewport subscription helpers
- adjusted server metrics and packaging to the new native runtime fields and `@omega-edit/server/out` layout
- refreshed the Omega Edit test startup call sites for the 2.x `startServer(..., { logConfigFile })` signature

## Why
Omega Edit `v2.0.0-rc1` changes the client/server package layout and several APIs. This PR aligns the VS Code extension with the migration guide and the new helper APIs so we can validate the upgrade in CI.

## Impact
- keeps the data editor building and packaging against the RC release
- updates the runtime metrics surfaced in the UI to match the new server fields
- ensures the packaged VSIX includes the server binaries from the new `out/` directory structure

## Validation
- `yarn install`
- `yarn compile`
- `yarn test:svelte`
- `yarn vite:pkg`
- `yarn package`

## Notes
- `node .\\out\\tests\\runTest.js` still fails on this Windows environment because the downloaded `Code.exe` rejects the `@vscode/test-electron` launch flags (`--no-sandbox`, `--extensionTestsPath`, etc.), so the VS Code integration suite could not be exercised locally here.

