### PR TITLE
Change Test Timeout

### DIFF
--- a/src/tests/suite/daffodilDebugger.test.ts
+++ b/src/tests/suite/daffodilDebugger.test.ts
@@ -140,7 +140,7 @@ async function getDebuggerConfigs() {
     const infosetFormat = i % 2 == 0 ? 'xml' : 'json'
     const dfdlDebugger: DFDLDebugger = {
       daffodilVersion: debuggerVersionsToTest[versionIndex],
-      timeout: '4m',
+      timeout: '10m',
       logging: {
         level: 'INFO',
         file: path.join(os.tmpdir(), `yarn-test-daffodil-debugger-${port}.log`),

--- a/src/tests/suite/index.ts
+++ b/src/tests/suite/index.ts
@@ -28,7 +28,7 @@ export function run(): Promise<void> {
   const mocha = new Mocha({
     ui: 'tdd',
     color: true,
-    timeout: 999999,
+    timeout: '30m',
   })
 
   const testsRoot = path.resolve(__dirname, '..')


### PR DESCRIPTION
Closes #1627 

## Description

Increase timeouts for tests to avoid tests timing out from downloading Daffodil CLI jars

## Wiki

- [x] I have determined that no documentation updates are needed for these changes  
- [ ] I have added the following documentation for these changes

## Review Instructions including Screenshots

To test, run `git clean -fdx && yarn && yarn package && yarn test`
