### PR TITLE
Show infoset actions throughout active debug sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -390,14 +390,14 @@
         "command": "infoset.display",
         "title": "Display the infoset view",
         "category": "Daffodil Debug",
-        "enablement": "inDebugMode && editorLangId == 'dfdl'",
+        "enablement": "inDebugMode",
         "icon": "$(file-code)"
       },
       {
         "command": "infoset.diff",
         "title": "View infoset diff",
         "category": "Daffodil Debug",
-        "enablement": "inDebugMode && editorLangId == 'dfdl'",
+        "enablement": "inDebugMode",
         "icon": "$(diff)"
       },
       {

--- a/package.json
+++ b/package.json
@@ -221,12 +221,12 @@
         },
         {
           "command": "infoset.display",
-          "when": "inDebugMode && editorLangId == 'dfdl'",
+          "when": "inDebugMode",
           "group": "navigation@2"
         },
         {
           "command": "infoset.diff",
-          "when": "inDebugMode && editorLangId == 'dfdl'",
+          "when": "inDebugMode",
           "group": "navigation@3"
         },
         {


### PR DESCRIPTION
Closes #1703

## Description

- Relax the editor title menu conditions for the infoset actions.
- Show `infoset.display` and `infoset.diff` whenever a debug session is active, regardless of the focused editor language.
- Keep the change scoped to the existing `inDebugMode` context used by VS Code.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes  
- [ ] I have added the following documentation for these changes

## Review Instructions including Screenshots

- `node -e "const p=require('./package.json'); const items=p.contributes.menus['editor/title'].filter(x=>x.command==='infoset.display'||x.command==='infoset.diff'); if(items.some(x=>x.when!=='inDebugMode')) process.exit(1);"`

Prepared with local automation assistance and reviewed before submission.