### PR TITLE
fix: enable infoset and infoset-diff views from any file context during debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,12 +221,12 @@
         },
         {
           "command": "infoset.display",
-          "when": "inDebugMode && editorLangId == 'dfdl'",
+          "when": "inDebugMode",
           "group": "navigation@2"
         },
         {
           "command": "infoset.diff",
-          "when": "inDebugMode && editorLangId == 'dfdl'",
+          "when": "inDebugMode",
           "group": "navigation@3"
         },
         {
@@ -390,15 +390,13 @@
         "command": "infoset.display",
         "title": "Display the infoset view",
         "category": "Daffodil Debug",
-        "enablement": "inDebugMode && editorLangId == 'dfdl'",
-        "icon": "$(file-code)"
+        "enablement": "inDebugMode"
       },
       {
         "command": "infoset.diff",
         "title": "View infoset diff",
         "category": "Daffodil Debug",
-        "enablement": "inDebugMode && editorLangId == 'dfdl'",
-        "icon": "$(diff)"
+        "enablement": "inDebugMode"
       },
       {
         "command": "infoset.save",


### PR DESCRIPTION
## Fixes: apache/daffodil-vscode#1703

### Problem
While parsing a file, the Daffodil helper tab does not list the option to open the Infoset or Infoset Diff View unless the active tab is the DFDL schema file. This is because the `infoset.display` and `infoset.diff` commands are gated by `editorLangId == 'dfdl'` — they only appear when a DFDL schema file is the active editor.

This means if a user is debugging and switches to a data file or any other file type, they cannot access the infoset views from the Daffodil helper.

### Root Cause
In `package.json`, the command enablement and menu `when` clauses both included `editorLangId == 'dfdl'`:

```json
"enablement": "inDebugMode && editorLangId == 'dfdl'"
"when": "inDebugMode && editorLangId == 'dfdl'"
```

This condition restricts the infoset commands to DFDL schema editors only, even though the infoset data is available throughout the debug session.

### Fix
Remove `&& editorLangId == 'dfdl'` from both the `enablement` field and the `editor/title` menu `when` clause for both `infoset.display` and `infoset.diff` commands.

After the fix:
- `enablement`: `inDebugMode`
- `when`: `inDebugMode`

This keeps the commands available only during active debug sessions but removes the schema-file-only restriction, so users can open the infoset views from any file context while debugging.

### Acceptance Criteria
- [x] Infoset view command available from Daffodil helper during debugging regardless of active file type
- [x] Infoset diff view command available from Daffodil helper during debugging regardless of active file type
- [x] Commands remain gated by `inDebugMode` (not available outside debug sessions)

Closes #1703