### PR TITLE
DFDL-1555: insteading of erroring yet, change to warning

### DIFF
--- a/debugger/src/main/scala-2/org.apache.daffodil.debugger.dap/Support.scala
+++ b/debugger/src/main/scala-2/org.apache.daffodil.debugger.dap/Support.scala
@@ -27,6 +27,8 @@ import java.nio.file.Path
 import org.apache.daffodil.sapi._
 import org.apache.daffodil.sapi.io.InputSourceDataInputStream
 import org.apache.daffodil.sapi.infoset.{JsonInfosetOutputter, XMLTextInfosetOutputter}
+import cats.effect.IO
+import cats.syntax.all._
 
 object Support {
   /* Daffodil DataProcessor wrapper methods */
@@ -34,11 +36,19 @@ object Support {
       p: DataProcessor,
       debugger: org.apache.daffodil.runtime1.debugger.Debugger,
       variables: Map[String, String]
-  ): DataProcessor =
-    p.withDebugger(debugger)
-      .withDebugging(true)
-      .withExternalVariables(variables)
-      .withValidationMode(ValidationMode.Limited)
+  ): IO[(DataProcessor, List[String])] = {
+    val base = p.withDebugger(debugger).withDebugging(true)
+
+    variables.toList
+      .foldLeftM((base, List.empty[String])) { case ((dp, warnings), (k, v)) =>
+        IO(dp.withExternalVariables(Map(k -> v))).map((_, warnings)).handleErrorWith {
+          case e: ExternalVariableException =>
+            IO.pure((dp, warnings :+ s"Skipping unknown external variable '$k': ${e.getMessage}"))
+          case e => IO.raiseError(e)
+        }
+      }
+      .map { case (dp, warnings) => (dp.withValidationMode(ValidationMode.Limited), warnings) }
+  }
 
   /* Daffodil infoset wrapper methods */
   def getInputSourceDataInputStream(data: InputStream): InputSourceDataInputStream = new InputSourceDataInputStream(

--- a/debugger/src/main/scala-3/org.apache.daffodil.debugger.dap/Support.scala
+++ b/debugger/src/main/scala-3/org.apache.daffodil.debugger.dap/Support.scala
@@ -26,23 +26,29 @@ import java.io._
 import java.nio.file.Path
 import org.apache.daffodil.api._
 import scala.jdk.CollectionConverters._
+import cats.effect.IO
+import cats.syntax.all._
+import org.apache.daffodil.api.exceptions.ExternalVariableException
 
 object Support {
   /* Daffodil DataProcessor wrapper methods */
-  def dataProcessorWithDebugger(p: DataProcessor, debugger: Debugger, variables: Map[String, String]): DataProcessor =
-    p.withDebugger(debugger)
-      .withExternalVariables(variables.asJava)
-      .withValidation("daffodil")
+  def dataProcessorWithDebugger(
+      p: DataProcessor,
+      debugger: Debugger,
+      variables: Map[String, String]
+  ): IO[(DataProcessor, List[String])] = {
+    val base = p.withDebugger(debugger)
 
-  /* Daffodil infoset wrapper methods */
-  def getInputSourceDataInputStream(data: InputStream): InputSourceDataInputStream =
-    Daffodil.newInputSourceDataInputStream(data)
-  def getInfosetOutputter(infosetFormat: String, stream: OutputStream): InfosetOutputter =
-    infosetFormat match {
-      case "xml"  => Daffodil.newXMLTextInfosetOutputter(stream, true)
-      case "json" => Daffodil.newJsonInfosetOutputter(stream, true)
-      case other  => throw new IllegalArgumentException(s"unsupported infosetFormat: $other")
-    }
+    variables.toList
+      .foldLeftM((base, List.empty[String])) { case ((dp, warnings), (k, v)) =>
+        IO(dp.withExternalVariables(Map(k -> v).asJava)).map((_, warnings)).handleErrorWith {
+          case e: ExternalVariableException =>
+            IO.pure((dp, warnings :+ s"Skipping unknown external variable '$k': ${e.getMessage}"))
+          case e => IO.raiseError(e)
+        }
+      }
+      .map { case (dp, warnings) => (dp.withValidation("daffodil"), warnings) }
+  }
 
   /* Daffodil ProcessorFactory wrapper methods */
   def getProcessorFactory(
@@ -57,8 +63,20 @@ object Support {
       .compileFile(schema.toFile(), rootName.orNull, rootNamespace.orNull)
 
   /* Method to convert java list of diagnostics to a sequence of diagnostics */
+  /* Method to convert java list of diagnostics to a sequence of diagnostics */
   def parseDiagnosticList(
       dl: java.util.List[org.apache.daffodil.api.Diagnostic]
   ): Seq[org.apache.daffodil.api.Diagnostic] =
     dl.asScala.toSeq
+
+  /* Daffodil infoset wrapper methods */
+  def getInputSourceDataInputStream(data: InputStream): InputSourceDataInputStream =
+    Daffodil.newInputSourceDataInputStream(data)
+
+  def getInfosetOutputter(infosetFormat: String, stream: OutputStream): InfosetOutputter =
+    infosetFormat match {
+      case "xml"  => Daffodil.newXMLTextInfosetOutputter(stream, true)
+      case "json" => Daffodil.newJsonInfosetOutputter(stream, true)
+      case other  => throw new IllegalArgumentException(s"unsupported infosetFormat: $other")
+    }
 }

--- a/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
+++ b/debugger/src/main/scala/org.apache.daffodil.debugger.dap/Parse.scala
@@ -80,9 +80,12 @@ object Parse {
       dapEvents: Channel[IO, Events.DebugEvent]
   ): IO[Parse] =
     for {
-      dp <- DAPCompiler()
+      dpAndWarnings <- DAPCompiler()
         .compile(schema, rootName, rootNamespace, tunables)
-        .map(p => Support.dataProcessorWithDebugger(p, debugger, variables))
+        .flatMap(p => Support.dataProcessorWithDebugger(p, debugger, variables))
+      dp = dpAndWarnings._1
+      warnings = dpAndWarnings._2
+      _ <- warnings.traverse(w => dapEvents.send(Parse.Event.Warning(w)))
       done <- Ref[IO].of(false)
       pleaseStop <- Deferred[IO, Unit]
     } yield new Parse {
@@ -1096,6 +1099,7 @@ object Parse {
     case object Fini extends Event
     case class Control(state: DAPodil.Debugee.State) extends Event
     case class Error(message: String) extends Events.DebugEvent("daffodil.parseError")
+    case class Warning(message: String) extends Events.DebugEvent("daffodil.warning")
 
     implicit val show: Show[Event] = Show.fromToString
   }

--- a/src/adapter/daffodilEvent.ts
+++ b/src/adapter/daffodilEvent.ts
@@ -30,6 +30,10 @@ export function handleDebugEvent(e: vscode.DebugSessionCustomEvent) {
       fs.copyFileSync(path, `${path}.prev.xml`)
       fs.writeFileSync(path, update.content)
       break
+
+    case daf.warningEvent:
+      vscode.window.showWarningMessage(e.body.message)
+      break
     // this allows for any error event to be caught in this case
     case e.event.startsWith('daffodil.error') ? e.event : '':
       if (!e.body.message.startsWith('Schema Definition Error:')) {

--- a/src/daffodilDebugger/daffodil.ts
+++ b/src/daffodilDebugger/daffodil.ts
@@ -36,6 +36,11 @@ export interface DaffodilParseError {
   message: string
 }
 
+export const warningEvent = 'daffodil.warning'
+export interface DaffodilWarning {
+  message: string
+}
+
 export const infosetEvent = 'daffodil.infoset'
 export interface InfosetEvent {
   content: string
@@ -80,6 +85,7 @@ export type DaffodilEventType =
   | 'daffodil.parseError'
   | 'daffodil.infoset'
   | 'daffodil.config'
+  | 'daffodil.warning'
 export type DaffodilEventData = { command: string; data: any }
 export type DaffodilDataType =
   | DaffodilData
@@ -87,12 +93,14 @@ export type DaffodilDataType =
   | DaffodilParseError
   | InfosetEvent
   | ConfigEvent
+  | DaffodilWarning
 export type DaffodilDataTypeMap = {
   'daffodil.data': DaffodilData
   'daffodil.dataLeftOver': DaffodilDataLeftOver
   'daffodil.parseError': DaffodilParseError
   'daffodil.infoset': InfosetEvent
   'daffodil.config': ConfigEvent
+  'daffodil.warning': DaffodilWarning
 }
 
 export class DaffodilDebugEvent<


### PR DESCRIPTION
Closes #1555 

## Description

when a variable defined in launch.json does not exist in the DFDL schema, the debugger previously threw an unhandled ExternalVariableException and aborted the session entirely. This change catches that exception and changes it to a warning, allowing the debugger to start normally with the unrecognized variable simply skipped.

## Wiki

- [x] I have determined that no documentation updates are needed for these changes  
- [ ] I have added the following documentation for these changes

## Testing steps

1.  Run git clean -fdx
2. Start the extension 
3. Add a viarable defintion to the launch.json file, it can be anything you want, see example below:
<img width="258" height="373" alt="image" src="https://github.com/user-attachments/assets/e4961b38-23bb-49a5-ab93-44efa0141b22" />

4. Then run a debug session, you should see a warning banner on the bottom right, and debugger should continue to work as normal
<img width="1182" height="740" alt="{5336952D-4BF1-4125-B645-A1826D28D5F7}" src="https://github.com/user-attachments/assets/f9eca078-a23d-4b7d-a5a0-93f327c1dc50" />


### Confirmation Testing
Manually tested by adding "variables": { "foo": "bar" } to a launch.json where foo does not exist in the target schema. Confirmed the debugger launches successfully and the warning message appears. Confirmed that valid variables (ones that do exist in the schema) are still applied correctly.

