### PR TITLE
Ensure proper Daffodil Explorer display of Open Infoset options

### DIFF
--- a/doc/Introduction-to-Daffodil-VS-Code-Extension.md
+++ b/doc/Introduction-to-Daffodil-VS-Code-Extension.md
@@ -192,6 +192,11 @@ Leave the `${command:AskForSchemaName}`/`${command:AskForDataName}` values and y
 |***Debugging for the first time for Visual Studio Code***||
 |You will see the data editor pop up!|![commandpalletedaff](https://github.com/user-attachments/assets/56ac7f2d-6889-4a93-8bbe-052b20129e91)|
 
+|<div style="width:200px"></div>|<div style="width:205px"></div>|
+|:---|:---|
+|***DFDL Command Panel***||
+|All debugging-related commands are conveniently grouped in one place, making them easier to find and use. This command panel dynamically updates to only show relevant commands based on the current debug mode and can be quickly executed using a play button.|![{D03B1D68-20CC-4F42-901F-0728C8137038}](https://github.com/user-attachments/assets/52165b90-3dd5-495b-8b86-bd15b4f960a1)|
+
 
 |<div style="width:200px"></div>|<div style="width:205px"></div>|
 |:---|:---|

--- a/package.json
+++ b/package.json
@@ -223,12 +223,12 @@
         },
         {
           "command": "infoset.display",
-          "when": "inDebugMode && editorLangId == 'dfdl'",
+          "when": "inDebugMode",
           "group": "navigation@2"
         },
         {
           "command": "infoset.diff",
-          "when": "inDebugMode && editorLangId == 'dfdl'",
+          "when": "inDebugMode",
           "group": "navigation@3"
         },
         {
@@ -404,16 +404,16 @@
       },
       {
         "command": "infoset.display",
-        "title": "Display the infoset view",
+        "title": "Open infoset view",
         "category": "Daffodil Debug",
-        "enablement": "inDebugMode && editorLangId == 'dfdl'",
+        "enablement": "inDebugMode",
         "icon": "$(file-code)"
       },
       {
         "command": "infoset.diff",
-        "title": "View infoset diff",
+        "title": "Open infoset diff view",
         "category": "Daffodil Debug",
-        "enablement": "inDebugMode && editorLangId == 'dfdl'",
+        "enablement": "inDebugMode",
         "icon": "$(diff)"
       },
       {


### PR DESCRIPTION
Changed restrictions on when the "open infoset" options appear in theDaffodil Explorer.
Also borrowed page from the wiki for inclusion in the New User's Guide that explains the Daffodil Exporer.

Closes #1703 

## Description

The options to open the Infoset & Infoset Diff windows would only appear in the Daffodil Explorer, if the active tab was the text editor containing the schema file.
It is now shown as an option even when other tabs are the active one (ex: Data editor)

## Wiki

- [x] I have determined that no documentation updates are needed for these changes  
- [ ] I have added the following documentation for these changes

Added info about the Daffodil Explorer to the New User's Guide

## Review Instructions including Screenshots
Verify the `Open Infoset View` & `Open Infoset Diff View` options are shown even when the text editor containing a DFDL file **is not** the active tab
<img width="421" height="490" alt="image" src="https://github.com/user-attachments/assets/677b39ef-6319-4eec-ab53-6f0e4bc6c02a" />


### Confirmation Testing

[OPTIONAL: Describe the tests you performed to confirm that the change works as intended.  
Include steps, commands, test data, or screenshots/GIFs as necessary.]

### Regression Testing

[OPTIONAL: Describe any regression testing performed to ensure existing functionality was not broken.  
List relevant test suites, manual checks, or validation steps.]
